### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing guide
+
+**Want to contribute? Great!** 
+We try to make it easy, and all contributions, even the smaller ones, are more than welcome.
+This includes bug reports, fixes, documentation, examples... 
+But first, read this page (including the small print at the end).
+
+* [Legal](#legal)
+* [Reporting an issue](#reporting-an-issue)
+* [Before you contribute](#before-you-contribute)
+  + [Code reviews](#code-reviews)
+  + [Coding Guidelines](#coding-guidelines)
+  + [Continuous Integration](#continuous-integration)
+  + [Tests and documentation are not optional](#tests-and-documentation-are-not-optional)
+  + [Current status](#current-status)
+* [The small print](#the-small-print)
+
+
+## Legal
+
+All original contributions to Apicurio projects are licensed under the
+[ASL - Apache License](https://www.apache.org/licenses/LICENSE-2.0),
+version 2.0 or later, or, if another license is specified as governing the file or directory being
+modified, such other license.
+
+## Reporting an issue
+
+This project uses GitHub issues to manage the issues. Open an issue directly in GitHub.
+
+If you believe you found a bug, and it's likely possible, please indicate a way to reproduce it, what you are seeing and what you would expect to see.
+
+## Before you contribute
+
+To contribute, use GitHub Pull Requests, from your **own** fork.
+
+Also, make sure you have set up your Git authorship correctly:
+
+```
+git config --global user.name "Your Full Name"
+git config --global user.email your.email@example.com
+```
+
+If you use different computers to contribute, please make sure the name is the same on all your computers.
+
+We may use this information to acknowledge your contributions!
+
+### Code reviews
+
+All submissions, including submissions by project members, need to be reviewed and approved by at least one project owner before being merged.
+
+[GitHub Pull Request Review Process](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews) is followed for every pull request.
+
+### Coding Guidelines
+
+ * We primarily use the Git history to track authorship. GitHub also has [this nice page with your contributions](https://github.com/quarkusio/quarkus/graphs/contributors).
+ * Please take care to write code that fits with existing code styles. The sintactic formatting is automated and can be applied project wise using the command `msn spotless:apply`.
+ * Commits should be atomic and semantic. Please properly squash your pull requests before submitting them. Fixup commits can be used temporarily during the review process but things should be squashed at the end to have meaningful commits.
+ * We typically squash and merge pull requests when they are approved. This tends to keep the commit history a little bit more tidy without placing undue burden on the developers.
+
+### Continuous Integration
+
+Because we are all humans, and to ensure Chicory evolves in the right direction, all changes must pass continuous integration before being merged. The CI is based on GitHub Actions, which means that pull requests will receive automatic feedback.  Please watch out for the results of these workflows to see if your PR passes all tests.
+
+### Tests and documentation are not optional
+
+Don't forget to include tests in your pull requests. 
+Also don't forget the documentation (reference documentation, javadoc...).
+
+## Current status
+
+The project is still in a pre-alpha state, where a chunk of the official [testsuite](https://github.com/WebAssembly/testsuite) is not yet completed.
+Since there is some significant work to be ironed out we have been taking a few decisions to reduce the burden:
+
+- we are concentrating on the happy path: this means that we disabled most of the tests exercising validation of the input
+- we prioritize the inclusion of more `.wabt` files from the stable spec at `v1`: exception handling, GC, SIMD etc. will come in the future
+- we sync in Zulip: if you wanna contribute you are encouraged to drop a message in the chat and we are happy to assist
+
+## The small print
+
+This project is an open source project. Please act responsibly, be nice, polite and enjoy!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing guide
 
-**Want to contribute? Great!** 
+**Want to contribute? Great!**
 We try to make it easy, and all contributions, even the smaller ones, are more than welcome.
-This includes bug reports, fixes, documentation, examples... 
+This includes bug reports, fixes, documentation, examples...
 But first, read this page (including the small print at the end).
 
 * [Legal](#legal)
@@ -63,7 +63,7 @@ Because we are all humans, and to ensure Chicory evolves in the right direction,
 
 ### Tests and documentation are not optional
 
-Don't forget to include tests in your pull requests. 
+Don't forget to include tests in your pull requests.
 Also don't forget the documentation (reference documentation, javadoc...).
 
 ## Current status

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ But first, read this page (including the small print at the end).
 
 ## Legal
 
-All original contributions to Apicurio projects are licensed under the
+All original contributions to Chicory projects are licensed under the
 [ASL - Apache License](https://www.apache.org/licenses/LICENSE-2.0),
 version 2.0 or later, or, if another license is specified as governing the file or directory being
 modified, such other license.


### PR DESCRIPTION
As noticed in #113 we are falling short on documentation about the current processes.
This should help a little, or, at least, will be a place to collect the information instead of repeating it on different channels.