### PR TITLE
table_grow.wast spec passing

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -92,7 +92,8 @@
             bulk.wast,
             table_init.wast,
             table_copy.wast,
-            table_fill.wast</orderedWastToProcess>
+            table_fill.wast,
+            table_grow.wast</orderedWastToProcess>
           <excludedTests>
             <!-- Assertion failures -->
             <!-- Errors -->

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -305,7 +305,7 @@ public class Machine {
                             var i = this.stack.pop().asInt();
                             if (i < 0
                                     || (table.getLimitMax() != 0 && i >= table.getLimitMax())
-                                    || i >= table.getLimitMin()) {
+                                    || i >= table.getSize()) {
                                 throw new WASMRuntimeException("out of bounds table access");
                             }
                             var ref = table.getRef(i);
@@ -1839,6 +1839,44 @@ public class Machine {
                             for (int i = offset; i < end; i++) {
                                 table.setRef(i, val);
                             }
+                            break;
+                        }
+                    case TABLE_SIZE:
+                        {
+                            var tableidx = (int) operands[0];
+                            var table = instance.getTable(tableidx);
+                            if (table == null) {
+                                table = instance.getImports().getTables()[tableidx].getTable();
+                            }
+
+                            this.stack.push(Value.i32(table.getSize()));
+                            break;
+                        }
+                    case TABLE_GROW:
+                        {
+                            var tableidx = (int) operands[0];
+                            var table = instance.getTable(tableidx);
+                            if (table == null) {
+                                table = instance.getImports().getTables()[tableidx].getTable();
+                            }
+
+                            var size = stack.pop().asInt();
+                            var valValue = stack.pop();
+                            var val = valValue.asExtRef();
+
+                            var res = table.grow(size, val);
+                            stack.push(Value.i32(res));
+                            break;
+                        }
+                    case REF_FUNC:
+                        {
+                            stack.push(Value.funcRef(operands[0]));
+                            break;
+                        }
+                    case REF_NULL:
+                        {
+                            var type = ValueType.byId(operands[0]);
+                            stack.push(new Value(type, (long) REF_NULL_VALUE));
                             break;
                         }
                     case REF_IS_NULL:

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
@@ -224,6 +224,12 @@ public class Module {
                                 // TODO: what? only runtime?
                                 break;
                             }
+                        case Mem:
+                            {
+                                var memElem = (ElemMem) el;
+                                // TODO: what? only runtime?
+                                break;
+                            }
                         default:
                             throw new ChicoryException(
                                     "Elment type: " + el.getElemType() + " not yet supported");

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElementType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElementType.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum ElementType {
-    ExtRef(0x67),
+    ExtRef(0x6F),
     FuncRef(0x70);
 
     private final long id;

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Table.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Table.java
@@ -3,9 +3,10 @@ package com.dylibso.chicory.wasm.types;
 import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
 
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
+import java.util.Arrays;
 
 public class Table {
-    private ElementType elementType;
+    private final ElementType elementType;
     private long limitMin;
     private long limitMax;
 
@@ -37,6 +38,18 @@ public class Table {
 
     public int getSize() {
         return refs.length;
+    }
+
+    public int grow(int size, Integer value) {
+        var oldSize = refs.length;
+        var targetSize = oldSize + size;
+        if (size < 0 || (limitMax != 0 && targetSize > limitMax)) {
+            return -1;
+        }
+        var newRefs = Arrays.copyOf(refs, targetSize);
+        Arrays.fill(newRefs, oldSize, targetSize, value);
+        refs = newRefs;
+        return oldSize;
     }
 
     public Value getRef(int index) {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ValueType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ValueType.java
@@ -9,7 +9,7 @@ public enum ValueType {
     I64(0x7e),
     I32(0x7f),
     V128(0x7b),
-    FuncRef(0x7a),
+    FuncRef(0x70),
     ExternRef(0x6f);
 
     private final long id;

--- a/wasm/src/main/resources/instructions.tsv
+++ b/wasm/src/main/resources/instructions.tsv
@@ -178,7 +178,7 @@ i32.extend_16_s      	$C1
 i64.extend_8_s      	$C2
 i64.extend_16_s      	$C3
 i64.extend_32_s      	$C4
-ref.null	$D0
+ref.null <varuint>	$D0
 ref.is_null	$D1
 ref.func <varuint>	$D2
 i32.trunc_sat_f32_s 	$FC00


### PR DESCRIPTION
Getting `table_grow.wast` to pass, fixed a few bugs around to get there.
This is the reference:
https://webassembly.github.io/spec/core/exec/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-grow-x