### PR TITLE
fix: Fixes parsing of _start function

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
@@ -168,20 +168,15 @@ public class Module {
 
         if (module.getStartSection() != null) {
             startFuncId = (int) module.getStartSection().getStartIndex();
-        }
-
-        if (module.getFunctionSection() != null) {
-            if (startFuncId == null) startFuncId = importId;
-            for (var ft : module.getFunctionSection().getTypeIndices()) {
-                functionTypes[funcIdx++] = ft;
-            }
-        }
-
-        if (startFuncId != null) {
-            // if we got a start func, let's add it to the exports
             var desc = new ExportDesc(startFuncId, ExportDescType.FuncIdx);
             var export = new Export("_start", desc);
             exports.put("_start", export);
+        }
+
+        if (module.getFunctionSection() != null) {
+            for (var ft : module.getFunctionSection().getTypeIndices()) {
+                functionTypes[funcIdx++] = ft;
+            }
         }
 
         Table[] tables = new Table[0];


### PR DESCRIPTION
Extracted from the wasi3 branch https://github.com/dylibso/chicory/compare/main...wasi3#diff-dee877c864dc5f9b538d7a4fc0c15f9ed45276f095e548172bb3780ea6b55764

There seemed to be a bug in the logic that parses the _start function. getExport("_start") was giving me the first function in the function list and not the actual _start function.


BTW I created this bug by naively writing that parsing code. I think it was working because in our tests of _start, _start was the only function. But when there are other functions before it, it fails.