### PR TITLE
Remove size property from sections

### DIFF
--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -180,49 +180,49 @@ public final class Parser {
                         }
                     case SectionId.TYPE:
                         {
-                            var typeSection = parseTypeSection(buffer, sectionId, sectionSize);
+                            var typeSection = parseTypeSection(buffer, sectionId);
                             listener.onSection(typeSection);
                             break;
                         }
                     case SectionId.IMPORT:
                         {
-                            var importSection = parseImportSection(buffer, sectionId, sectionSize);
+                            var importSection = parseImportSection(buffer, sectionId);
                             listener.onSection(importSection);
                             break;
                         }
                     case SectionId.FUNCTION:
                         {
-                            var funcSection = parseFunctionSection(buffer, sectionId, sectionSize);
+                            var funcSection = parseFunctionSection(buffer, sectionId);
                             listener.onSection(funcSection);
                             break;
                         }
                     case SectionId.TABLE:
                         {
-                            var tableSection = parseTableSection(buffer, sectionId, sectionSize);
+                            var tableSection = parseTableSection(buffer, sectionId);
                             listener.onSection(tableSection);
                             break;
                         }
                     case SectionId.MEMORY:
                         {
-                            var memorySection = parseMemorySection(buffer, sectionId, sectionSize);
+                            var memorySection = parseMemorySection(buffer, sectionId);
                             listener.onSection(memorySection);
                             break;
                         }
                     case SectionId.GLOBAL:
                         {
-                            var globalSection = parseGlobalSection(buffer, sectionId, sectionSize);
+                            var globalSection = parseGlobalSection(buffer, sectionId);
                             listener.onSection(globalSection);
                             break;
                         }
                     case SectionId.EXPORT:
                         {
-                            var exportSection = parseExportSection(buffer, sectionId, sectionSize);
+                            var exportSection = parseExportSection(buffer, sectionId);
                             listener.onSection(exportSection);
                             break;
                         }
                     case SectionId.START:
                         {
-                            var startSection = parseStartSection(buffer, sectionId, sectionSize);
+                            var startSection = parseStartSection(buffer, sectionId);
                             listener.onSection(startSection);
                             break;
                         }
@@ -235,20 +235,20 @@ public final class Parser {
                         }
                     case SectionId.CODE:
                         {
-                            var codeSection = parseCodeSection(buffer, sectionId, sectionSize);
+                            var codeSection = parseCodeSection(buffer, sectionId);
                             listener.onSection(codeSection);
                             break;
                         }
                     case SectionId.DATA:
                         {
-                            var dataSection = parseDataSection(buffer, sectionId, sectionSize);
+                            var dataSection = parseDataSection(buffer, sectionId);
                             listener.onSection(dataSection);
                             break;
                         }
                     default:
                         {
                             // "Skipping Section with ID due to configuration: " + sectionId
-                            listener.onSection(new Section(sectionId, sectionSize));
+                            listener.onSection(new Section(sectionId));
                             buffer.position((int) (buffer.position() + sectionSize));
                             break;
                         }
@@ -286,15 +286,14 @@ public final class Parser {
         CustomSection section;
         if (name.equals("name")) {
             // todo: pluggable custom section factories
-            section = new NameCustomSection(sectionSize, bytes);
+            section = new NameCustomSection(bytes);
         } else {
-            section = new UnknownCustomSection(size, name, bytes);
+            section = new UnknownCustomSection(name, bytes);
         }
         return section;
     }
 
