### PR TITLE
fix: comment out logger

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -99,16 +99,16 @@ public class Machine {
                 if (shouldReturn) return;
                 var instruction = code.get(frame.pc);
                 frame.pc++;
-                LOGGER.log(
-                        System.Logger.Level.DEBUG,
-                        "func="
-                                + frame.funcId
-                                + "@"
-                                + frame.pc
-                                + ": "
-                                + instruction
-                                + " stack="
-                                + this.stack);
+//                LOGGER.log(
+//                        System.Logger.Level.DEBUG,
+//                        "func="
+//                                + frame.funcId
+//                                + "@"
+//                                + frame.pc
+//                                + ": "
+//                                + instruction
+//                                + " stack="
+//                                + this.stack);
                 var opcode = instruction.getOpcode();
                 var operands = instruction.getOperands();
                 switch (opcode) {


### PR DESCRIPTION
This log statement makes everything a lot slower because it's on the hot path. Runs the tests about 30% faster on my machine. I assume that Java has to compute that string everytime too. but the conditional to not log is probably happening after the function is called.

Open to different suggestions about how to deal with this. But i feel like since it's mostly used by us i don't mind uncommenting it when i need it.