### PR TITLE
Update Readme and cleanups

### DIFF
--- a/log/README.md
+++ b/log/README.md
@@ -1,0 +1,3 @@
+# log
+
+Library to abstract over the used logger.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,0 +1,3 @@
+# runtime
+
+The actual Chicory Wasm runtime.

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -95,7 +95,6 @@
             table_grow.wast,
             table_size.wast,
             ref_func.wast,
-            call_indirect.wast,
             store.wast,
             ref_is_null.wast</orderedWastToProcess>
           <excludedTests>

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
@@ -440,46 +440,6 @@ public class Module {
     }
 
     /**
-     * Use {@link #builder(File)}
-     *
-     * @deprecated
-     */
-    @Deprecated
-    public static Module build(File wasmFile) {
-        return builder(wasmFile).build();
-    }
-
-    /**
-     * Use {@link #builder(InputStream)}
-     *
-     * @deprecated
-     */
-    @Deprecated
-    public static Module build(InputStream is) {
-        return builder(is).build();
-    }
-
-    /**
-     * Use {@link #builder(ByteBuffer)}
-     *
-     * @deprecated
-     */
-    @Deprecated
-    public static Module build(ByteBuffer buffer) {
-        return builder(buffer).build();
-    }
-
-    /**
-     * Use {@link #builder(File)}
-     *
-     * @deprecated
-     */
-    @Deprecated
-    public static Module build(File wasmFile, ModuleType type) {
-        return builder(wasmFile).withType(type).build();
-    }
-
-    /**
      * Creates a {@link Builder} for the specified {@link InputStream}
      *
      * @param input the input stream

--- a/test-gen-plugin/README.md
+++ b/test-gen-plugin/README.md
@@ -1,0 +1,5 @@
+# test-gen-plugin
+
+<internal-usage-only>
+
+A maven plugin that handles the test generation that exercises both the wasm package and the runtime package. Tests are parsed from the [Wasm testsuite](https://github.com/WebAssembly/testsuite) and generate Java JUnit tests.

--- a/wasm-support-plugin/README.md
+++ b/wasm-support-plugin/README.md
@@ -1,0 +1,5 @@
+# wasm-support-plugin
+
+<internal-usage-only>
+
+A maven plugin that handles the generation of OpCode definitions from an agnostic `tsv` file.

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,4 +1,4 @@
-# wasmparser
+# wasm
 
 This is a pure Java library that can parse Wasm binaries. This is in alpha at the moment.
 We are working on coverage of the spec, tests, and the API may change. When things get settled
@@ -10,10 +10,14 @@ There are two ways you can interface with this library. The simplest way is to p
 module using `parseModule`:
 
 ```java
-var parser = new Parser("/tmp/code.wasm");
-var module = parser.parseModule();
-var customSection = module.getCustomSections()[0];
-System.out.println("First custom section: " + customSection.getName());
+var parser = new Parser(new SystemLogger());
+try (var fis = new FileInputStream("/tmp/code.wasm")) {
+    var module = parser.parseModule(fis);
+    var customSection = module.customSections().get(0);
+    System.out.println("First custom section: " + customSection.getName());
+} catch (Exception e) {
+    throw new RuntimeException(e);
+};
 ```
 
 The second is to use the `ParserListener` interface and the `parse()` method. In this mode you can also call
@@ -22,7 +26,7 @@ sections. This is useful for performance if you only want to parse a piece of th
 If you don't call this method once it will parse all sections.
 
 ```java
-var parser = new Parser("/tmp/code.wasm");
+var parser = new Parser(new SystemLogger());
 
 // include the custom sections, don't call this to receive all sections
 parser.includeSection(SectionId.CUSTOM);
@@ -39,6 +43,10 @@ parser.setListener(section -> {
     }
 });
 
-// call parse() instead of parseModule()
-parser.parse();
+// call parseModule()
+try (var fis = new FileInputStream("/tmp/code.wasm")) {
+    parser.parseModule(fis);
+} catch (Exception e) {
+    throw new RuntimeException(e);
+};
 ```


### PR DESCRIPTION
Updated the docs to comply with the recent awesome changes by @lburgazzoli and @dmlloyd .
Removed the description of the modules as it gets outdated really quickly in favor of Readme files in the sub-folders.
Also removed `Deprecated` methods, we are in `0.0.X` and we don't need to respect compatibility at this point in time.