### PR TITLE
Allow overriding wabt version during built-time for tests

### DIFF
--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
@@ -62,7 +62,7 @@ public class TestGenMojo extends AbstractMojo {
     /**
      * Wabt version
      */
-    @Parameter(required = true, defaultValue = "1.0.33")
+    @Parameter(required = true, property = "wabtVersion", defaultValue = "1.0.33")
     private String wabtVersion;
 
     @Parameter(


### PR DESCRIPTION
We now allow to specify the version of the wabt toolkit via system property, e.g.: mvn clean verify -DwabtVersion=1.0.34