### PR TITLE
fix: Fixes memory fill out of bounds error

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -481,9 +481,6 @@ public class Machine {
                             var val = stack.pop().asByte();
                             var offset = stack.pop().asInt();
                             var end = (size + offset);
-                            if (end > instance.getMemory().getMaximumSize()) {
-                                throw new WASMRuntimeException("out of bounds memory access");
-                            }
                             instance.getMemory().fill(val, offset, end);
                             break;
                         }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
@@ -299,14 +299,22 @@ public final class Memory {
     }
 
     public void fill(byte value) {
-        // see https://appsintheopen.com/posts/53-resetting-bytebuffers-to-zero-in-java
-        Arrays.fill(buffer.array(), value);
-        buffer.position(0);
+        try {
+            // see https://appsintheopen.com/posts/53-resetting-bytebuffers-to-zero-in-java
+            Arrays.fill(buffer.array(), value);
+            buffer.position(0);
+        } catch (IndexOutOfBoundsException e) {
+            throw new WASMRuntimeException("out of bounds memory access");
+        }
     }
 
     public void fill(byte value, int fromIndex, int toIndex) {
-        Arrays.fill(buffer.array(), fromIndex, toIndex, value);
-        buffer.position(0);
+        try {
+            Arrays.fill(buffer.array(), fromIndex, toIndex, value);
+            buffer.position(0);
+        } catch (IndexOutOfBoundsException e) {
+            throw new WASMRuntimeException("out of bounds memory access");
+        }
     }
 
     public void copy(int dest, int src, int size) {


### PR DESCRIPTION
I believe the purpose of this code was to do a bounds check before writing the memory, but `getMaximumSize()` returns the unit of pages. What i think was meant was to find the last memory address which would be something like `memory.buffer.size()`.

However, I think it's better to let the bytebuffer handle the bounds checking here. So removed the check and captured the indexoob error like we do with the other memory access methods.