### PR TITLE
Fixed global import init

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -117,10 +117,6 @@
             SpecV1MemoryInitTest.test204, SpecV1MemoryInitTest.test206,
             SpecV1MemoryInitTest.test208, SpecV1MemoryInitTest.test210,
             SpecV1MemoryInitTest.test212, SpecV1MemoryInitTest.test214,
-            <!-- imports integration is
-            missing -->
-            SpecV1GlobalTest.test6,
-            SpecV1GlobalTest.test7, SpecV1GlobalTest.test57,
             <!-- call indirect failures -->
             SpecV1MemoryGrowTest.test64,
             SpecV1MemoryGrowTest.test65, SpecV1MemoryGrowTest.test66,

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
@@ -83,10 +83,17 @@ public class Module {
                     globals[i] = Value.f64(instr.getOperands()[0]);
                     break;
                 case GLOBAL_GET:
-                    // TODO this assumes that these are already initialized declared in order
-                    // should we make this more resilient? Should initialization happen later?
-                    globals[i] = globals[(int) instr.getOperands()[0]];
-                    break;
+                    {
+                        // TODO this assumes that these are already initialized declared in order
+                        // should we make this more resilient? Should initialization happen later?
+                        var globalImports = hostImports.getGlobals();
+                        var idx = (int) instr.getOperands()[0];
+                        globals[i] =
+                                idx < globalImports.length
+                                        ? globalImports[idx].getValue()
+                                        : globals[idx];
+                        break;
+                    }
                 case REF_NULL:
                     globals[i] = Value.REF_NULL;
                     break;

--- a/runtime/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
+++ b/runtime/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
@@ -1,0 +1,16 @@
+package com.dylibso.chicory.imports;
+
+import com.dylibso.chicory.runtime.HostGlobal;
+import com.dylibso.chicory.runtime.HostImports;
+import com.dylibso.chicory.wasm.types.Value;
+
+public class SpecV1GlobalHostFuncs {
+
+    public static HostImports fallback() {
+        return new HostImports(
+                new HostGlobal[] {
+                    new HostGlobal("spectest", "global_i32", Value.i32(666)),
+                    new HostGlobal("spectest", "global_i64", Value.i64(666))
+                });
+    }
+}


### PR DESCRIPTION
Re-enabled global tests that had been disabled due to lack of import support in tests. Found & fixed module instantiation bug that the tests discovered.