### PR TITLE
Make HostFunction's ctor accessible

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
@@ -10,7 +10,7 @@ public class HostFunction {
     private final List<ValueType> paramTypes;
     private final List<ValueType> returnTypes;
 
-    HostFunction(
+    public HostFunction(
             WasmFunctionHandle handle,
             String moduleName,
             String fieldName,


### PR DESCRIPTION
Looking at the README, it seems like `HostFunction`'s constructor should be public.