### PR TITLE
[chore] add a script to easily list missing specs

### DIFF
--- a/scripts/list-missing-specs.sh
+++ b/scripts/list-missing-specs.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+# set -euxo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+rm -rf ${SCRIPT_DIR}/pom.txt ${SCRIPT_DIR}/pom_sorted.txt ${SCRIPT_DIR}/testsuite.txt ${SCRIPT_DIR}/testsuite_sorted.txt
+
+IFS=', ' read -r -a pom <<< "$(yq -p=xml '.project.build.plugins.plugin.configuration.wastToProcess' ${SCRIPT_DIR}/../runtime/pom.xml | tr '\n' ' ')"
+
+for element in "${pom[@]}"
+do
+    echo "$element" | xargs >> ${SCRIPT_DIR}/pom.txt
+done
+
+IFS=', ' read -r -a pom <<< "$(yq -p=xml '.project.build.plugins.plugin.configuration.orderedWastToProcess' ${SCRIPT_DIR}/../runtime/pom.xml | tr '\n' ' ')"
+
+for element in "${pom[@]}"
+do
+    echo "$element" | xargs >> ${SCRIPT_DIR}/pom.txt
+done
+
+{
+    cd ${SCRIPT_DIR}/../testsuite
+    IFS=$'\n' read -rd '' -a testsuite <<< "$(ls -a *.wast)"
+}
+
+for element in "${testsuite[@]}"
+do
+    echo "$element" | xargs >> ${SCRIPT_DIR}/testsuite.txt
+done
+
+sort -n ${SCRIPT_DIR}/pom.txt > ${SCRIPT_DIR}/pom_sorted.txt
+sort -n ${SCRIPT_DIR}/testsuite.txt > ${SCRIPT_DIR}/testsuite_sorted.txt
+
+diff --color ${SCRIPT_DIR}/pom_sorted.txt ${SCRIPT_DIR}/testsuite_sorted.txt
+
+rm -rf ${SCRIPT_DIR}/pom.txt ${SCRIPT_DIR}/pom_sorted.txt ${SCRIPT_DIR}/testsuite.txt ${SCRIPT_DIR}/testsuite_sorted.txt


### PR DESCRIPTION
It's a bit hacky and not sure about portability ...
Not sure if we should have it in the main repo, I can even keep It local, but it helps when eyeballing to find what to tackle next.