### PR TITLE
fix: Ensure that machine explodes when CALL-INDIRECT is used

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -123,22 +123,27 @@ public class Machine {
                     case RETURN:
                         shouldReturn = true;
                         break;
-//                    case CALL_INDIRECT:
-//                        {
-//                            //                    var index = this.stack.pop().asInt();
-//                            //                    var funcId =
-//                            // instance.getTable().getFuncRef(index);
-//                            //                    var typeId =
-//                            // instance.getFunctionTypes().get(funcId);
-//                            //                    var type = instance.getTypes().get(typeId);
-//                            //                    // given a list of param types, let's pop those
-//                            // params off the stack
-//                            //                    // and pass as args to the function call
-//                            //                    var args =
-//                            // extractArgsForParams(type.paramTypes());
-//                            //                    call(funcId, args, false);
-//                            break;
-//                        }
+                        //                    case CALL_INDIRECT:
+                        //                        {
+                        //                            //                    var index =
+                        // this.stack.pop().asInt();
+                        //                            //                    var funcId =
+                        //                            // instance.getTable().getFuncRef(index);
+                        //                            //                    var typeId =
+                        //                            // instance.getFunctionTypes().get(funcId);
+                        //                            //                    var type =
+                        // instance.getTypes().get(typeId);
+                        //                            //                    // given a list of param
+                        // types, let's pop those
+                        //                            // params off the stack
+                        //                            //                    // and pass as args to
+                        // the function call
+                        //                            //                    var args =
+                        //                            // extractArgsForParams(type.paramTypes());
+                        //                            //                    call(funcId, args,
+                        // false);
+                        //                            break;
+                        //                        }
                     case DROP:
                         this.stack.pop();
                         break;


### PR DESCRIPTION
I will implement this instruction in a follow up when i add table and element support. For now we want it to explode if the machine encounters it because it's failing subtly now which will make debugging confusing. If you see this explode you can safely ignore it. Add it to the exclude list with a comment that it's failing because of the missing indirect. I will try them again after I implement it.