### PR TITLE
Refactor Parser

### DIFF
--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Encoding.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Encoding.java
@@ -3,6 +3,7 @@ package com.dylibso.chicory.wasm;
 import java.nio.ByteBuffer;
 
 public final class Encoding {
+
     /**
      * Reads an unsigned integer from {@code byteBuffer}.
      */
@@ -77,7 +78,11 @@ public final class Encoding {
         return result;
     }
 
-    // Computes the number of bytes required to encode a given value as LEB128
+    /**
+     * Computes the number of bytes required to encode a given value as LEB128
+     * @param value
+     * @return
+     */
     public static int computeLeb128Size(int value) {
         int size = 0;
         do {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/ParserListener.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/ParserListener.java
@@ -3,5 +3,6 @@ package com.dylibso.chicory.wasm;
 import com.dylibso.chicory.wasm.types.Section;
 
 public interface ParserListener {
+
     void onSection(Section section);
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameSection.java
@@ -3,16 +3,17 @@ package com.dylibso.chicory.wasm.types;
 import com.dylibso.chicory.wasm.Parser;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class NameSection extends CustomSection {
 
-    private List<String> funcNames;
+    private final List<String> funcNames;
 
     public NameSection(CustomSection sec) {
         super(sec.getSectionId(), sec.getSectionSize());
         this.setBytes(sec.getBytes());
-        funcNames = parseFunctionNames();
+        this.funcNames = parseFunctionNames();
     }
 
     private List<String> parseFunctionNames() {
@@ -37,7 +38,7 @@ public class NameSection extends CustomSection {
             names.add(Parser.readName(buf));
         }
 
-        return names;
+        return Collections.unmodifiableList(names);
     }
 
     public List<String> getFunctionNames() {

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
@@ -119,17 +119,16 @@ public class ParserTest {
     public void shouldSupportCustomListener() {
         var parser = new Parser("src/test/resources/wasm/code.wasm");
         parser.includeSection(SectionId.CUSTOM);
-        parser.setListener(
+        parser.parse(
                 s -> {
                     if (s.getSectionId() == SectionId.CUSTOM) {
                         var customSection = (CustomSection) s;
                         var name = customSection.getName();
-                        assertTrue(name.length() > 0);
+                        assertFalse(name.isEmpty());
                     } else {
                         fail("Should not have received section with id: " + s.getSectionId());
                     }
                 });
-        parser.parse();
     }
 
     //    @Test


### PR DESCRIPTION
- Make Parser final until we need extensibility
- Adapted Parser to avoid mutable fields
- Reduced nesting in dense code
- Use BitSet instead of List<Integer> for includeSections
- Move ParserListener from instance field to Method parameter as it is always required for parsing