### PR TITLE
Be defensive about arrays

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostImports.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostImports.java
@@ -1,6 +1,11 @@
 package com.dylibso.chicory.runtime;
 
 public class HostImports {
+    private static final HostFunction[] NO_HOST_FUNCTIONS = new HostFunction[0];
+    private static final HostGlobal[] NO_HOST_GLOBALS = new HostGlobal[0];
+    private static final HostMemory[] NO_HOST_MEMORIES = new HostMemory[0];
+    private static final HostTable[] NO_HOST_TABLES = new HostTable[0];
+
     private final HostFunction[] functions;
     private final HostGlobal[] globals;
     private final HostMemory[] memories;
@@ -8,53 +13,53 @@ public class HostImports {
     private FromHost[] index;
 
     public HostImports() {
-        this.functions = new HostFunction[] {};
-        this.globals = new HostGlobal[] {};
-        this.memories = new HostMemory[] {};
-        this.tables = new HostTable[] {};
+        this.functions = NO_HOST_FUNCTIONS;
+        this.globals = NO_HOST_GLOBALS;
+        this.memories = NO_HOST_MEMORIES;
+        this.tables = NO_HOST_TABLES;
     }
 
     public HostImports(HostFunction[] functions) {
-        this.functions = functions;
-        this.globals = new HostGlobal[] {};
-        this.memories = new HostMemory[] {};
-        this.tables = new HostTable[] {};
+        this.functions = functions.clone();
+        this.globals = NO_HOST_GLOBALS;
+        this.memories = NO_HOST_MEMORIES;
+        this.tables = NO_HOST_TABLES;
     }
 
     public HostImports(HostGlobal[] globals) {
-        this.functions = new HostFunction[] {};
-        this.globals = globals;
-        this.memories = new HostMemory[] {};
-        this.tables = new HostTable[] {};
+        this.functions = NO_HOST_FUNCTIONS;
+        this.globals = globals.clone();
+        this.memories = NO_HOST_MEMORIES;
+        this.tables = NO_HOST_TABLES;
     }
 
     public HostImports(HostMemory[] memories) {
-        this.functions = new HostFunction[] {};
-        this.globals = new HostGlobal[] {};
-        this.memories = memories;
-        this.tables = new HostTable[] {};
+        this.functions = NO_HOST_FUNCTIONS;
+        this.globals = NO_HOST_GLOBALS;
+        this.memories = memories.clone();
+        this.tables = NO_HOST_TABLES;
     }
 
     public HostImports(HostMemory memory) {
-        this.functions = new HostFunction[] {};
-        this.globals = new HostGlobal[] {};
+        this.functions = NO_HOST_FUNCTIONS;
+        this.globals = NO_HOST_GLOBALS;
         this.memories = new HostMemory[] {memory};
-        this.tables = new HostTable[] {};
+        this.tables = NO_HOST_TABLES;
     }
 
     public HostImports(HostTable[] tables) {
-        this.functions = new HostFunction[] {};
-        this.globals = new HostGlobal[] {};
-        this.memories = new HostMemory[] {};
-        this.tables = tables;
+        this.functions = NO_HOST_FUNCTIONS;
+        this.globals = NO_HOST_GLOBALS;
+        this.memories = NO_HOST_MEMORIES;
+        this.tables = tables.clone();
     }
 
     public HostImports(
             HostFunction[] functions, HostGlobal[] globals, HostMemory memory, HostTable[] tables) {
-        this.functions = functions;
-        this.globals = globals;
+        this.functions = functions.clone();
+        this.globals = globals.clone();
         this.memories = new HostMemory[] {memory};
-        this.tables = tables;
+        this.tables = tables.clone();
     }
 
     public HostImports(
@@ -62,26 +67,58 @@ public class HostImports {
             HostGlobal[] globals,
             HostMemory[] memories,
             HostTable[] tables) {
-        this.functions = functions;
-        this.globals = globals;
-        this.memories = memories;
-        this.tables = tables;
+        this.functions = functions.clone();
+        this.globals = globals.clone();
+        this.memories = memories.clone();
+        this.tables = tables.clone();
     }
 
     public HostFunction[] getFunctions() {
-        return functions;
+        return functions.clone();
+    }
+
+    public int getFunctionCount() {
+        return functions.length;
+    }
+
+    public HostFunction getFunction(int idx) {
+        return functions[idx];
     }
 
     public HostGlobal[] getGlobals() {
         return globals;
     }
 
+    public int getGlobalCount() {
+        return globals.length;
+    }
+
+    public HostGlobal getGlobal(int idx) {
+        return globals[idx];
+    }
+
     public HostMemory[] getMemories() {
         return memories;
     }
 
+    public int getMemoryCount() {
+        return memories.length;
+    }
+
+    public HostMemory getMemory(int idx) {
+        return memories[idx];
+    }
+
     public HostTable[] getTables() {
         return tables;
+    }
+
+    public int getTableCount() {
+        return tables.length;
+    }
+
+    public HostTable getTable(int idx) {
+        return tables[idx];
     }
 
     public FromHost[] getIndex() {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -36,19 +36,19 @@ public class Instance {
             Table[] tables,
             Element[] elements) {
         this.module = module;
-        this.globalInitializers = globalInitializers;
-        this.globals = globals;
+        this.globalInitializers = globalInitializers.clone();
+        this.globals = globals.clone();
         this.importedGlobalsOffset = importedGlobalsOffset;
         this.importedFunctionsOffset = importedFunctionsOffset;
         this.importedTablesOffset = importedTablesOffset;
         this.memory = memory;
-        this.functions = functions;
-        this.types = types;
-        this.functionTypes = functionTypes;
+        this.functions = functions.clone();
+        this.types = types.clone();
+        this.functionTypes = functionTypes.clone();
         this.imports = imports;
         this.machine = new Machine(this);
-        this.tables = tables;
-        this.elements = elements;
+        this.tables = tables.clone();
+        this.elements = elements.clone();
     }
 
     public ExportFunction getExport(String name) {
@@ -65,16 +65,12 @@ public class Instance {
         };
     }
 
-    public FunctionBody[] getFunctions() {
-        return functions;
-    }
-
     public FunctionBody getFunction(int idx) {
         if (idx < importedFunctionsOffset) return null;
         return functions[idx - importedFunctionsOffset];
     }
 
-    public int getFunctionsSize() {
+    public int getFunctionCount() {
         return importedFunctionsOffset + functions.length;
     }
 
@@ -82,13 +78,9 @@ public class Instance {
         return memory;
     }
 
-    public Value[] getGlobals() {
-        return globals;
-    }
-
     public void setGlobal(int idx, Value val) {
         if (idx < importedGlobalsOffset) {
-            imports.getGlobals()[idx].setValue(val);
+            imports.getGlobal(idx).setValue(val);
         }
         globals[idx - importedGlobalsOffset] = val;
     }
@@ -107,8 +99,12 @@ public class Instance {
         return globalInitializers[idx - importedGlobalsOffset];
     }
 
-    public FunctionType[] getTypes() {
-        return types;
+    public int getGlobalCount() {
+        return globals.length;
+    }
+
+    public FunctionType getType(int idx) {
+        return types[idx];
     }
 
     public int getFunctionType(int idx) {
@@ -134,7 +130,7 @@ public class Instance {
         return elements[idx];
     }
 
-    public int getElementSize() {
+    public int getElementCount() {
         return elements.length;
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -36,7 +36,7 @@ public class Machine {
             throws ChicoryException {
 
         var typeId = instance.getFunctionType(funcId);
-        var type = instance.getTypes()[typeId];
+        var type = instance.getType(typeId);
 
         if (callType != null) {
             verifyIndirectCall(type, callType);
@@ -139,7 +139,7 @@ public class Machine {
                                 frame.numberOfValuesToReturn =
                                         Math.max(frame.numberOfValuesToReturn, 1);
                             } else { // look it up
-                                var funcType = instance.getTypes()[typeId];
+                                var funcType = instance.getType(typeId);
                                 frame.numberOfValuesToReturn =
                                         Math.max(
                                                 frame.numberOfValuesToReturn,
@@ -209,10 +209,10 @@ public class Machine {
                             var tableIdx = (int) operands[1];
                             var table = instance.getTable(tableIdx);
                             if (table == null) { // imported table
-                                table = instance.getImports().getTables()[tableIdx].getTable();
+                                table = instance.getImports().getTable(tableIdx).getTable();
                             }
                             var typeId = (int) operands[0];
-                            var type = instance.getTypes()[typeId];
+                            var type = instance.getType(typeId);
                             int funcTableIdx = this.stack.pop().asInt();
                             int funcId = table.getRef(funcTableIdx).asFuncRef();
                             if (funcId == REF_NULL_VALUE) {
@@ -274,7 +274,7 @@ public class Machine {
                             int idx = (int) operands[0];
                             var val = instance.getGlobal(idx);
                             if (val == null) {
-                                val = instance.getImports().getGlobals()[idx].getValue();
+                                val = instance.getImports().getGlobal(idx).getValue();
                             }
                             this.stack.push(val);
                             break;
@@ -285,7 +285,7 @@ public class Machine {
                             var mutabilityType =
                                     (instance.getGlobalInitializer(id) == null)
                                             ? instance.getImports()
-                                                    .getGlobals()[id]
+                                                    .getGlobal(id)
                                                     .getMutabilityType()
                                             : instance.getGlobalInitializer(id);
                             if (mutabilityType == MutabilityType.Const) {
@@ -301,7 +301,7 @@ public class Machine {
                             var idx = (int) operands[0];
                             var table = instance.getTable(idx);
                             if (table == null) {
-                                table = instance.getImports().getTables()[idx].getTable();
+                                table = instance.getImports().getTable(idx).getTable();
                             }
                             var i = this.stack.pop().asInt();
                             if (i < 0
@@ -318,7 +318,7 @@ public class Machine {
                             var idx = (int) operands[0];
                             var table = instance.getTable(idx);
                             if (table == null) {
-                                table = instance.getImports().getTables()[idx].getTable();
+                                table = instance.getImports().getTable(idx).getTable();
                             }
                             var value = this.stack.pop().asExtRef();
                             var i = this.stack.pop().asInt();
@@ -943,7 +943,7 @@ public class Machine {
                         {
                             var funcId = (int) operands[0];
                             var typeId = instance.getFunctionType(funcId);
-                            var type = instance.getTypes()[typeId];
+                            var type = instance.getType(typeId);
                             // given a list of param types, let's pop those params off the stack
                             // and pass as args to the function call
                             var args = extractArgsForParams(type.getParams());
@@ -1783,11 +1783,11 @@ public class Machine {
 
                             var table = instance.getTable(tableidx);
                             if (table == null) {
-                                table = instance.getImports().getTables()[tableidx].getTable();
+                                table = instance.getImports().getTable(tableidx).getTable();
                             }
 
                             if (size < 0
-                                    || elementidx > instance.getElementSize()
+                                    || elementidx > instance.getElementCount()
                                     || instance.getElement(elementidx) == null
                                     || elemidx + size > instance.getElement(elementidx).getSize()
                                     || end > table.getSize()) {
@@ -1796,7 +1796,7 @@ public class Machine {
 
                             for (int i = offset; i < end; i++) {
                                 var val = getRuntimeElementValue(elementidx, elemidx++);
-                                if (val > instance.getFunctionsSize()) {
+                                if (val > instance.getFunctionCount()) {
                                     throw new WASMRuntimeException("out of bounds table access");
                                 }
                                 table.setRef(i, val);
@@ -1864,7 +1864,7 @@ public class Machine {
 
                             var table = instance.getTable(tableidx);
                             if (table == null) {
-                                table = instance.getImports().getTables()[tableidx].getTable();
+                                table = instance.getImports().getTable(tableidx).getTable();
                             }
 
                             if (size < 0 || end > table.getSize()) {
@@ -1881,7 +1881,7 @@ public class Machine {
                             var tableidx = (int) operands[0];
                             var table = instance.getTable(tableidx);
                             if (table == null) {
-                                table = instance.getImports().getTables()[tableidx].getTable();
+                                table = instance.getImports().getTable(tableidx).getTable();
                             }
 
                             this.stack.push(Value.i32(table.getSize()));
@@ -1892,7 +1892,7 @@ public class Machine {
                             var tableidx = (int) operands[0];
                             var table = instance.getTable(tableidx);
                             if (table == null) {
-                                table = instance.getImports().getTables()[tableidx].getTable();
+                                table = instance.getImports().getTable(tableidx).getTable();
                             }
 
                             var size = stack.pop().asInt();

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
@@ -86,11 +86,10 @@ public class Module {
                     {
                         // TODO this assumes that these are already initialized declared in order
                         // should we make this more resilient? Should initialization happen later?
-                        var globalImports = hostImports.getGlobals();
                         var idx = (int) instr.getOperands()[0];
                         globals[i] =
-                                idx < globalImports.length
-                                        ? globalImports[idx].getValue()
+                                idx < hostImports.getGlobalCount()
+                                        ? hostImports.getGlobal(idx).getValue()
                                         : globals[idx];
                         break;
                     }
@@ -243,7 +242,7 @@ public class Module {
 
         Memory memory = null;
         if (module.getMemorySection() != null) {
-            assert (mappedHostImports.getMemories().length == 0);
+            assert (mappedHostImports.getMemoryCount() == 0);
 
             var memories = module.getMemorySection().getMemories();
             if (memories.length > 1) {
@@ -253,14 +252,14 @@ public class Module {
                 memory = new Memory(memories[0].getMemoryLimits(), dataSegments);
             }
         } else {
-            if (mappedHostImports.getMemories().length > 0) {
-                assert (mappedHostImports.getMemories().length == 1);
-                if (mappedHostImports.getMemories()[0] == null
-                        || mappedHostImports.getMemories()[0].getMemory() == null) {
+            if (mappedHostImports.getMemoryCount() > 0) {
+                assert (mappedHostImports.getMemoryCount() == 1);
+                if (mappedHostImports.getMemory(0) == null
+                        || mappedHostImports.getMemory(0).getMemory() == null) {
                     throw new ChicoryException(
                             "Imported memory not defined, cannot run the program");
                 }
-                memory = mappedHostImports.getMemories()[0].getMemory();
+                memory = mappedHostImports.getMemory(0).getMemory();
             } else {
                 // No memory defined
             }
@@ -344,13 +343,16 @@ public class Module {
         var hostTables = new HostTable[hostTableNum];
         var hostTableIdx = 0;
         var hostIndex = new FromHost[hostFuncNum + hostGlobalNum + hostMemNum + hostTableNum];
+        int cnt;
         for (var impIdx = 0; impIdx < imports.length; impIdx++) {
             var i = imports[impIdx];
             var name = i.getModuleName() + "." + i.getFieldName();
             var found = false;
             switch (i.getDesc().getType()) {
                 case FuncIdx:
-                    for (var f : hostImports.getFunctions()) {
+                    cnt = hostImports.getFunctionCount();
+                    for (int j = 0; j < cnt; j++) {
+                        HostFunction f = hostImports.getFunction(j);
                         if (i.getModuleName().equals(f.getModuleName())
                                 && i.getFieldName().equals(f.getFieldName())) {
                             hostFuncs[hostFuncIdx] = f;
@@ -362,7 +364,9 @@ public class Module {
                     hostFuncIdx++;
                     break;
                 case GlobalIdx:
-                    for (var g : hostImports.getGlobals()) {
+                    cnt = hostImports.getGlobalCount();
+                    for (int j = 0; j < cnt; j++) {
+                        HostGlobal g = hostImports.getGlobal(j);
                         if (i.getModuleName().equals(g.getModuleName())
                                 && i.getFieldName().equals(g.getFieldName())) {
                             hostGlobals[hostGlobalIdx] = g;
@@ -374,7 +378,9 @@ public class Module {
                     hostGlobalIdx++;
                     break;
                 case MemIdx:
-                    for (var m : hostImports.getMemories()) {
+                    cnt = hostImports.getMemoryCount();
+                    for (int j = 0; j < cnt; j++) {
+                        HostMemory m = hostImports.getMemory(j);
                         if (i.getModuleName().equals(m.getModuleName())
                                 && i.getFieldName().equals(m.getFieldName())) {
                             hostMems[hostMemIdx] = m;
@@ -386,7 +392,9 @@ public class Module {
                     hostMemIdx++;
                     break;
                 case TableIdx:
-                    for (var t : hostImports.getTables()) {
+                    cnt = hostImports.getTableCount();
+                    for (int j = 0; j < cnt; j++) {
+                        HostTable t = hostImports.getTable(j);
                         if (i.getModuleName().equals(t.getModuleName())
                                 && i.getFieldName().equals(t.getFieldName())) {
                             hostTables[hostTableIdx] = t;

--- a/runtime/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
+++ b/runtime/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
@@ -208,6 +208,6 @@ public class SpecV1ImportsHostFuncs {
         HostFunction[] hostFunctions = Arrays.copyOf(base, base.length + additional.length);
         System.arraycopy(additional, 0, hostFunctions, base.length, additional.length);
         return new HostImports(
-                hostFunctions, new HostGlobal[] {}, base().getMemories()[0], base().getTables());
+                hostFunctions, new HostGlobal[] {}, base().getMemory(0), base().getTables());
     }
 }


### PR DESCRIPTION
* Replace most direct array usage with `xxxCount`/`getXxx(idx)` pairs.
* Make sure that all remaining direct array usages employ defensive copies.
* Standardize `xxxsSize` -> `xxxCount` for uniformity and legibility.