### PR TITLE
Make `Machine` non-public

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -19,7 +19,7 @@ import java.util.List;
 /**
  * This is responsible for holding and interpreting the Wasm code.
  */
-public class Machine {
+class Machine {
 
     private final MStack stack;
 


### PR DESCRIPTION
The `Machine` class is an implementation detail. Callers cannot meaningfully interact with it, so it should be non-public.