### PR TITLE
Version-aware wast2json resolve

### DIFF
--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/Wast2JsonWrapper.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/Wast2JsonWrapper.java
@@ -233,14 +233,21 @@ public class Wast2JsonWrapper {
     }
 
     /**
-     * Compares the available wast2json version with the minimum required version
-     * using semantic version numbers. Assumes that the version is a 3 part semantic
-     * version number.
+     * Compares the available wast2json version with the minimum required version. It
+     * first checks for an exact match on the version strings, and if they do not
+     * exactly match it tries to parse and compare them using 3 part semantic version numbers.
      * @param actual the version of wast2json already installed
-     * @param required the minimum version of wast2json that's required
+     * @param required the version of wast2json that's required
      * @return true if the actual version meets the requirements, false otherwise
      */
     private boolean versionMatches(String actual, String required) {
+        actual = actual.trim();
+        required = required.trim();
+
+        if(actual.equals(required)){
+            return true;
+        }
+
         var actualComponents = splitVersion(actual);
         var requiredComponents = splitVersion(required);
 
@@ -261,6 +268,6 @@ public class Wast2JsonWrapper {
     }
 
     private String[] splitVersion(String v) {
-        return v.trim().split("\\.");
+        return v.split("\\.");
     }
 }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/Wast2JsonWrapper.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/Wast2JsonWrapper.java
@@ -155,7 +155,11 @@ public class Wast2JsonWrapper {
             ps = pb.start();
             ps.waitFor(1, TimeUnit.SECONDS);
             if (ps.exitValue() != 0) {
-                System.err.println(ps.getErrorStream().toString());
+                log.warn(
+                        "Couldn't get system "
+                                + WAST2JSON
+                                + " version: "
+                                + ps.getErrorStream().toString());
             }
             systemVersion = new String(ps.getInputStream().readAllBytes());
         } catch (IOException e) {
@@ -170,8 +174,19 @@ public class Wast2JsonWrapper {
 
         if (ps != null && ps.exitValue() == 0) {
             if (systemVersion != null && versionMatches(systemVersion, wabtVersion)) {
-                log.info(WAST2JSON + " binary detected available, using the system one.");
+                log.info(
+                        WAST2JSON
+                                + " binary detected available, using the system one with version "
+                                + systemVersion);
                 return WAST2JSON;
+            } else {
+                log.info(
+                        "System "
+                                + WAST2JSON
+                                + " cannot be used due to its version: actual - "
+                                + systemVersion
+                                + ", required - "
+                                + wabtVersion);
             }
         }
 

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/Wast2JsonWrapper.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/Wast2JsonWrapper.java
@@ -4,10 +4,7 @@ import static com.dylibso.chicory.maven.Constants.SPEC_JSON;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -152,24 +149,30 @@ public class Wast2JsonWrapper {
     private String resolveOrInstallWast2Json() {
         ProcessBuilder pb = new ProcessBuilder(WAST2JSON, "--version");
         pb.directory(new File("."));
-        pb.inheritIO();
         Process ps = null;
+        String systemVersion = null;
         try {
             ps = pb.start();
             ps.waitFor(1, TimeUnit.SECONDS);
+            if (ps.exitValue() != 0) {
+                System.err.println(ps.getErrorStream().toString());
+            }
+            systemVersion = new String(ps.getInputStream().readAllBytes());
         } catch (IOException e) {
             // ignore
         } catch (InterruptedException e) {
             // ignore
         }
 
-        if (ps != null && ps.exitValue() == 0) {
-            log.info(WAST2JSON + " binary detected available, using the system one.");
-            return WAST2JSON;
-        }
-
         if (wabtVersion.equals("latest")) {
             wabtVersion = resolveLatestVersion();
+        }
+
+        if (ps != null && ps.exitValue() == 0) {
+            if (systemVersion != null && versionMatches(systemVersion, wabtVersion)) {
+                log.info(WAST2JSON + " binary detected available, using the system one.");
+                return WAST2JSON;
+            }
         }
 
         // Downloading locally WABT
@@ -227,5 +230,37 @@ public class Wast2JsonWrapper {
         } else {
             throw new IllegalArgumentException("Detected OS is not supported: " + osName);
         }
+    }
+
+    /**
+     * Compares the available wast2json version with the minimum required version
+     * using semantic version numbers. Assumes that the version is a 3 part semantic
+     * version number.
+     * @param actual the version of wast2json already installed
+     * @param required the minimum version of wast2json that's required
+     * @return true if the actual version meets the requirements, false otherwise
+     */
+    private boolean versionMatches(String actual, String required) {
+        var actualComponents = splitVersion(actual);
+        var requiredComponents = splitVersion(required);
+
+        if (actualComponents.length != 3 || requiredComponents.length != 3) {
+            return false;
+        }
+
+        return componentMatches(actualComponents, requiredComponents, 0)
+                && componentMatches(actualComponents, requiredComponents, 1)
+                && componentMatches(actualComponents, requiredComponents, 2);
+    }
+
+    private boolean componentMatches(String[] actual, String[] required, int component) {
+        var actualField = Integer.parseInt(actual[component]);
+        var requiredField = Integer.parseInt(required[component]);
+
+        return actualField >= requiredField;
+    }
+
+    private String[] splitVersion(String v) {
+        return v.trim().split("\\.");
     }
 }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/Wast2JsonWrapper.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/Wast2JsonWrapper.java
@@ -244,7 +244,7 @@ public class Wast2JsonWrapper {
         actual = actual.trim();
         required = required.trim();
 
-        if(actual.equals(required)){
+        if (actual.equals(required)) {
             return true;
         }
 


### PR DESCRIPTION
On some Linux distros, the wabt version in the repos is rather old (in my case, Linux Mint has 1.0.27). This causes issues when the system version is older than the tests require.

This PR does a basic semantic version number check between the system-installed `wast2json` (if present) and the version required by the tests before delegating to the system install.