-    private static TypeSection parseTypeSection(
-            ByteBuffer buffer, long sectionId, long sectionSize) {
+    private static TypeSection parseTypeSection(ByteBuffer buffer, long sectionId) {
 
         var typeCount = readVarUInt32(buffer);
         var types = new FunctionType[(int) typeCount];
@@ -330,11 +329,10 @@ public final class Parser {
             types[i] = new FunctionType(params, returns);
         }
 
-        return new TypeSection(sectionId, sectionSize, types);
+        return new TypeSection(sectionId, types);
     }
 
-    private static ImportSection parseImportSection(
-            ByteBuffer buffer, long sectionId, long sectionSize) {
+    private static ImportSection parseImportSection(ByteBuffer buffer, long sectionId) {
 
         var importCount = readVarUInt32(buffer);
         var imports = new Import[(int) importCount];
@@ -395,11 +393,10 @@ public final class Parser {
             }
         }
 
-        return new ImportSection(sectionId, sectionSize, imports);
+        return new ImportSection(sectionId, imports);
     }
 
-    private static FunctionSection parseFunctionSection(
-            ByteBuffer buffer, long sectionId, long sectionSize) {
+    private static FunctionSection parseFunctionSection(ByteBuffer buffer, long sectionId) {
 
         var functionCount = readVarUInt32(buffer);
         var typeIndices = new int[(int) functionCount];
@@ -410,11 +407,10 @@ public final class Parser {
             typeIndices[i] = (int) typeIndex;
         }
 
-        return new FunctionSection(sectionId, sectionSize, typeIndices);
+        return new FunctionSection(sectionId, typeIndices);
     }
 
-    private static TableSection parseTableSection(
-            ByteBuffer buffer, long sectionId, long sectionSize) {
+    private static TableSection parseTableSection(ByteBuffer buffer, long sectionId) {
 
         var tableCount = readVarUInt32(buffer);
         var tables = new Table[(int) tableCount];
@@ -432,11 +428,10 @@ public final class Parser {
             tables[i] = new Table(tableType, min, max);
         }
 
-        return new TableSection(sectionId, sectionSize, tables);
+        return new TableSection(sectionId, tables);
     }
 
-    private static MemorySection parseMemorySection(
-            ByteBuffer buffer, long sectionId, long sectionSize) {
+    private static MemorySection parseMemorySection(ByteBuffer buffer, long sectionId) {
 
         var memoryCount = readVarUInt32(buffer);
         var memories = new Memory[(int) memoryCount];
@@ -447,7 +442,7 @@ public final class Parser {
             memories[i] = new Memory(limits);
         }
 
-        return new MemorySection(sectionId, sectionSize, memories);
+        return new MemorySection(sectionId, memories);
     }
 
     private static MemoryLimits parseMemoryLimits(ByteBuffer buffer) {
@@ -464,8 +459,7 @@ public final class Parser {
         return new MemoryLimits(initial, maximum);
     }
 
-    private static GlobalSection parseGlobalSection(
-            ByteBuffer buffer, long sectionId, long sectionSize) {
+    private static GlobalSection parseGlobalSection(ByteBuffer buffer, long sectionId) {
 
         var globalCount = readVarUInt32(buffer);
         var globals = new Global[(int) globalCount];
@@ -478,11 +472,10 @@ public final class Parser {
             globals[i] = new Global(valueType, mutabilityType, init);
         }
 
-        return new GlobalSection(sectionId, sectionSize, globals);
+        return new GlobalSection(sectionId, globals);
     }
 
-    private static ExportSection parseExportSection(
-            ByteBuffer buffer, long sectionId, long sectionSize) {
+    private static ExportSection parseExportSection(ByteBuffer buffer, long sectionId) {
 
         var exportCount = readVarUInt32(buffer);
         var exports = new Export[(int) exportCount];
@@ -496,13 +489,12 @@ public final class Parser {
             exports[i] = new Export(name, desc);
         }
 
-        return new ExportSection(sectionId, sectionSize, exports);
+        return new ExportSection(sectionId, exports);
     }
 
-    private static StartSection parseStartSection(
-            ByteBuffer buffer, long sectionId, long sectionSize) {
+    private static StartSection parseStartSection(ByteBuffer buffer, long sectionId) {
 
-        var startSection = new StartSection(sectionId, sectionSize);
+        var startSection = new StartSection(sectionId);
         startSection.setStartIndex(readVarUInt32(buffer));
         return startSection;
     }
@@ -519,7 +511,7 @@ public final class Parser {
         }
         assert (buffer.position() == initialPosition + sectionSize);
 
-        return new ElementSection(sectionId, sectionSize, elements);
+        return new ElementSection(sectionId, elements);
     }
 
     private static Element parseSingleElement(ByteBuffer buffer) {
@@ -606,8 +598,7 @@ public final class Parser {
         return exprs;
     }
 
-    private static CodeSection parseCodeSection(
-            ByteBuffer buffer, long sectionId, long sectionSize) {
+    private static CodeSection parseCodeSection(ByteBuffer buffer, long sectionId) {
 
         var funcBodyCount = readVarUInt32(buffer);
         var functionBodies = new FunctionBody[(int) funcBodyCount];
@@ -748,11 +739,10 @@ public final class Parser {
             functionBodies[i] = new FunctionBody(locals, instructions);
         }
 
-        return new CodeSection(sectionId, sectionSize, functionBodies);
+        return new CodeSection(sectionId, functionBodies);
     }
 
-    private static DataSection parseDataSection(
-            ByteBuffer buffer, long sectionId, long sectionSize) {
+    private static DataSection parseDataSection(ByteBuffer buffer, long sectionId) {
 
         var dataSegmentCount = readVarUInt32(buffer);
         var dataSegments = new DataSegment[(int) dataSegmentCount];
@@ -779,7 +769,7 @@ public final class Parser {
             }
         }
 
-        return new DataSection(sectionId, sectionSize, dataSegments);
+        return new DataSection(sectionId, dataSegments);
     }
 
     private static Instruction parseInstruction(ByteBuffer buffer) {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeSection.java
@@ -3,8 +3,8 @@ package com.dylibso.chicory.wasm.types;
 public class CodeSection extends Section {
     private FunctionBody[] functionBodies;
 
-    public CodeSection(long id, long size, FunctionBody[] functionBodies) {
-        super(id, size);
+    public CodeSection(long id, FunctionBody[] functionBodies) {
+        super(id);
         this.functionBodies = functionBodies;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/CustomSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/CustomSection.java
@@ -5,8 +5,8 @@ package com.dylibso.chicory.wasm.types;
  */
 public abstract class CustomSection extends Section {
 
-    protected CustomSection(long size) {
-        super(SectionId.CUSTOM, size);
+    protected CustomSection() {
+        super(SectionId.CUSTOM);
     }
 
     public abstract String name();

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSection.java
@@ -3,8 +3,8 @@ package com.dylibso.chicory.wasm.types;
 public class DataSection extends Section {
     private DataSegment[] dataSegments;
 
-    public DataSection(long id, long size, DataSegment[] dataSegments) {
-        super(id, size);
+    public DataSection(long id, DataSegment[] dataSegments) {
+        super(id);
         this.dataSegments = dataSegments;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElementSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElementSection.java
@@ -3,8 +3,8 @@ package com.dylibso.chicory.wasm.types;
 public class ElementSection extends Section {
     private Element[] elements;
 
-    public ElementSection(long id, long size, Element[] elements) {
-        super(id, size);
+    public ElementSection(long id, Element[] elements) {
+        super(id);
         this.elements = elements;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ExportSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ExportSection.java
@@ -3,8 +3,8 @@ package com.dylibso.chicory.wasm.types;
 public class ExportSection extends Section {
     private Export[] exports;
 
-    public ExportSection(long id, long size, Export[] exports) {
-        super(id, size);
+    public ExportSection(long id, Export[] exports) {
+        super(id);
         this.exports = exports;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionSection.java
@@ -3,8 +3,8 @@ package com.dylibso.chicory.wasm.types;
 public class FunctionSection extends Section {
     private int[] typeIndices;
 
-    public FunctionSection(long id, long size, int[] typeIndices) {
-        super(id, size);
+    public FunctionSection(long id, int[] typeIndices) {
+        super(id);
         this.typeIndices = typeIndices;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalSection.java
@@ -3,8 +3,8 @@ package com.dylibso.chicory.wasm.types;
 public class GlobalSection extends Section {
     private Global[] globals;
 
-    public GlobalSection(long id, long size, Global[] globals) {
-        super(id, size);
+    public GlobalSection(long id, Global[] globals) {
+        super(id);
         this.globals = globals;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ImportSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ImportSection.java
@@ -3,8 +3,8 @@ package com.dylibso.chicory.wasm.types;
 public class ImportSection extends Section {
     private Import[] imports;
 
-    public ImportSection(long id, long size, Import[] imports) {
-        super(id, size);
+    public ImportSection(long id, Import[] imports) {
+        super(id);
         this.imports = imports;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/MemorySection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/MemorySection.java
@@ -3,8 +3,8 @@ package com.dylibso.chicory.wasm.types;
 public class MemorySection extends Section {
     private Memory[] memories;
 
-    public MemorySection(long id, long size, Memory[] memories) {
-        super(id, size);
+    public MemorySection(long id, Memory[] memories) {
+        super(id);
         this.memories = memories;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameCustomSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameCustomSection.java
@@ -16,11 +16,10 @@ public class NameCustomSection extends CustomSection {
     /**
      * Construct a new instance.
      *
-     * @param size the size of the section
      * @param bytes the byte content of the section
      */
-    public NameCustomSection(final long size, final byte[] bytes) {
-        super(size);
+    public NameCustomSection(final byte[] bytes) {
+        super();
         funcNames = parseFunctionNames(bytes);
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Section.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Section.java
@@ -2,18 +2,12 @@ package com.dylibso.chicory.wasm.types;
 
 public class Section {
     private final int id;
-    private final long size;
 
-    public Section(long id, long size) {
+    public Section(long id) {
         this.id = (int) id;
-        this.size = size;
     }
 
     public int sectionId() {
         return id;
-    }
-
-    public long sectionSize() {
-        return size;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/StartSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/StartSection.java
@@ -3,8 +3,8 @@ package com.dylibso.chicory.wasm.types;
 public class StartSection extends Section {
     private long startIndex;
 
-    public StartSection(long id, long size) {
-        super(id, size);
+    public StartSection(long id) {
+        super(id);
     }
 
     public long startIndex() {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableSection.java
@@ -3,8 +3,8 @@ package com.dylibso.chicory.wasm.types;
 public class TableSection extends Section {
     private Table[] tables;
 
-    public TableSection(long id, long size, Table[] tables) {
-        super(id, size);
+    public TableSection(long id, Table[] tables) {
+        super(id);
         this.tables = tables;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TypeSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TypeSection.java
@@ -3,8 +3,8 @@ package com.dylibso.chicory.wasm.types;
 public class TypeSection extends Section {
     private FunctionType[] types;
 
-    public TypeSection(long id, long size, FunctionType[] types) {
-        super(id, size);
+    public TypeSection(long id, FunctionType[] types) {
+        super(id);
         this.types = types;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/UnknownCustomSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/UnknownCustomSection.java
@@ -12,12 +12,11 @@ public final class UnknownCustomSection extends CustomSection {
     /**
      * Construct a new instance.
      *
-     * @param size the section size
      * @param name the name of the section (must not be {@code null})
      * @param bytes the section contents (must not be {@code null})
      */
-    public UnknownCustomSection(final long size, final String name, final byte[] bytes) {
-        super(size);
+    public UnknownCustomSection(final String name, final byte[] bytes) {
+        super();
         this.name = Objects.requireNonNull(name, "name");
         this.bytes = bytes.clone();
     }


### PR DESCRIPTION
The size property is unused in section objects. Requiring it to be specified does not pose any inconvenience for reading, but it would make it very difficult to construct sections for writing.