### PR TITLE
Use newer "getter" idiom

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/FromHost.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/FromHost.java
@@ -8,9 +8,9 @@ public interface FromHost {
         TABLE;
     }
 
-    String getModuleName();
+    String moduleName();
 
-    String getFieldName();
+    String fieldName();
 
-    FromHostType getType();
+    FromHostType type();
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
@@ -23,28 +23,28 @@ public class HostFunction implements FromHost {
         this.returnTypes = returnTypes;
     }
 
-    public WasmFunctionHandle getHandle() {
+    public WasmFunctionHandle handle() {
         return handle;
     }
 
-    public String getModuleName() {
+    public String moduleName() {
         return moduleName;
     }
 
-    public String getFieldName() {
+    public String fieldName() {
         return fieldName;
     }
 
     @Override
-    public FromHostType getType() {
+    public FromHostType type() {
         return FromHostType.FUNCTION;
     }
 
-    public List<ValueType> getParamTypes() {
+    public List<ValueType> paramTypes() {
         return paramTypes;
     }
 
-    public List<ValueType> getReturnTypes() {
+    public List<ValueType> returnTypes() {
         return returnTypes;
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostGlobal.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostGlobal.java
@@ -20,7 +20,7 @@ public class HostGlobal implements FromHost {
         this.fieldName = fieldName;
     }
 
-    public Value getValue() {
+    public Value value() {
         return value;
     }
 
@@ -28,20 +28,20 @@ public class HostGlobal implements FromHost {
         this.value = value;
     }
 
-    public MutabilityType getMutabilityType() {
+    public MutabilityType mutabilityType() {
         return type;
     }
 
-    public String getModuleName() {
+    public String moduleName() {
         return moduleName;
     }
 
-    public String getFieldName() {
+    public String fieldName() {
         return fieldName;
     }
 
     @Override
-    public FromHostType getType() {
+    public FromHostType type() {
         return FromHostType.GLOBAL;
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostImports.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostImports.java
@@ -73,55 +73,55 @@ public class HostImports {
         this.tables = tables.clone();
     }
 
-    public HostFunction[] getFunctions() {
+    public HostFunction[] functions() {
         return functions.clone();
     }
 
-    public int getFunctionCount() {
+    public int functionCount() {
         return functions.length;
     }
 
-    public HostFunction getFunction(int idx) {
+    public HostFunction function(int idx) {
         return functions[idx];
     }
 
-    public HostGlobal[] getGlobals() {
+    public HostGlobal[] globals() {
         return globals;
     }
 
-    public int getGlobalCount() {
+    public int globalCount() {
         return globals.length;
     }
 
-    public HostGlobal getGlobal(int idx) {
+    public HostGlobal global(int idx) {
         return globals[idx];
     }
 
-    public HostMemory[] getMemories() {
+    public HostMemory[] memories() {
         return memories;
     }
 
-    public int getMemoryCount() {
+    public int memoryCount() {
         return memories.length;
     }
 
-    public HostMemory getMemory(int idx) {
+    public HostMemory memory(int idx) {
         return memories[idx];
     }
 
-    public HostTable[] getTables() {
+    public HostTable[] tables() {
         return tables;
     }
 
-    public int getTableCount() {
+    public int tableCount() {
         return tables.length;
     }
 
-    public HostTable getTable(int idx) {
+    public HostTable table(int idx) {
         return tables[idx];
     }
 
-    public FromHost[] getIndex() {
+    public FromHost[] index() {
         return index;
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostMemory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostMemory.java
@@ -11,20 +11,20 @@ public class HostMemory implements FromHost {
         this.memory = memory;
     }
 
-    public String getModuleName() {
+    public String moduleName() {
         return moduleName;
     }
 
-    public String getFieldName() {
+    public String fieldName() {
         return fieldName;
     }
 
     @Override
-    public FromHostType getType() {
+    public FromHostType type() {
         return FromHostType.MEMORY;
     }
 
-    public Memory getMemory() {
+    public Memory memory() {
         return memory;
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostTable.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostTable.java
@@ -39,20 +39,20 @@ public class HostTable implements FromHost {
         }
     }
 
-    public String getModuleName() {
+    public String moduleName() {
         return moduleName;
     }
 
-    public String getFieldName() {
+    public String fieldName() {
         return fieldName;
     }
 
     @Override
-    public FromHostType getType() {
+    public FromHostType type() {
         return FromHostType.TABLE;
     }
 
-    public Table getTable() {
+    public Table table() {
         return table;
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -56,9 +56,9 @@ public class Instance {
         this.elements = elements.clone();
     }
 
-    public ExportFunction getExport(String name) {
-        var export = module.getExport(name);
-        var funcId = (int) export.getDesc().getIndex();
+    public ExportFunction export(String name) {
+        var export = module.export(name);
+        var funcId = (int) export.desc().index();
         return (args) -> {
             this.module.logger().debug(() -> "Args: " + Arrays.toString(args));
             try {
@@ -69,72 +69,72 @@ public class Instance {
         };
     }
 
-    public FunctionBody getFunction(int idx) {
+    public FunctionBody function(int idx) {
         if (idx < importedFunctionsOffset) return null;
         return functions[idx - importedFunctionsOffset];
     }
 
-    public int getFunctionCount() {
+    public int functionCount() {
         return importedFunctionsOffset + functions.length;
     }
 
-    public Memory getMemory() {
+    public Memory memory() {
         return memory;
     }
 
-    public void setGlobal(int idx, Value val) {
+    public void writeGlobal(int idx, Value val) {
         if (idx < importedGlobalsOffset) {
-            imports.getGlobal(idx).setValue(val);
+            imports.global(idx).setValue(val);
         }
         globals[idx - importedGlobalsOffset] = val;
     }
 
-    public Value getGlobal(int idx) {
+    public Value readGlobal(int idx) {
         if (idx < importedGlobalsOffset) {
             return null;
         }
         return globals[idx - importedGlobalsOffset];
     }
 
-    public Global getGlobalInitializer(int idx) {
+    public Global globalInitializer(int idx) {
         if (idx < importedGlobalsOffset) {
             return null;
         }
         return globalInitializers[idx - importedGlobalsOffset];
     }
 
-    public int getGlobalCount() {
+    public int globalCount() {
         return globals.length;
     }
 
-    public FunctionType getType(int idx) {
+    public FunctionType type(int idx) {
         return types[idx];
     }
 
-    public int getFunctionType(int idx) {
+    public int functionType(int idx) {
         return functionTypes[idx];
     }
 
-    public HostImports getImports() {
+    public HostImports imports() {
         return imports;
     }
 
-    public Module getModule() {
+    public Module module() {
         return module;
     }
 
-    public Table getTable(int idx) {
+    public Table table(int idx) {
         if (idx < importedTablesOffset) {
             return null;
         }
         return tables[idx - importedTablesOffset];
     }
 
-    public Element getElement(int idx) {
+    public Element element(int idx) {
         return elements[idx];
     }
 
-    public int getElementCount() {
+    public int elementCount() {
         return elements.length;
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
@@ -25,7 +25,7 @@ public class MStack {
         this.unwindFrame = null;
     }
 
-    public Stack<Value> getUnwindFrame() {
+    public Stack<Value> unwindFrame() {
         return this.unwindFrame;
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
@@ -51,9 +51,9 @@ public class Module {
         this.logger = logger;
         this.module = module;
         this.exports = new HashMap<>();
-        if (module.getExportSection() != null) {
-            for (var e : module.getExportSection().getExports()) {
-                exports.put(e.getName(), e);
+        if (module.exportSection() != null) {
+            for (var e : module.exportSection().exports()) {
+                exports.put(e.name(), e);
             }
         }
     }
@@ -68,37 +68,37 @@ public class Module {
 
     public Instance instantiate(HostImports hostImports) {
         var globalInitializers = new Global[] {};
-        if (this.module.getGlobalSection() != null) {
-            globalInitializers = this.module.getGlobalSection().getGlobals();
+        if (this.module.globalSection() != null) {
+            globalInitializers = this.module.globalSection().globals();
         }
         var globals = new Value[globalInitializers.length];
         for (var i = 0; i < globalInitializers.length; i++) {
             var g = globalInitializers[i];
-            if (g.getInit().length > 2)
+            if (g.initInstructions().length > 2)
                 throw new RuntimeException(
                         "We don't a global initializer with multiple instructions");
-            var instr = g.getInit()[0];
-            switch (instr.getOpcode()) {
+            var instr = g.initInstructions()[0];
+            switch (instr.opcode()) {
                 case I32_CONST:
-                    globals[i] = Value.i32(instr.getOperands()[0]);
+                    globals[i] = Value.i32(instr.operands()[0]);
                     break;
                 case I64_CONST:
-                    globals[i] = Value.i64(instr.getOperands()[0]);
+                    globals[i] = Value.i64(instr.operands()[0]);
                     break;
                 case F32_CONST:
-                    globals[i] = Value.f32(instr.getOperands()[0]);
+                    globals[i] = Value.f32(instr.operands()[0]);
                     break;
                 case F64_CONST:
-                    globals[i] = Value.f64(instr.getOperands()[0]);
+                    globals[i] = Value.f64(instr.operands()[0]);
                     break;
                 case GLOBAL_GET:
                     {
                         // TODO this assumes that these are already initialized declared in order
                         // should we make this more resilient? Should initialization happen later?
-                        var idx = (int) instr.getOperands()[0];
+                        var idx = (int) instr.operands()[0];
                         globals[i] =
-                                idx < hostImports.getGlobalCount()
-                                        ? hostImports.getGlobal(idx).getValue()
+                                idx < hostImports.globalCount()
+                                        ? hostImports.global(idx).value()
                                         : globals[idx];
                         break;
                     }
@@ -106,44 +106,44 @@ public class Module {
                     globals[i] = Value.EXTREF_NULL;
                     break;
                 case REF_FUNC:
-                    globals[i] = Value.funcRef(instr.getOperands()[0]);
+                    globals[i] = Value.funcRef(instr.operands()[0]);
                     break;
                 default:
                     throw new RuntimeException(
                             "We only support i32.const, i64.const, f32.const, f64.const,"
                                     + " global.get, ref.func and ref.null opcodes on global"
                                     + " initializers right now. We failed to initialize opcode: "
-                                    + instr.getOpcode());
+                                    + instr.opcode());
             }
         }
 
         var dataSegments = new DataSegment[0];
-        if (module.getDataSection() != null) {
-            dataSegments = module.getDataSection().getDataSegments();
+        if (module.dataSection() != null) {
+            dataSegments = module.dataSection().dataSegments();
         }
 
         var types = new FunctionType[0];
         // TODO i guess we should explode if this is the case, is this possible?
-        if (module.getTypeSection() != null) {
-            types = module.getTypeSection().getTypes();
+        if (module.typeSection() != null) {
+            types = module.typeSection().types();
         }
 
         var numFuncTypes = 0;
-        var funcSection = module.getFunctionSection();
+        var funcSection = module.functionSection();
         if (funcSection != null) {
-            numFuncTypes = funcSection.getTypeIndices().length;
+            numFuncTypes = funcSection.typeIndices().length;
         }
-        if (module.getImportSection() != null) {
+        if (module.importSection() != null) {
             numFuncTypes +=
-                    Arrays.stream(module.getImportSection().getImports())
-                            .filter(is -> is.getDesc().getType() == ImportDescType.FuncIdx)
+                    Arrays.stream(module.importSection().imports())
+                            .filter(is -> is.desc().type() == ImportDescType.FuncIdx)
                             .count();
         }
 
         FunctionBody[] functions = new FunctionBody[0];
-        var codeSection = module.getCodeSection();
+        var codeSection = module.codeSection();
         if (codeSection != null) {
-            functions = module.getCodeSection().getFunctionBodies();
+            functions = module.codeSection().functionBodies();
         }
 
         int importId = 0;
@@ -152,13 +152,13 @@ public class Module {
         var imports = new Import[0];
         var funcIdx = 0;
 
-        if (module.getImportSection() != null) {
-            imports = new Import[module.getImportSection().getImports().length];
-            for (var imprt : module.getImportSection().getImports()) {
-                switch (imprt.getDesc().getType()) {
+        if (module.importSection() != null) {
+            imports = new Import[module.importSection().imports().length];
+            for (var imprt : module.importSection().imports()) {
+                switch (imprt.desc().type()) {
                     case FuncIdx:
                         {
-                            var type = (int) imprt.getDesc().getIndex();
+                            var type = (int) imprt.desc().index();
                             functionTypes[importId] = type;
                             // The global function id increases on this table
                             // function ids are assigned on imports first
@@ -177,37 +177,37 @@ public class Module {
 
         var mappedHostImports = mapHostImports(imports, hostImports);
 
-        if (module.getStartSection() != null) {
-            startFuncId = (int) module.getStartSection().getStartIndex();
+        if (module.startSection() != null) {
+            startFuncId = (int) module.startSection().startIndex();
             var desc = new ExportDesc(startFuncId, ExportDescType.FuncIdx);
             var export = new Export("_start", desc);
             exports.put("_start", export);
         }
 
-        if (module.getFunctionSection() != null) {
-            for (var ft : module.getFunctionSection().getTypeIndices()) {
+        if (module.functionSection() != null) {
+            for (var ft : module.functionSection().typeIndices()) {
                 functionTypes[funcIdx++] = ft;
             }
         }
 
         Table[] tables = new Table[0];
         Element[] elements = new Element[0];
-        if (module.getTableSection() != null) {
-            var tableLength = module.getTableSection().getTables().length;
+        if (module.tableSection() != null) {
+            var tableLength = module.tableSection().tables().length;
             tables = new Table[tableLength];
             for (int i = 0; i < tableLength; i++) {
-                tables[i] = module.getTableSection().getTables()[i];
+                tables[i] = module.tableSection().tables()[i];
             }
-            if (module.getElementSection() != null) {
-                elements = module.getElementSection().getElements();
-                for (var el : module.getElementSection().getElements()) {
-                    switch (el.getElemType()) {
+            if (module.elementSection() != null) {
+                elements = module.elementSection().elements();
+                for (var el : module.elementSection().elements()) {
+                    switch (el.elemType()) {
                         case Type:
                             {
                                 var typeElem = (ElemType) el;
-                                var expr = typeElem.getExpr();
-                                var addr = getConstantValue(expr);
-                                for (var fi : typeElem.getFuncIndices()) {
+                                var expr = typeElem.exprInstructions();
+                                var addr = computeConstantValue(expr);
+                                for (var fi : typeElem.funcIndices()) {
                                     tables[0].setRef(addr++, (int) fi);
                                 }
                                 break;
@@ -215,10 +215,10 @@ public class Module {
                         case Table:
                             {
                                 var tableElem = (ElemTable) el;
-                                var idx = (int) tableElem.getTableIndex();
-                                var expr = tableElem.getExpr();
-                                var addr = getConstantValue(expr);
-                                for (var fi : tableElem.getFuncIndices()) {
+                                var idx = (int) tableElem.tableIndex();
+                                var expr = tableElem.exprInstructions();
+                                var addr = computeConstantValue(expr);
+                                for (var fi : tableElem.funcIndices()) {
                                     tables[idx].setRef(addr++, (int) fi);
                                 }
                                 break;
@@ -243,32 +243,32 @@ public class Module {
                             }
                         default:
                             throw new ChicoryException(
-                                    "Elment type: " + el.getElemType() + " not yet supported");
+                                    "Elment type: " + el.elemType() + " not yet supported");
                     }
                 }
             }
         }
 
         Memory memory = null;
-        if (module.getMemorySection() != null) {
-            assert (mappedHostImports.getMemoryCount() == 0);
+        if (module.memorySection() != null) {
+            assert (mappedHostImports.memoryCount() == 0);
 
-            var memories = module.getMemorySection().getMemories();
+            var memories = module.memorySection().memories();
             if (memories.length > 1) {
                 throw new ChicoryException("Multiple memories are not supported");
             }
             if (memories.length > 0) {
-                memory = new Memory(memories[0].getMemoryLimits(), dataSegments);
+                memory = new Memory(memories[0].memoryLimits(), dataSegments);
             }
         } else {
-            if (mappedHostImports.getMemoryCount() > 0) {
-                assert (mappedHostImports.getMemoryCount() == 1);
-                if (mappedHostImports.getMemory(0) == null
-                        || mappedHostImports.getMemory(0).getMemory() == null) {
+            if (mappedHostImports.memoryCount() > 0) {
+                assert (mappedHostImports.memoryCount() == 1);
+                if (mappedHostImports.memory(0) == null
+                        || mappedHostImports.memory(0).memory() == null) {
                     throw new ChicoryException(
                             "Imported memory not defined, cannot run the program");
                 }
-                memory = mappedHostImports.getMemory(0).getMemory();
+                memory = mappedHostImports.memory(0).memory();
             } else {
                 // No memory defined
             }
@@ -278,7 +278,7 @@ public class Module {
         var functionImportsOffset = 0;
         var tablesImportsOffset = 0;
         for (int i = 0; i < imports.length; i++) {
-            switch (imports[i].getDesc().getType()) {
+            switch (imports[i].desc().type()) {
                 case GlobalIdx:
                     globalImportsOffset++;
                     break;
@@ -309,15 +309,15 @@ public class Module {
                 elements);
     }
 
-    public static int getConstantValue(Instruction[] expr) {
+    public static int computeConstantValue(Instruction[] expr) {
         assert (expr.length == 1);
-        if (expr[0].getOpcode() != OpCode.I32_CONST) {
+        if (expr[0].opcode() != OpCode.I32_CONST) {
             throw new RuntimeException(
                     "Don't support data segment expressions other than"
                             + " i32.const yet, found: "
-                            + expr[0].getOpcode());
+                            + expr[0].opcode());
         }
-        return (int) expr[0].getOperands()[0];
+        return (int) expr[0].operands()[0];
     }
 
     private HostImports mapHostImports(Import[] imports, HostImports hostImports) {
@@ -326,7 +326,7 @@ public class Module {
         int hostMemNum = 0;
         int hostTableNum = 0;
         for (var imprt : imports) {
-            switch (imprt.getDesc().getType()) {
+            switch (imprt.desc().type()) {
                 case FuncIdx:
                     hostFuncNum++;
                     break;
@@ -355,15 +355,15 @@ public class Module {
         int cnt;
         for (var impIdx = 0; impIdx < imports.length; impIdx++) {
             var i = imports[impIdx];
-            var name = i.getModuleName() + "." + i.getFieldName();
+            var name = i.moduleName() + "." + i.fieldName();
             var found = false;
-            switch (i.getDesc().getType()) {
+            switch (i.desc().type()) {
                 case FuncIdx:
-                    cnt = hostImports.getFunctionCount();
+                    cnt = hostImports.functionCount();
                     for (int j = 0; j < cnt; j++) {
-                        HostFunction f = hostImports.getFunction(j);
-                        if (i.getModuleName().equals(f.getModuleName())
-                                && i.getFieldName().equals(f.getFieldName())) {
+                        HostFunction f = hostImports.function(j);
+                        if (i.moduleName().equals(f.moduleName())
+                                && i.fieldName().equals(f.fieldName())) {
                             hostFuncs[hostFuncIdx] = f;
                             hostIndex[impIdx] = f;
                             found = true;
@@ -373,11 +373,11 @@ public class Module {
                     hostFuncIdx++;
                     break;
                 case GlobalIdx:
-                    cnt = hostImports.getGlobalCount();
+                    cnt = hostImports.globalCount();
                     for (int j = 0; j < cnt; j++) {
-                        HostGlobal g = hostImports.getGlobal(j);
-                        if (i.getModuleName().equals(g.getModuleName())
-                                && i.getFieldName().equals(g.getFieldName())) {
+                        HostGlobal g = hostImports.global(j);
+                        if (i.moduleName().equals(g.moduleName())
+                                && i.fieldName().equals(g.fieldName())) {
                             hostGlobals[hostGlobalIdx] = g;
                             hostIndex[impIdx] = g;
                             found = true;
@@ -387,11 +387,11 @@ public class Module {
                     hostGlobalIdx++;
                     break;
                 case MemIdx:
-                    cnt = hostImports.getMemoryCount();
+                    cnt = hostImports.memoryCount();
                     for (int j = 0; j < cnt; j++) {
-                        HostMemory m = hostImports.getMemory(j);
-                        if (i.getModuleName().equals(m.getModuleName())
-                                && i.getFieldName().equals(m.getFieldName())) {
+                        HostMemory m = hostImports.memory(j);
+                        if (i.moduleName().equals(m.moduleName())
+                                && i.fieldName().equals(m.fieldName())) {
                             hostMems[hostMemIdx] = m;
                             hostIndex[impIdx] = m;
                             found = true;
@@ -401,11 +401,11 @@ public class Module {
                     hostMemIdx++;
                     break;
                 case TableIdx:
-                    cnt = hostImports.getTableCount();
+                    cnt = hostImports.tableCount();
                     for (int j = 0; j < cnt; j++) {
-                        HostTable t = hostImports.getTable(j);
-                        if (i.getModuleName().equals(t.getModuleName())
-                                && i.getFieldName().equals(t.getFieldName())) {
+                        HostTable t = hostImports.table(j);
+                        if (i.moduleName().equals(t.moduleName())
+                                && i.fieldName().equals(t.fieldName())) {
                             hostTables[hostTableIdx] = t;
                             hostIndex[impIdx] = t;
                             found = true;
@@ -427,15 +427,15 @@ public class Module {
         return result;
     }
 
-    public Export getExport(String name) {
+    public Export export(String name) {
         var e = this.exports.get(name);
         if (e == null) throw new ChicoryException("Unknown export with name " + name);
         return e;
     }
 
-    public NameSection getNameSection() {
+    public NameSection nameSection() {
         if (nameSec != null) return nameSec;
-        nameSec = this.module.getNameSection();
+        nameSec = this.module.nameSection();
         return nameSec;
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/StackFrame.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/StackFrame.java
@@ -36,7 +36,7 @@ public class StackFrame {
         // pre-initialize everything to 0
         for (var i = 0; i < initLocals.size(); i++) {
             var l = initLocals.get(i);
-            var type = l.getType() == null ? ValueType.I32 : l.getType();
+            var type = l.type() == null ? ValueType.I32 : l.type();
             // TODO need a cleaner way to initialize?
             // there are footguns to using the raw Value constructor
             switch (type) {
@@ -63,7 +63,7 @@ public class StackFrame {
         this.locals.put(i, v);
     }
 
-    Value getLocal(int i) {
+    Value local(int i) {
         var l = this.locals.get(i);
         // TODO is this right?
         if (l == null) {
@@ -74,10 +74,10 @@ public class StackFrame {
 
     @Override
     public String toString() {
-        var nameSec = instance.getModule().getNameSection();
+        var nameSec = instance.module().nameSection();
         var id = "[" + funcId + "]";
         if (nameSec != null) {
-            var funcName = nameSec.getFunctionNames().get(funcId);
+            var funcName = nameSec.functionNames().get(funcId);
             if (funcName != null) id = funcName + id;
         }
         return id + "\n\tpc=" + pc + " locals=" + Arrays.toString(locals.values().toArray());

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/TrapException.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/TrapException.java
@@ -11,7 +11,7 @@ public class TrapException extends ChicoryException {
         super(msg);
     }
 
-    public List<StackFrame> getCallStack() {
+    public List<StackFrame> callStack() {
         return callStack;
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/exceptions/WASMMachineException.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/exceptions/WASMMachineException.java
@@ -25,7 +25,7 @@ public class WASMMachineException extends ChicoryException {
         this.frames = frames == null ? List.of() : List.copyOf(frames);
     }
 
-    public List<StackFrame> getStackFrames() {
+    public List<StackFrame> stackFrames() {
         return frames;
     }
 }

--- a/runtime/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
+++ b/runtime/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
@@ -203,11 +203,11 @@ public class SpecV1ImportsHostFuncs {
                         "func-i64->i64",
                         List.of(ValueType.I64),
                         List.of(ValueType.I64));
-        var base = base().getFunctions();
+        var base = base().functions();
         var additional = new HostFunction[] {testFunc, testFuncI64};
         HostFunction[] hostFunctions = Arrays.copyOf(base, base.length + additional.length);
         System.arraycopy(additional, 0, hostFunctions, base.length, additional.length);
         return new HostImports(
-                hostFunctions, new HostGlobal[] {}, base().getMemory(0), base().getTables());
+                hostFunctions, new HostGlobal[] {}, base().memory(0), base().tables());
     }
 }

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
@@ -19,7 +19,7 @@ public class ModuleTest {
     public void shouldWorkFactorial() {
         var module = Module.builder("compiled/iterfact.wat.wasm").build();
         var instance = module.instantiate();
-        var iterFact = instance.getExport("iterFact");
+        var iterFact = instance.export("iterFact");
         var result = iterFact.apply(Value.i32(5))[0];
         assertEquals(120, result.asInt());
     }
@@ -27,7 +27,7 @@ public class ModuleTest {
     @Test
     public void shouldSupportBrTable() {
         var instance = Module.builder("compiled/br_table.wat.wasm").build().instantiate();
-        var switchLike = instance.getExport("switch_like");
+        var switchLike = instance.export("switch_like");
         var result = switchLike.apply(Value.i32(0))[0];
         assertEquals(102, result.asInt());
         result = switchLike.apply(Value.i32(1))[0];
@@ -47,7 +47,7 @@ public class ModuleTest {
     @Test
     public void shouldExerciseBranches() {
         var module = Module.builder("compiled/branching.wat.wasm").build().instantiate();
-        var foo = module.getExport("foo");
+        var foo = module.export("foo");
 
         var result = foo.apply(Value.i32(0))[0];
         assertEquals(42, result.asInt());
@@ -70,7 +70,7 @@ public class ModuleTest {
                 new HostFunction(
                         (Instance instance,
                                 Value... args) -> { // decompiled is: console_log(13, 0);
-                            Memory memory = instance.getMemory();
+                            Memory memory = instance.memory();
                             var len = args[0].asInt();
                             var offset = args[1].asInt();
                             var message = memory.readString(offset, len);
@@ -90,7 +90,7 @@ public class ModuleTest {
                 Module.builder("compiled/host-function.wat.wasm")
                         .build()
                         .instantiate(new HostImports(funcs));
-        var logIt = instance.getExport("logIt");
+        var logIt = instance.export("logIt");
         logIt.apply();
 
         assertEquals(10, count.get());
@@ -99,7 +99,7 @@ public class ModuleTest {
     @Test
     public void shouldComputeFactorial() {
         var module = Module.builder("compiled/iterfact.wat.wasm").build().instantiate();
-        var iterFact = module.getExport("iterFact");
+        var iterFact = module.export("iterFact");
 
         // don't make this too big we will overflow 32 bits
         for (var i = 0; i < 10; i++) {
@@ -141,7 +141,7 @@ public class ModuleTest {
                 Module.builder("compiled/start.wat.wasm")
                         .build()
                         .instantiate(new HostImports(funcs));
-        var start = module.getExport("_start");
+        var start = module.export("_start");
         start.apply();
 
         assertTrue(count.get() > 0);
@@ -150,14 +150,14 @@ public class ModuleTest {
     @Test
     public void shouldTrapOnUnreachable() {
         var instance = Module.builder("compiled/trap.wat.wasm").build().instantiate();
-        var start = instance.getExport("_start");
+        var start = instance.export("_start");
         assertThrows(WASMMachineException.class, start::apply);
     }
 
     @Test
     public void shouldSupportGlobals() {
         var instance = Module.builder("compiled/globals.wat.wasm").build().instantiate();
-        var doit = instance.getExport("doit");
+        var doit = instance.export("doit");
         var result = doit.apply(Value.i32(32))[0];
         assertEquals(42, result.asInt());
     }
@@ -165,10 +165,10 @@ public class ModuleTest {
     @Test
     public void shouldCountVowels() {
         var instance = Module.builder("compiled/count_vowels.rs.wasm").build().instantiate();
-        var alloc = instance.getExport("alloc");
-        var dealloc = instance.getExport("dealloc");
-        var countVowels = instance.getExport("count_vowels");
-        var memory = instance.getMemory();
+        var alloc = instance.export("alloc");
+        var dealloc = instance.export("dealloc");
+        var countVowels = instance.export("count_vowels");
+        var memory = instance.memory();
         var message = "Hello, World!";
         var len = message.getBytes().length;
         var ptr = alloc.apply(Value.i32(len))[0].asInt();
@@ -182,7 +182,7 @@ public class ModuleTest {
     public void shouldRunBasicCProgram() {
         // check with: wasmtime src/test/resources/wasm/basic.c.wasm --invoke run
         var instance = Module.builder("compiled/basic.c.wasm").build().instantiate();
-        var run = instance.getExport("run");
+        var run = instance.export("run");
         var result = run.apply()[0];
         assertEquals(42, result.asInt());
     }
@@ -210,7 +210,7 @@ public class ModuleTest {
     @Test
     public void shouldWorkWithMemoryOps() {
         var instance = Module.builder("compiled/memory.wat.wasm").build().instantiate();
-        var run = instance.getExport("run32");
+        var run = instance.export("run32");
         var results = run.apply(Value.i32(42));
         var result = results[0];
         assertEquals(42, result.asInt());
@@ -221,15 +221,15 @@ public class ModuleTest {
         result = run.apply(Value.i32(Integer.MIN_VALUE))[0];
         assertEquals(Integer.MIN_VALUE, result.asInt());
 
-        run = instance.getExport("run64");
+        run = instance.export("run64");
         result = run.apply(Value.i64(42))[0];
         assertEquals(42L, result.asLong());
 
-        run = instance.getExport("run64");
+        run = instance.export("run64");
         result = run.apply(Value.i64(Long.MIN_VALUE))[0];
         assertEquals(Long.MIN_VALUE, result.asLong());
 
-        run = instance.getExport("run64");
+        run = instance.export("run64");
         result = run.apply(Value.i64(Long.MAX_VALUE))[0];
         assertEquals(Long.MAX_VALUE, result.asLong());
     }
@@ -240,7 +240,7 @@ public class ModuleTest {
         // run 100
         var instance = Module.builder("compiled/kitchensink.wat.wasm").build().instantiate();
 
-        var run = instance.getExport("run");
+        var run = instance.export("run");
         assertEquals(6, run.apply(Value.i32(100))[0].asInt());
     }
 

--- a/runtime/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/runtime/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -42,15 +42,15 @@ public class TestModule {
         return this;
     }
 
-    public File getFile() {
+    public File file() {
         return file;
     }
 
-    public Module getModule() {
+    public Module module() {
         return module;
     }
 
-    public Instance getInstance() {
+    public Instance instance() {
         return instance;
     }
 }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/Action.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/Action.java
@@ -19,19 +19,19 @@ public class Action {
     @JsonProperty("args")
     private WasmValue[] args;
 
-    public ActionType getType() {
+    public ActionType type() {
         return type;
     }
 
-    public String getModule() {
+    public String module() {
         return module;
     }
 
-    public String getField() {
+    public String field() {
         return field;
     }
 
-    public WasmValue[] getArgs() {
+    public WasmValue[] args() {
         return args;
     }
 

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/ActionType.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/ActionType.java
@@ -16,7 +16,7 @@ public enum ActionType {
     }
 
     @JsonValue()
-    public String getValue() {
+    public String value() {
         return value;
     }
 }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/Command.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/Command.java
@@ -59,35 +59,35 @@ public class Command {
                 + '}';
     }
 
-    public CommandType getType() {
+    public CommandType type() {
         return type;
     }
 
-    public String getName() {
+    public String name() {
         return name;
     }
 
-    public int getLine() {
+    public int line() {
         return line;
     }
 
-    public String getFilename() {
+    public String filename() {
         return filename;
     }
 
-    public Action getAction() {
+    public Action action() {
         return action;
     }
 
-    public WasmValue[] getExpected() {
+    public WasmValue[] expected() {
         return expected;
     }
 
-    public String getText() {
+    public String text() {
         return text;
     }
 
-    public String getModuleType() {
+    public String moduleType() {
         return moduleType;
     }
 }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/CommandType.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/CommandType.java
@@ -32,7 +32,7 @@ public enum CommandType {
     }
 
     @JsonValue()
-    public String getValue() {
+    public String value() {
         return value;
     }
 }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/WasmValue.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/WasmValue.java
@@ -10,11 +10,11 @@ public class WasmValue {
     @JsonProperty("value")
     private String value;
 
-    public WasmValueType getType() {
+    public WasmValueType type() {
         return type;
     }
 
-    public String getValue() {
+    public String value() {
         return value;
     }
 
@@ -115,7 +115,7 @@ public class WasmValue {
         }
     }
 
-    public String getDelta() {
+    public String delta() {
         switch (type) {
             case F32:
             case F64:

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/WasmValueType.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/WasmValueType.java
@@ -24,7 +24,7 @@ public enum WasmValueType {
     }
 
     @JsonValue()
-    public String getValue() {
+    public String value() {
         return value;
     }
 }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/Wast.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/Wast.java
@@ -11,11 +11,11 @@ public class Wast {
     @JsonProperty("commands")
     private Command[] commands;
 
-    public File getSourceFilename() {
+    public File sourceFilename() {
         return sourceFilename;
     }
 
-    public Command[] getCommands() {
+    public Command[] commands() {
         return commands;
     }
 }

--- a/wasi/src/main/java/com/dylibso/chicory/runtime/wasi/WasiOptions.java
+++ b/wasi/src/main/java/com/dylibso/chicory/runtime/wasi/WasiOptions.java
@@ -18,15 +18,15 @@ public class WasiOptions {
         this.stdin = stdin;
     }
 
-    public PrintStream getStdout() {
+    public PrintStream stdout() {
         return stdout;
     }
 
-    public PrintStream getStderr() {
+    public PrintStream stderr() {
         return stderr;
     }
 
-    public InputStream getStdin() {
+    public InputStream stdin() {
         return stdin;
     }
 }

--- a/wasi/src/main/java/com/dylibso/chicory/runtime/wasi/WasiPreview1.java
+++ b/wasi/src/main/java/com/dylibso/chicory/runtime/wasi/WasiPreview1.java
@@ -325,7 +325,7 @@ public class WasiPreview1 {
                     InputStream stream;
                     switch (fd) {
                         case 0:
-                            stream = this.options.getStdin();
+                            stream = this.options.stdin();
                             break;
                         default:
                             throw new WASMRuntimeException("We don't yet support fd " + fd);
@@ -340,7 +340,7 @@ public class WasiPreview1 {
                     var iovsLen = args[2].asInt();
                     var retPtr = args[3].asInt();
                     var bytesRead = 0;
-                    Memory memory = instance.getMemory();
+                    Memory memory = instance.memory();
                     for (var i = 0; i < iovsLen; i++) {
                         var offset = i * 8;
                         var base = iovs + offset;
@@ -437,10 +437,10 @@ public class WasiPreview1 {
                     PrintStream stream;
                     switch (fd) {
                         case 1:
-                            stream = this.options.getStdout();
+                            stream = this.options.stdout();
                             break;
                         case 2:
-                            stream = this.options.getStderr();
+                            stream = this.options.stderr();
                             break;
                         default:
                             throw new WASMRuntimeException("We don't yet support fd " + fd);
@@ -455,7 +455,7 @@ public class WasiPreview1 {
                     var iovsLen = args[2].asInt();
                     var retPtr = args[3].asInt();
                     var bytesWritten = 0;
-                    Memory memory = instance.getMemory();
+                    Memory memory = instance.memory();
                     for (var i = 0; i < iovsLen; i++) {
                         var offset = i * 8;
                         var base = iovs + offset;

--- a/wasi/src/test/java/com/dylibso/chicory/runtime/MockPrintStream.java
+++ b/wasi/src/test/java/com/dylibso/chicory/runtime/MockPrintStream.java
@@ -16,7 +16,7 @@ class MockPrintStream extends PrintStream {
         super.println(s);
     }
 
-    public String getOutput() {
+    public String output() {
         return baos.toString();
     }
 }

--- a/wasi/src/test/java/com/dylibso/chicory/runtime/WasiPreview1Test.java
+++ b/wasi/src/test/java/com/dylibso/chicory/runtime/WasiPreview1Test.java
@@ -24,9 +24,9 @@ public class WasiPreview1Test {
                 Module.builder(new File("src/test/resources/compiled/hello-wasi.wat.wasm"))
                         .build()
                         .instantiate(imports);
-        var run = instance.getExport("_start");
+        var run = instance.export("_start");
         run.apply();
-        assertEquals(fakeStdout.getOutput().strip(), "hello world");
+        assertEquals(fakeStdout.output().strip(), "hello world");
     }
 
     @Test
@@ -40,9 +40,9 @@ public class WasiPreview1Test {
                 Module.builder(new File("src/test/resources/compiled/hello-wasi.rs.wasm"))
                         .build()
                         .instantiate(imports);
-        var run = instance.getExport("_start");
+        var run = instance.export("_start");
         run.apply(); // prints Hello, World!
-        assertEquals(expected, stdout.getOutput().strip());
+        assertEquals(expected, stdout.output().strip());
     }
 
     @Test
@@ -56,7 +56,7 @@ public class WasiPreview1Test {
                 Module.builder(new File("src/test/resources/compiled/greet-wasi.rs.wasm"))
                         .build()
                         .instantiate(imports);
-        var run = instance.getExport("_start");
+        var run = instance.export("_start");
         run.apply();
     }
 }

--- a/wasm-support-plugin/src/main/java/OpCodeGenMojo.java
+++ b/wasm-support-plugin/src/main/java/OpCodeGenMojo.java
@@ -126,7 +126,7 @@ public class OpCodeGenMojo extends AbstractMojo {
                                         new NameExpr("this.opcode"),
                                         new NameExpr("opcode"),
                                         AssignExpr.Operator.ASSIGN)));
-        opcodeField.createGetter();
+        opcodeField.createGetter().setName("opcode");
 
         var byOpCodeMap =
                 enumDef.addFieldWithInitializer(
@@ -165,8 +165,7 @@ public class OpCodeGenMojo extends AbstractMojo {
         // byOpCode initialization
         staticBlock.addStatement(
                 new NameExpr(
-                        "for (OpCode e: OpCode.values()) {"
-                                + " byOpCode.put(e.getOpcode(), e); }"));
+                        "for (OpCode e: OpCode.values()) {" + " byOpCode.put(e.opcode(), e); }"));
         for (var assign : staticAssignement) {
             staticBlock.addStatement(assign);
         }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/ControlTree.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/ControlTree.java
@@ -82,11 +82,11 @@ public class ControlTree {
         return this.parent == null;
     }
 
-    public Instruction getInstruction() {
+    public Instruction instruction() {
         return instruction;
     }
 
-    public int getInstructionNumber() {
+    public int instructionNumber() {
         return initialInstructionNumber;
     }
 
@@ -94,11 +94,11 @@ public class ControlTree {
         this.nested.add(nested);
     }
 
-    public ControlTree getParent() {
+    public ControlTree parent() {
         return parent;
     }
 
-    public List<ControlTree> getNested() {
+    public List<ControlTree> nested() {
         return nested;
     }
 
@@ -109,11 +109,11 @@ public class ControlTree {
     public void setFinalInstructionNumber(int finalInstructionNumber, Instruction end) {
         this.finalInstructionNumber = finalInstructionNumber;
 
-        if (end.getScope() == OpCode.LOOP) {
+        if (end.scope() == OpCode.LOOP) {
             var lastLoopInstruction = 0;
             for (var ct : this.parent.nested) {
-                if (ct.getInstruction().getOpcode() == OpCode.LOOP) {
-                    lastLoopInstruction = ct.getInstructionNumber();
+                if (ct.instruction().opcode() == OpCode.LOOP) {
+                    lastLoopInstruction = ct.instructionNumber();
                 }
             }
             this.finalInstructionNumber = lastLoopInstruction + 1;

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Module.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Module.java
@@ -48,23 +48,23 @@ public class Module {
         this.exportSection = exportSection;
     }
 
-    public TypeSection getTypeSection() {
+    public TypeSection typeSection() {
         return typeSection;
     }
 
-    public FunctionSection getFunctionSection() {
+    public FunctionSection functionSection() {
         return functionSection;
     }
 
-    public ExportSection getExportSection() {
+    public ExportSection exportSection() {
         return exportSection;
     }
 
-    public StartSection getStartSection() {
+    public StartSection startSection() {
         return startSection;
     }
 
-    public ImportSection getImportSection() {
+    public ImportSection importSection() {
         return importSection;
     }
 
@@ -76,7 +76,7 @@ public class Module {
         this.importSection = importSection;
     }
 
-    public CodeSection getCodeSection() {
+    public CodeSection codeSection() {
         return codeSection;
     }
 
@@ -88,11 +88,11 @@ public class Module {
         this.dataSection = dataSection;
     }
 
-    public DataSection getDataSection() {
+    public DataSection dataSection() {
         return dataSection;
     }
 
-    public MemorySection getMemorySection() {
+    public MemorySection memorySection() {
         return memorySection;
     }
 
@@ -100,7 +100,7 @@ public class Module {
         this.memorySection = memorySection;
     }
 
-    public GlobalSection getGlobalSection() {
+    public GlobalSection globalSection() {
         return globalSection;
     }
 
@@ -108,7 +108,7 @@ public class Module {
         this.globalSection = globalSection;
     }
 
-    public TableSection getTableSection() {
+    public TableSection tableSection() {
         return tableSection;
     }
 
@@ -117,24 +117,24 @@ public class Module {
     }
 
     public void addCustomSection(CustomSection customSection) {
-        this.customSections.put(customSection.getName(), customSection);
+        this.customSections.put(customSection.name(), customSection);
     }
 
-    public List<CustomSection> getCustomSections() {
+    public List<CustomSection> customSections() {
         return new ArrayList<>(customSections.values());
     }
 
-    public CustomSection getCustomSection(String name) {
+    public CustomSection customSection(String name) {
         return customSections.get(name);
     }
 
-    public NameSection getNameSection() {
+    public NameSection nameSection() {
         var customSec = customSections.get("name");
         if (customSec == null) return null;
         return new NameSection(customSec);
     }
 
-    public ElementSection getElementSection() {
+    public ElementSection elementSection() {
         return elementSection;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ActiveDataSegment.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ActiveDataSegment.java
@@ -14,11 +14,11 @@ public class ActiveDataSegment extends DataSegment {
         this.offset = offset;
     }
 
-    public long getIdx() {
+    public long index() {
         return idx;
     }
 
-    public Instruction[] getOffset() {
+    public Instruction[] offsetInstructions() {
         return offset;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Ast.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Ast.java
@@ -14,13 +14,13 @@ public class Ast {
         this.stack.push(root);
     }
 
-    public CodeBlock getRoot() {
+    public CodeBlock root() {
         return root;
     }
 
     public void addInstruction(Instruction i) {
         var current = peek();
-        switch (i.getOpcode()) {
+        switch (i.opcode()) {
             case BLOCK:
                 {
                     current.addInstruction(i);
@@ -68,16 +68,16 @@ public class Ast {
     }
 
     private void printAst(StringBuilder sb, CodeBlock block, int depth) {
-        for (var i : block.getInstructions()) {
+        for (var i : block.instructions()) {
             sb.append("0x");
-            sb.append(Integer.toHexString(i.getAddress()));
+            sb.append(Integer.toHexString(i.address()));
             sb.append(" | ");
             sb.append("\t".repeat(depth));
             sb.append(i);
             sb.append("\n");
 
-            if (i.getCodeBlock() != null) {
-                printAst(sb, i.getCodeBlock(), depth + 1);
+            if (i.codeBlock() != null) {
+                printAst(sb, i.codeBlock(), depth + 1);
             }
         }
     }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeBlock.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeBlock.java
@@ -16,7 +16,7 @@ public class CodeBlock {
         this.instructions.add(i);
     }
 
-    public List<Instruction> getInstructions() {
+    public List<Instruction> instructions() {
         return instructions;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeSection.java
@@ -8,7 +8,7 @@ public class CodeSection extends Section {
         this.functionBodies = functionBodies;
     }
 
-    public FunctionBody[] getFunctionBodies() {
+    public FunctionBody[] functionBodies() {
         return functionBodies;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/CustomSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/CustomSection.java
@@ -9,7 +9,7 @@ public class CustomSection extends Section {
         super(id, size);
     }
 
-    public String getName() {
+    public String name() {
         return name;
     }
 
@@ -17,7 +17,7 @@ public class CustomSection extends Section {
         this.name = name;
     }
 
-    public byte[] getBytes() {
+    public byte[] bytes() {
         return bytes;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSection.java
@@ -8,7 +8,7 @@ public class DataSection extends Section {
         this.dataSegments = dataSegments;
     }
 
-    public DataSegment[] getDataSegments() {
+    public DataSegment[] dataSegments() {
         return dataSegments;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSegment.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSegment.java
@@ -7,7 +7,7 @@ public class DataSegment {
         this.data = data;
     }
 
-    public byte[] getData() {
+    public byte[] data() {
         return data;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemData.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemData.java
@@ -2,7 +2,7 @@ package com.dylibso.chicory.wasm.types;
 
 public class ElemData implements Element {
     @Override
-    public ElemType getElemType() {
+    public ElemType elemType() {
         return ElemType.Data;
     }
 
@@ -18,7 +18,7 @@ public class ElemData implements Element {
         this.exprs = exprs;
     }
 
-    public long getTableIndex() {
+    public long tableIndex() {
         return tableIndex;
     }
 
@@ -26,15 +26,15 @@ public class ElemData implements Element {
         this.tableIndex = tableIndex;
     }
 
-    public Instruction[] getExpr() {
+    public Instruction[] exprInstructions() {
         return expr;
     }
 
-    public void setExpr(Instruction[] expr) {
+    public void setExprInstructions(Instruction[] expr) {
         this.expr = expr;
     }
 
-    public RefType getRefType() {
+    public RefType refType() {
         return refType;
     }
 
@@ -42,15 +42,15 @@ public class ElemData implements Element {
         this.refType = refType;
     }
 
-    public Instruction[][] getExprs() {
+    public Instruction[][] exprInstructionLists() {
         return exprs;
     }
 
-    public void setExprs(Instruction[][] exprs) {
+    public void setExprInstructionLists(Instruction[][] exprs) {
         this.exprs = exprs;
     }
 
-    public int getSize() {
+    public int size() {
         return exprs.length;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemElem.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemElem.java
@@ -2,7 +2,7 @@ package com.dylibso.chicory.wasm.types;
 
 public class ElemElem implements Element {
     @Override
-    public ElemType getElemType() {
+    public ElemType elemType() {
         return ElemType.Elem;
     }
 
@@ -14,7 +14,7 @@ public class ElemElem implements Element {
         this.exprs = exprs;
     }
 
-    public RefType getRefType() {
+    public RefType refType() {
         return refType;
     }
 
@@ -22,7 +22,7 @@ public class ElemElem implements Element {
         this.refType = refType;
     }
 
-    public Instruction[][] getExprs() {
+    public Instruction[][] exprs() {
         return exprs;
     }
 
@@ -30,7 +30,7 @@ public class ElemElem implements Element {
         this.exprs = exprs;
     }
 
-    public int getSize() {
+    public int size() {
         return exprs.length;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemFunc.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemFunc.java
@@ -2,7 +2,7 @@ package com.dylibso.chicory.wasm.types;
 
 public class ElemFunc implements Element {
     @Override
-    public ElemType getElemType() {
+    public ElemType elemType() {
         return ElemType.Func;
     }
 
@@ -12,7 +12,7 @@ public class ElemFunc implements Element {
         this.funcIndices = funcIndices;
     }
 
-    public long[] getFuncIndices() {
+    public long[] funcIndices() {
         return funcIndices;
     }
 
@@ -20,7 +20,7 @@ public class ElemFunc implements Element {
         this.funcIndices = funcIndices;
     }
 
-    public int getSize() {
+    public int size() {
         return funcIndices.length;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemGlobal.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemGlobal.java
@@ -2,7 +2,7 @@ package com.dylibso.chicory.wasm.types;
 
 public class ElemGlobal implements Element {
     @Override
-    public ElemType getElemType() {
+    public ElemType elemType() {
         return ElemType.Global;
     }
 
@@ -14,23 +14,23 @@ public class ElemGlobal implements Element {
         this.exprs = exprs;
     }
 
-    public Instruction[] getExpr() {
+    public Instruction[] exprInstructions() {
         return expr;
     }
 
-    public void setExpr(Instruction[] expr) {
+    public void setExprInstructions(Instruction[] expr) {
         this.expr = expr;
     }
 
-    public Instruction[][] getExprs() {
+    public Instruction[][] exprInstructionLists() {
         return exprs;
     }
 
-    public void setExprs(Instruction[][] exprs) {
+    public void setExprInstructionLists(Instruction[][] exprs) {
         this.exprs = exprs;
     }
 
-    public int getSize() {
+    public int size() {
         return exprs.length;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemMem.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemMem.java
@@ -2,7 +2,7 @@ package com.dylibso.chicory.wasm.types;
 
 public class ElemMem implements Element {
     @Override
-    public ElemType getElemType() {
+    public ElemType elemType() {
         return ElemType.Mem;
     }
 
@@ -12,7 +12,7 @@ public class ElemMem implements Element {
         this.funcIndices = funcIndices;
     }
 
-    public int getSize() {
+    public int size() {
         return funcIndices.length;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemStart.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemStart.java
@@ -2,7 +2,7 @@ package com.dylibso.chicory.wasm.types;
 
 public class ElemStart implements Element {
     @Override
-    public ElemType getElemType() {
+    public ElemType elemType() {
         return ElemType.Start;
     }
 
@@ -14,7 +14,7 @@ public class ElemStart implements Element {
         this.exprs = exprs;
     }
 
-    public RefType getRefType() {
+    public RefType refType() {
         return refType;
     }
 
@@ -22,15 +22,15 @@ public class ElemStart implements Element {
         this.refType = refType;
     }
 
-    public Instruction[][] getExprs() {
+    public Instruction[][] exprInstructionLists() {
         return exprs;
     }
 
-    public void setExprs(Instruction[][] exprs) {
+    public void setExprInstructionLists(Instruction[][] exprs) {
         this.exprs = exprs;
     }
 
-    public int getSize() {
+    public int size() {
         return exprs.length;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemTable.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemTable.java
@@ -2,7 +2,7 @@ package com.dylibso.chicory.wasm.types;
 
 public class ElemTable implements Element {
     @Override
-    public ElemType getElemType() {
+    public ElemType elemType() {
         return ElemType.Table;
     }
 
@@ -16,19 +16,19 @@ public class ElemTable implements Element {
         this.funcIndices = funcIndices;
     }
 
-    public long[] getFuncIndices() {
+    public long[] funcIndices() {
         return funcIndices;
     }
 
-    public Instruction[] getExpr() {
+    public Instruction[] exprInstructions() {
         return expr;
     }
 
-    public long getTableIndex() {
+    public long tableIndex() {
         return tableIndex;
     }
 
-    public int getSize() {
+    public int size() {
         return expr.length;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElemType.java
@@ -2,7 +2,7 @@ package com.dylibso.chicory.wasm.types;
 
 public class ElemType implements Element {
     @Override
-    public ElemType getElemType() {
+    public ElemType elemType() {
         return ElemType.Type;
     }
 
@@ -14,15 +14,15 @@ public class ElemType implements Element {
         this.funcIndices = funcIndices;
     }
 
-    public long[] getFuncIndices() {
+    public long[] funcIndices() {
         return funcIndices;
     }
 
-    public Instruction[] getExpr() {
+    public Instruction[] exprInstructions() {
         return expr;
     }
 
-    public int getSize() {
+    public int size() {
         return expr.length;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Element.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Element.java
@@ -2,9 +2,9 @@ package com.dylibso.chicory.wasm.types;
 
 public interface Element {
 
-    ElemType getElemType();
+    ElemType elemType();
 
-    int getSize();
+    int size();
 
     enum ElemType {
         Type(0),

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElementSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElementSection.java
@@ -8,7 +8,7 @@ public class ElementSection extends Section {
         this.elements = elements;
     }
 
-    public Element[] getElements() {
+    public Element[] elements() {
         return elements;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Export.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Export.java
@@ -9,11 +9,11 @@ public class Export {
         this.desc = desc;
     }
 
-    public String getName() {
+    public String name() {
         return name;
     }
 
-    public ExportDesc getDesc() {
+    public ExportDesc desc() {
         return desc;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ExportDesc.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ExportDesc.java
@@ -9,11 +9,11 @@ public class ExportDesc {
         this.type = type;
     }
 
-    public long getIndex() {
+    public long index() {
         return index;
     }
 
-    public ExportDescType getType() {
+    public ExportDescType type() {
         return type;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ExportSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ExportSection.java
@@ -8,7 +8,7 @@ public class ExportSection extends Section {
         this.exports = exports;
     }
 
-    public Export[] getExports() {
+    public Export[] exports() {
         return exports;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionBody.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionBody.java
@@ -11,15 +11,15 @@ public class FunctionBody {
         this.instructions = instructions;
     }
 
-    public List<Value> getLocals() {
+    public List<Value> locals() {
         return locals;
     }
 
-    public List<Instruction> getInstructions() {
+    public List<Instruction> instructions() {
         return instructions;
     }
 
-    public Ast getAst() {
+    public Ast ast() {
         var ast = new Ast();
         for (var i : instructions) {
             ast.addInstruction(i);

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionSection.java
@@ -8,7 +8,7 @@ public class FunctionSection extends Section {
         this.typeIndices = typeIndices;
     }
 
-    public int[] getTypeIndices() {
+    public int[] typeIndices() {
         return typeIndices;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionType.java
@@ -11,11 +11,11 @@ public class FunctionType {
         this.returns = returns;
     }
 
-    public ValueType[] getParams() {
+    public ValueType[] params() {
         return params;
     }
 
-    public ValueType[] getReturns() {
+    public ValueType[] returns() {
         return returns;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Global.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Global.java
@@ -11,15 +11,15 @@ public class Global {
         this.init = init;
     }
 
-    public MutabilityType getMutabilityType() {
+    public MutabilityType mutabilityType() {
         return mutabilityType;
     }
 
-    public ValueType getValueType() {
+    public ValueType valueType() {
         return valueType;
     }
 
-    public Instruction[] getInit() {
+    public Instruction[] initInstructions() {
         return init;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalSection.java
@@ -8,7 +8,7 @@ public class GlobalSection extends Section {
         this.globals = globals;
     }
 
-    public Global[] getGlobals() {
+    public Global[] globals() {
         return globals;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Import.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Import.java
@@ -11,15 +11,15 @@ public class Import {
         this.desc = desc;
     }
 
-    public String getModuleName() {
+    public String moduleName() {
         return moduleName;
     }
 
-    public String getFieldName() {
+    public String fieldName() {
         return fieldName;
     }
 
-    public ImportDesc getDesc() {
+    public ImportDesc desc() {
         return desc;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ImportDesc.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ImportDesc.java
@@ -31,11 +31,11 @@ public class ImportDesc {
         this.valType = valType;
     }
 
-    public long getIndex() {
+    public long index() {
         return index;
     }
 
-    public ImportDescType getType() {
+    public ImportDescType type() {
         return type;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ImportSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ImportSection.java
@@ -8,7 +8,7 @@ public class ImportSection extends Section {
         this.imports = imports;
     }
 
-    public Import[] getImports() {
+    public Import[] imports() {
         return imports;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Instruction.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Instruction.java
@@ -21,11 +21,11 @@ public class Instruction {
         this.operands = operands;
     }
 
-    public OpCode getOpcode() {
+    public OpCode opcode() {
         return opcode;
     }
 
-    public long[] getOperands() {
+    public long[] operands() {
         return operands;
     }
 
@@ -33,7 +33,7 @@ public class Instruction {
         this.block = block;
     }
 
-    public CodeBlock getCodeBlock() {
+    public CodeBlock codeBlock() {
         return block;
     }
 
@@ -45,11 +45,11 @@ public class Instruction {
         return result + opcode.toString();
     }
 
-    public int getAddress() {
+    public int address() {
         return address;
     }
 
-    public Integer getLabelTrue() {
+    public Integer labelTrue() {
         return labelTrue;
     }
 
@@ -57,7 +57,7 @@ public class Instruction {
         this.labelTrue = labelTrue;
     }
 
-    public Integer getLabelFalse() {
+    public Integer labelFalse() {
         return labelFalse;
     }
 
@@ -65,7 +65,7 @@ public class Instruction {
         this.labelFalse = labelFalse;
     }
 
-    public int[] getLabelTable() {
+    public int[] labelTable() {
         return labelTable;
     }
 
@@ -73,7 +73,7 @@ public class Instruction {
         this.labelTable = labelTable;
     }
 
-    public Integer getDepth() {
+    public Integer depth() {
         return depth;
     }
 
@@ -81,7 +81,7 @@ public class Instruction {
         this.depth = depth;
     }
 
-    public OpCode getScope() {
+    public OpCode scope() {
         return scope;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Limits.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Limits.java
@@ -9,11 +9,11 @@ public class Limits {
         this.max = max;
     }
 
-    public int getMin() {
+    public int min() {
         return min;
     }
 
-    public int getMax() {
+    public int max() {
         return max;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Memory.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Memory.java
@@ -7,7 +7,7 @@ public class Memory {
         this.memoryLimits = memoryLimits;
     }
 
-    public MemoryLimits getMemoryLimits() {
+    public MemoryLimits memoryLimits() {
         return memoryLimits;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/MemoryLimits.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/MemoryLimits.java
@@ -43,11 +43,11 @@ public class MemoryLimits {
         return new MemoryLimits(0, MAX_PAGES);
     }
 
-    public int getInitial() {
+    public int initialPages() {
         return initial;
     }
 
-    public int getMaximum() {
+    public int maximumPages() {
         return maximum;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/MemorySection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/MemorySection.java
@@ -8,7 +8,7 @@ public class MemorySection extends Section {
         this.memories = memories;
     }
 
-    public Memory[] getMemories() {
+    public Memory[] memories() {
         return memories;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameSection.java
@@ -11,13 +11,13 @@ public class NameSection extends CustomSection {
     private final List<String> funcNames;
 
     public NameSection(CustomSection sec) {
-        super(sec.getSectionId(), sec.getSectionSize());
-        this.setBytes(sec.getBytes());
+        super(sec.sectionId(), sec.sectionSize());
+        this.setBytes(sec.bytes());
         this.funcNames = parseFunctionNames();
     }
 
     private List<String> parseFunctionNames() {
-        ByteBuffer buf = ByteBuffer.wrap(this.getBytes());
+        ByteBuffer buf = ByteBuffer.wrap(this.bytes());
 
         List<String> names = new ArrayList<>();
 
@@ -41,7 +41,7 @@ public class NameSection extends CustomSection {
         return Collections.unmodifiableList(names);
     }
 
-    public List<String> getFunctionNames() {
+    public List<String> functionNames() {
         return funcNames;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Section.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Section.java
@@ -9,11 +9,11 @@ public class Section {
         this.size = size;
     }
 
-    public int getSectionId() {
+    public int sectionId() {
         return id;
     }
 
-    public long getSectionSize() {
+    public long sectionSize() {
         return size;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/StartSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/StartSection.java
@@ -7,7 +7,7 @@ public class StartSection extends Section {
         super(id, size);
     }
 
-    public long getStartIndex() {
+    public long startIndex() {
         return startIndex;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Table.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Table.java
@@ -24,19 +24,19 @@ public class Table {
         }
     }
 
-    public ElementType getElementType() {
+    public ElementType elementType() {
         return elementType;
     }
 
-    public long getLimitMin() {
+    public long limitMin() {
         return limitMin;
     }
 
-    public Long getLimitMax() {
+    public Long limitMax() {
         return limitMax;
     }
 
-    public int getSize() {
+    public int size() {
         return refs.length;
     }
 
@@ -52,14 +52,14 @@ public class Table {
         return oldSize;
     }
 
-    public Value getRef(int index) {
+    public Value ref(int index) {
         int res = REF_NULL_VALUE;
         try {
             res = this.refs[index];
         } catch (IndexOutOfBoundsException e) {
             throw new ChicoryException("undefined element", e);
         }
-        if (this.getElementType() == ElementType.FuncRef) {
+        if (this.elementType() == ElementType.FuncRef) {
             return Value.funcRef(res);
         } else {
             return Value.externRef(res);

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableSection.java
@@ -8,7 +8,7 @@ public class TableSection extends Section {
         this.tables = tables;
     }
 
-    public Table[] getTables() {
+    public Table[] tables() {
         return tables;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TypeSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TypeSection.java
@@ -8,7 +8,7 @@ public class TypeSection extends Section {
         this.types = types;
     }
 
-    public FunctionType[] getTypes() {
+    public FunctionType[] types() {
         return types;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -158,11 +158,11 @@ public class Value {
         return Double.longBitsToDouble(asLong());
     }
 
-    public ValueType getType() {
+    public ValueType type() {
         return this.type;
     }
 
-    public byte[] getData() {
+    public byte[] data() {
         switch (this.type) {
             case I64:
             case F64:

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
@@ -34,34 +34,34 @@ public class ParserTest {
             var module = parser.parseModule(is);
 
             // check types section
-            var typeSection = module.getTypeSection();
-            var types = typeSection.getTypes();
+            var typeSection = module.typeSection();
+            var types = typeSection.types();
             assertEquals(2, types.length);
             assertEquals("(I32) -> nil", types[0].toString());
             assertEquals("() -> nil", types[1].toString());
 
             // check import section
-            var importSection = module.getImportSection();
-            var imports = importSection.getImports();
+            var importSection = module.importSection();
+            var imports = importSection.imports();
             assertEquals(1, imports.length);
             assertEquals("func[] <env.gotit>", imports[0].toString());
 
             // check data section
-            var dataSection = module.getDataSection();
-            var dataSegments = dataSection.getDataSegments();
+            var dataSection = module.dataSection();
+            var dataSegments = dataSection.dataSegments();
             assertEquals(1, dataSegments.length);
             var segment = (ActiveDataSegment) dataSegments[0];
-            assertEquals(0, segment.getIdx());
-            assertEquals(OpCode.I32_CONST, segment.getOffset()[0].getOpcode());
-            assertArrayEquals(new byte[] {0x00, 0x01, 0x02, 0x03}, segment.getData());
+            assertEquals(0, segment.index());
+            assertEquals(OpCode.I32_CONST, segment.offsetInstructions()[0].opcode());
+            assertArrayEquals(new byte[] {0x00, 0x01, 0x02, 0x03}, segment.data());
 
             // check start section
-            var startSection = module.getStartSection();
-            assertEquals(1, startSection.getStartIndex());
+            var startSection = module.startSection();
+            assertEquals(1, startSection.startIndex());
 
             // check function section
-            var funcSection = module.getFunctionSection();
-            var typeIndices = funcSection.getTypeIndices();
+            var funcSection = module.functionSection();
+            var typeIndices = funcSection.typeIndices();
             assertEquals(1, typeIndices.length);
             assertEquals(1L, (long) typeIndices[0]);
 
@@ -71,27 +71,27 @@ public class ParserTest {
             //        assertEquals(1, exports.size());
 
             // check memory section
-            var memorySection = module.getMemorySection();
-            var memories = memorySection.getMemories();
+            var memorySection = module.memorySection();
+            var memories = memorySection.memories();
             assertEquals(1, memories.length);
-            assertEquals(1, memories[0].getMemoryLimits().getInitial());
-            assertEquals(65536, memories[0].getMemoryLimits().getMaximum());
+            assertEquals(1, memories[0].memoryLimits().initialPages());
+            assertEquals(65536, memories[0].memoryLimits().maximumPages());
 
-            var codeSection = module.getCodeSection();
-            var functionBodies = codeSection.getFunctionBodies();
+            var codeSection = module.codeSection();
+            var functionBodies = codeSection.functionBodies();
             assertEquals(1, functionBodies.length);
             var func = functionBodies[0];
-            var locals = func.getLocals();
+            var locals = func.locals();
             assertEquals(0, locals.size());
-            var instructions = func.getInstructions();
+            var instructions = func.instructions();
             assertEquals(3, instructions.size());
 
             assertEquals("0x00000032: I32_CONST [42]", instructions.get(0).toString());
-            assertEquals(OpCode.I32_CONST, instructions.get(0).getOpcode());
-            assertEquals(42L, (long) instructions.get(0).getOperands()[0]);
-            assertEquals(OpCode.CALL, instructions.get(1).getOpcode());
-            assertEquals(0L, (long) instructions.get(1).getOperands()[0]);
-            assertEquals(OpCode.END, instructions.get(2).getOpcode());
+            assertEquals(OpCode.I32_CONST, instructions.get(0).opcode());
+            assertEquals(42L, (long) instructions.get(0).operands()[0]);
+            assertEquals(OpCode.CALL, instructions.get(1).opcode());
+            assertEquals(0L, (long) instructions.get(1).operands()[0]);
+            assertEquals(OpCode.END, instructions.get(2).opcode());
         }
     }
 
@@ -104,25 +104,25 @@ public class ParserTest {
             var module = parser.parseModule(is);
 
             // check types section
-            var typeSection = module.getTypeSection();
-            var types = typeSection.getTypes();
+            var typeSection = module.typeSection();
+            var types = typeSection.types();
             assertEquals(1, types.length);
             assertEquals("(I32) -> I32", types[0].toString());
 
             // check function section
-            var funcSection = module.getFunctionSection();
-            var typeIndices = funcSection.getTypeIndices();
+            var funcSection = module.functionSection();
+            var typeIndices = funcSection.typeIndices();
             assertEquals(1, typeIndices.length);
             assertEquals(0L, (long) typeIndices[0]);
 
-            var codeSection = module.getCodeSection();
-            var functionBodies = codeSection.getFunctionBodies();
+            var codeSection = module.codeSection();
+            var functionBodies = codeSection.functionBodies();
             assertEquals(1, functionBodies.length);
             var func = functionBodies[0];
-            var locals = func.getLocals();
+            var locals = func.locals();
             assertEquals(1, locals.size());
             assertEquals(1, locals.get(0).asInt());
-            var instructions = func.getInstructions();
+            var instructions = func.instructions();
             assertEquals(22, instructions.size());
         }
     }
@@ -167,12 +167,12 @@ public class ParserTest {
             parser.parse(
                     is,
                     s -> {
-                        if (s.getSectionId() == SectionId.CUSTOM) {
+                        if (s.sectionId() == SectionId.CUSTOM) {
                             var customSection = (CustomSection) s;
-                            var name = customSection.getName();
+                            var name = customSection.name();
                             assertFalse(name.isEmpty());
                         } else {
-                            fail("Should not have received section with id: " + s.getSectionId());
+                            fail("Should not have received section with id: " + s.sectionId());
                         }
                     });
         }
@@ -195,11 +195,11 @@ public class ParserTest {
 
         try (InputStream is = getClass().getResourceAsStream("/compiled/float.wat.wasm")) {
             var module = parser.parseModule(is);
-            var codeSection = module.getCodeSection();
-            var fbody = codeSection.getFunctionBodies()[0];
-            var f32 = Float.intBitsToFloat((int) fbody.getInstructions().get(0).getOperands()[0]);
+            var codeSection = module.codeSection();
+            var fbody = codeSection.functionBodies()[0];
+            var f32 = Float.intBitsToFloat((int) fbody.instructions().get(0).operands()[0]);
             assertEquals(0.12345678f, f32, 0.0);
-            var f64 = Double.longBitsToDouble(fbody.getInstructions().get(1).getOperands()[0]);
+            var f64 = Double.longBitsToDouble(fbody.instructions().get(1).operands()[0]);
             assertEquals(0.123456789012345d, f64, 0.0);
         }
     }
@@ -211,22 +211,22 @@ public class ParserTest {
 
         try (InputStream is = getClass().getResourceAsStream("/compiled/i32.wat.wasm")) {
             var module = parser.parseModule(is);
-            var codeSection = module.getCodeSection();
-            var fbody = codeSection.getFunctionBodies()[0];
-            assertEquals(-2147483648L, fbody.getInstructions().get(0).getOperands()[0]);
-            assertEquals(0L, fbody.getInstructions().get(2).getOperands()[0]);
-            assertEquals(2147483647L, fbody.getInstructions().get(4).getOperands()[0]);
-            assertEquals(-9223372036854775808L, fbody.getInstructions().get(6).getOperands()[0]);
-            assertEquals(0L, fbody.getInstructions().get(8).getOperands()[0]);
-            assertEquals(9223372036854775807L, fbody.getInstructions().get(10).getOperands()[0]);
-            assertEquals(-2147483647L, fbody.getInstructions().get(12).getOperands()[0]);
-            assertEquals(2147483646L, fbody.getInstructions().get(14).getOperands()[0]);
-            assertEquals(-9223372036854775807L, fbody.getInstructions().get(16).getOperands()[0]);
-            assertEquals(9223372036854775806L, fbody.getInstructions().get(18).getOperands()[0]);
-            assertEquals(-1L, fbody.getInstructions().get(20).getOperands()[0]);
-            assertEquals(1L, fbody.getInstructions().get(22).getOperands()[0]);
-            assertEquals(-1L, fbody.getInstructions().get(24).getOperands()[0]);
-            assertEquals(1L, fbody.getInstructions().get(26).getOperands()[0]);
+            var codeSection = module.codeSection();
+            var fbody = codeSection.functionBodies()[0];
+            assertEquals(-2147483648L, fbody.instructions().get(0).operands()[0]);
+            assertEquals(0L, fbody.instructions().get(2).operands()[0]);
+            assertEquals(2147483647L, fbody.instructions().get(4).operands()[0]);
+            assertEquals(-9223372036854775808L, fbody.instructions().get(6).operands()[0]);
+            assertEquals(0L, fbody.instructions().get(8).operands()[0]);
+            assertEquals(9223372036854775807L, fbody.instructions().get(10).operands()[0]);
+            assertEquals(-2147483647L, fbody.instructions().get(12).operands()[0]);
+            assertEquals(2147483646L, fbody.instructions().get(14).operands()[0]);
+            assertEquals(-9223372036854775807L, fbody.instructions().get(16).operands()[0]);
+            assertEquals(9223372036854775806L, fbody.instructions().get(18).operands()[0]);
+            assertEquals(-1L, fbody.instructions().get(20).operands()[0]);
+            assertEquals(1L, fbody.instructions().get(22).operands()[0]);
+            assertEquals(-1L, fbody.instructions().get(24).operands()[0]);
+            assertEquals(1L, fbody.instructions().get(26).operands()[0]);
         }
     }
 
@@ -237,10 +237,10 @@ public class ParserTest {
 
         try (InputStream is = getClass().getResourceAsStream("/compiled/define-locals.wat.wasm")) {
             var module = parser.parseModule(is);
-            var codeSection = module.getCodeSection();
-            var fbody = codeSection.getFunctionBodies()[0];
-            assertEquals(fbody.getLocals().get(0).getType(), ValueType.I32);
-            assertEquals(fbody.getLocals().get(1).getType(), ValueType.I64);
+            var codeSection = module.codeSection();
+            var fbody = codeSection.functionBodies()[0];
+            assertEquals(fbody.locals().get(0).type(), ValueType.I32);
+            assertEquals(fbody.locals().get(1).type(), ValueType.I64);
         }
     }
 
@@ -251,8 +251,8 @@ public class ParserTest {
 
         try (InputStream is = getClass().getResourceAsStream("/compiled/count_vowels.rs.wasm")) {
             var module = parser.parseModule(is);
-            var nameSec = module.getNameSection();
-            assertEquals(125, nameSec.getFunctionNames().size());
+            var nameSec = module.nameSection();
+            assertEquals(125, nameSec.functionNames().size());
         }
     }
 }

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/types/MemoryLimitsTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/types/MemoryLimitsTest.java
@@ -12,8 +12,8 @@ class MemoryLimitsTest {
     public void shouldCreateDefaultMemoryLimits() {
         MemoryLimits defaults = MemoryLimits.defaultLimits();
         assertNotNull(defaults);
-        assertEquals(0, defaults.getInitial());
-        assertEquals(MemoryLimits.MAX_PAGES, defaults.getMaximum());
+        assertEquals(0, defaults.initialPages());
+        assertEquals(MemoryLimits.MAX_PAGES, defaults.maximumPages());
     }
 
     @Test

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/types/ValueTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/types/ValueTest.java
@@ -28,11 +28,11 @@ public class ValueTest {
         var f32Ref = 0.12345678f;
         var f32 = Value.f32(1039980265L);
         assertEquals(f32Ref, f32.asFloat(), 0.0);
-        assertArrayEquals(f32.getData(), Value.fromFloat(f32Ref).getData());
+        assertArrayEquals(f32.data(), Value.fromFloat(f32Ref).data());
         var f64Ref = 0.123456789012345d;
         var f64 = Value.f64(4593560419847042606L);
         assertEquals(f64Ref, f64.asDouble(), 0.0);
-        assertArrayEquals(f64.getData(), Value.fromDouble(f64Ref).getData());
+        assertArrayEquals(f64.data(), Value.fromDouble(f64Ref).data());
     }
 
     @Test


### PR DESCRIPTION
Modern Java is moving towards the idiom of using `xxx()` rather than `getXxx()` for getters. Setters are not migrating as aggressively, so leave them for now.