### PR TITLE
Fixed nonarithmetic NaN propagation

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -90,13 +90,7 @@
             <!--
             Assertion failures -->
             SpecV1ConversionsTest.test336, SpecV1ConversionsTest.test380,
-            SpecV1FloatExprsTest.test210, SpecV1FloatExprsTest.test306,
-            SpecV1FloatExprsTest.test307, SpecV1FloatExprsTest.test308,
-            SpecV1FloatExprsTest.test309, SpecV1FloatExprsTest.test748,
-            SpecV1FloatExprsTest.test749, SpecV1FloatExprsTest.test750,
-            SpecV1FloatExprsTest.test751, SpecV1FloatExprsTest.test758,
-            SpecV1FloatExprsTest.test759, SpecV1FloatExprsTest.test760,
-            SpecV1FloatExprsTest.test761, SpecV1MemoryInitTest.test39, SpecV1MemoryInitTest.test40,
+            SpecV1MemoryInitTest.test39, SpecV1MemoryInitTest.test40,
             SpecV1MemoryInitTest.test41, SpecV1MemoryInitTest.test42, SpecV1MemoryGrowTest.test67,
             SpecV1MemoryInitTest.test78, SpecV1MemoryInitTest.test79, SpecV1MemoryInitTest.test80,
             SpecV1MemoryInitTest.test93, SpecV1MemoryInitTest.test101, SpecV1MemoryInitTest.test102,

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -878,13 +878,34 @@ public class Machine {
                     case F32_NEG:
                         {
                             var tos = this.stack.pop().asFloat();
-                            this.stack.push(Value.fromFloat(-1.0f * tos));
+
+                            float result;
+                            if (Float.isNaN(tos)) {
+                                result =
+                                        Float.intBitsToFloat(
+                                                Float.floatToRawIntBits(tos) ^ 0x80000000);
+                            } else {
+                                result = -1.0f * tos;
+                            }
+
+                            this.stack.push(Value.fromFloat(result));
                             break;
                         }
                     case F64_NEG:
                         {
                             var tos = this.stack.pop().asDouble();
-                            this.stack.push(Value.fromDouble(-1.0d * tos));
+
+                            double result;
+                            if (Double.isNaN(tos)) {
+                                result =
+                                        Double.longBitsToDouble(
+                                                Double.doubleToRawLongBits(tos)
+                                                        ^ 0x8000000000000000L);
+                            } else {
+                                result = -1.0d * tos;
+                            }
+
+                            this.stack.push(Value.fromDouble(result));
                             break;
                         }
                     case CALL:

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -30,11 +30,11 @@ public class Value {
     }
 
     public static Value fromFloat(float data) {
-        return Value.f32(Float.floatToIntBits(data));
+        return Value.f32(Float.floatToRawIntBits(data));
     }
 
     public static Value fromDouble(double data) {
-        return Value.f64(Double.doubleToLongBits(data));
+        return Value.f64(Double.doubleToRawLongBits(data));
     }
 
     public static Value i32(long data) {


### PR DESCRIPTION
Fixed nonarithmetic NaN propagation  through Value box & fneg operations.

All `float_exprs.wast` tests pass with this.