### PR TITLE
Make `CustomSection` immutable, introduce hierarchy

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
@@ -22,7 +22,7 @@ import com.dylibso.chicory.wasm.types.Global;
 import com.dylibso.chicory.wasm.types.Import;
 import com.dylibso.chicory.wasm.types.ImportDescType;
 import com.dylibso.chicory.wasm.types.Instruction;
-import com.dylibso.chicory.wasm.types.NameSection;
+import com.dylibso.chicory.wasm.types.NameCustomSection;
 import com.dylibso.chicory.wasm.types.OpCode;
 import com.dylibso.chicory.wasm.types.Table;
 import com.dylibso.chicory.wasm.types.Value;
@@ -42,7 +42,7 @@ import java.util.function.Supplier;
 
 public class Module {
     private final com.dylibso.chicory.wasm.Module module;
-    private NameSection nameSec;
+    private NameCustomSection nameSec;
 
     private final HashMap<String, Export> exports;
     private final Logger logger;
@@ -433,7 +433,7 @@ public class Module {
         return e;
     }
 
-    public NameSection nameSection() {
+    public NameCustomSection nameSection() {
         if (nameSec != null) return nameSec;
         nameSec = this.module.nameSection();
         return nameSec;

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Module.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Module.java
@@ -9,7 +9,7 @@ import com.dylibso.chicory.wasm.types.FunctionSection;
 import com.dylibso.chicory.wasm.types.GlobalSection;
 import com.dylibso.chicory.wasm.types.ImportSection;
 import com.dylibso.chicory.wasm.types.MemorySection;
-import com.dylibso.chicory.wasm.types.NameSection;
+import com.dylibso.chicory.wasm.types.NameCustomSection;
 import com.dylibso.chicory.wasm.types.StartSection;
 import com.dylibso.chicory.wasm.types.TableSection;
 import com.dylibso.chicory.wasm.types.TypeSection;
@@ -128,10 +128,8 @@ public class Module {
         return customSections.get(name);
     }
 
-    public NameSection nameSection() {
-        var customSec = customSections.get("name");
-        if (customSec == null) return null;
-        return new NameSection(customSec);
+    public NameCustomSection nameSection() {
+        return (NameCustomSection) customSections.get("name");
     }
 
     public ElementSection elementSection() {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/CustomSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/CustomSection.java
@@ -1,27 +1,13 @@
 package com.dylibso.chicory.wasm.types;
 
-public class CustomSection extends Section {
-    private String name;
+/**
+ * A custom section of some kind.
+ */
+public abstract class CustomSection extends Section {
 
-    private byte[] bytes;
-
-    public CustomSection(long id, long size) {
-        super(id, size);
+    protected CustomSection(long size) {
+        super(SectionId.CUSTOM, size);
     }
 
-    public String name() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public byte[] bytes() {
-        return bytes;
-    }
-
-    public void setBytes(byte[] bytes) {
-        this.bytes = bytes;
-    }
+    public abstract String name();
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameCustomSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameCustomSection.java
@@ -6,18 +6,30 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class NameSection extends CustomSection {
+/**
+ * The "name" custom section.
+ */
+public class NameCustomSection extends CustomSection {
 
     private final List<String> funcNames;
 
-    public NameSection(CustomSection sec) {
-        super(sec.sectionId(), sec.sectionSize());
-        this.setBytes(sec.bytes());
-        this.funcNames = parseFunctionNames();
+    /**
+     * Construct a new instance.
+     *
+     * @param size the size of the section
+     * @param bytes the byte content of the section
+     */
+    public NameCustomSection(final long size, final byte[] bytes) {
+        super(size);
+        funcNames = parseFunctionNames(bytes);
     }
 
-    private List<String> parseFunctionNames() {
-        ByteBuffer buf = ByteBuffer.wrap(this.bytes());
+    public String name() {
+        return "name";
+    }
+
+    private List<String> parseFunctionNames(final byte[] bytes) {
+        ByteBuffer buf = ByteBuffer.wrap(bytes);
 
         List<String> names = new ArrayList<>();
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/UnknownCustomSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/UnknownCustomSection.java
@@ -1,0 +1,32 @@
+package com.dylibso.chicory.wasm.types;
+
+import java.util.Objects;
+
+/**
+ * A custom section which is unknown to the parser.
+ */
+public final class UnknownCustomSection extends CustomSection {
+    private final String name;
+    private final byte[] bytes;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param size the section size
+     * @param name the name of the section (must not be {@code null})
+     * @param bytes the section contents (must not be {@code null})
+     */
+    public UnknownCustomSection(final long size, final String name, final byte[] bytes) {
+        super(size);
+        this.name = Objects.requireNonNull(name, "name");
+        this.bytes = bytes.clone();
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public byte[] bytes() {
+        return bytes;
+    }
+}


### PR DESCRIPTION
The `CustomSection` class is mutable, including its name. Since this class is added to a `Map` based on its name, allowing the `name` property to be mutable can cause subtle bugs. Additionally, allowing section contents to be mutable after parsing can cause inconsistencies. Finally, formalize the custom section hierarchy somewhat to avoid redundant memory usage and to release the byte array when it is no longer needed.