### PR TITLE
Fix some issues with locals (in Parser + Machine)

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -57,7 +57,7 @@ class Machine {
 
         var func = instance.function(funcId);
         if (func != null) {
-            callStack.push(new StackFrame(instance, funcId, 0, args, func.locals()));
+            callStack.push(new StackFrame(instance, funcId, 0, args, func.localTypes()));
             eval(stack, instance, callStack, func.instructions());
         } else {
             callStack.push(new StackFrame(instance, funcId, 0, args, EMPTY_VALUE_TYPES));

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -2,6 +2,7 @@ package com.dylibso.chicory.runtime;
 
 import static com.dylibso.chicory.runtime.Module.computeConstantValue;
 import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
+import static com.dylibso.chicory.wasm.types.ValueType.EMPTY_VALUE_TYPES;
 
 import com.dylibso.chicory.runtime.exceptions.WASMRuntimeException;
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
@@ -59,7 +60,7 @@ class Machine {
             callStack.push(new StackFrame(instance, funcId, 0, args, func.locals()));
             eval(stack, instance, callStack, func.instructions());
         } else {
-            callStack.push(new StackFrame(instance, funcId, 0, args, List.of()));
+            callStack.push(new StackFrame(instance, funcId, 0, args, EMPTY_VALUE_TYPES));
             var imprt = instance.imports().index()[funcId];
             if (imprt == null) {
                 throw new ChicoryException("Missing host import, number: " + funcId);

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/StackFrame.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/StackFrame.java
@@ -30,10 +30,9 @@ public class StackFrame {
         this.instance = instance;
         this.funcId = funcId;
         this.pc = pc;
-        this.locals = new Value[args.length + localTypes.length];
+        this.locals = Arrays.copyOf(args, args.length + localTypes.length);
 
-        // initialize all locals.
-        for (var i = 0; i < args.length; i++) locals[i] = args[i];
+        // initialize codesegment locals.
         for (var i = 0; i < localTypes.length; i++) {
             ValueType type = localTypes[i];
             // TODO: How do we initialize non-numeric V128

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -737,8 +737,7 @@ public final class Parser {
                 // instruction);
             } while (buffer.position() < funcEndPoint);
 
-            ValueType[] localTypes = new ValueType[locals.size()];
-            locals.toArray(localTypes);
+            var localTypes = locals.toArray(ValueType[]::new);
             functionBodies[i] = new FunctionBody(localTypes, instructions);
         }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionBody.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionBody.java
@@ -3,15 +3,15 @@ package com.dylibso.chicory.wasm.types;
 import java.util.List;
 
 public class FunctionBody {
-    private List<Value> locals;
+    private final ValueType[] locals;
     private List<Instruction> instructions;
 
-    public FunctionBody(List<Value> locals, List<Instruction> instructions) {
+    public FunctionBody(ValueType[] locals, List<Instruction> instructions) {
         this.locals = locals;
         this.instructions = instructions;
     }
 
-    public List<Value> locals() {
+    public ValueType[] locals() {
         return locals;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionBody.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionBody.java
@@ -11,7 +11,7 @@ public class FunctionBody {
         this.instructions = instructions;
     }
 
-    public ValueType[] locals() {
+    public ValueType[] localTypes() {
         return locals;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -75,6 +75,31 @@ public class Value {
                 "Invalid type for 32 bit value, only I32 or F32 are allowed, given: " + type);
     }
 
+    /**
+     * Create a zeroed value for the particular type.
+     * @param valueType must be a valid zeroable type.
+     * @return a zero.
+     */
+    public static Value zero(ValueType valueType) {
+        switch (valueType) {
+            case I32:
+                return Value.i32(0);
+            case F32:
+                return Value.f32(0);
+            case I64:
+                return Value.i64(0);
+            case F64:
+                return Value.f64(0);
+            case FuncRef:
+                return Value.FUNCREF_NULL;
+            case ExternRef:
+                return Value.EXTREF_NULL;
+            default:
+                throw new IllegalArgumentException(
+                        "Can't create a zero value for type " + valueType);
+        }
+    }
+
     // TODO memoize these
     public int asInt() {
         switch (type) {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ValueType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ValueType.java
@@ -31,4 +31,6 @@ public enum ValueType {
     public static ValueType byId(long id) {
         return byId.get(id);
     }
+
+    public static final ValueType[] EMPTY_VALUE_TYPES = new ValueType[0];
 }

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
@@ -81,7 +81,7 @@ public class ParserTest {
             var functionBodies = codeSection.functionBodies();
             assertEquals(1, functionBodies.length);
             var func = functionBodies[0];
-            assertEquals(0, func.locals().length);
+            assertEquals(0, func.localTypes().length);
             var instructions = func.instructions();
             assertEquals(3, instructions.size());
 
@@ -118,7 +118,7 @@ public class ParserTest {
             var functionBodies = codeSection.functionBodies();
             assertEquals(1, functionBodies.length);
             var func = functionBodies[0];
-            var locals = func.locals();
+            var locals = func.localTypes();
             assertEquals(1, locals.length);
             assertEquals(ValueType.I32, locals[0]);
             var instructions = func.instructions();
@@ -238,8 +238,8 @@ public class ParserTest {
             var module = parser.parseModule(is);
             var codeSection = module.codeSection();
             var fbody = codeSection.functionBodies()[0];
-            assertEquals(fbody.locals()[0], ValueType.I32);
-            assertEquals(fbody.locals()[1], ValueType.I64);
+            assertEquals(fbody.localTypes()[0], ValueType.I32);
+            assertEquals(fbody.localTypes()[1], ValueType.I64);
         }
     }
 

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
@@ -81,8 +81,7 @@ public class ParserTest {
             var functionBodies = codeSection.functionBodies();
             assertEquals(1, functionBodies.length);
             var func = functionBodies[0];
-            var locals = func.locals();
-            assertEquals(0, locals.size());
+            assertEquals(0, func.locals().length);
             var instructions = func.instructions();
             assertEquals(3, instructions.size());
 
@@ -120,8 +119,8 @@ public class ParserTest {
             assertEquals(1, functionBodies.length);
             var func = functionBodies[0];
             var locals = func.locals();
-            assertEquals(1, locals.size());
-            assertEquals(1, locals.get(0).asInt());
+            assertEquals(1, locals.length);
+            assertEquals(ValueType.I32, locals[0]);
             var instructions = func.instructions();
             assertEquals(22, instructions.size());
         }
@@ -239,8 +238,8 @@ public class ParserTest {
             var module = parser.parseModule(is);
             var codeSection = module.codeSection();
             var fbody = codeSection.functionBodies()[0];
-            assertEquals(fbody.locals().get(0).type(), ValueType.I32);
-            assertEquals(fbody.locals().get(1).type(), ValueType.I64);
+            assertEquals(fbody.locals()[0], ValueType.I32);
+            assertEquals(fbody.locals()[1], ValueType.I64);
         }
     }
 


### PR DESCRIPTION
The parser was not correctly processing the section declaring the types of locals while parsing CodeSegment.  It had been using the count of how many adjacent locals were of the same type as a single local with that count as its default value.  This was causing machine to undercount how many locals existed.  It also led to erroneously initializing some locals to some unlikely initial values.

In setting up StackFrame it was only using locals being passed in to initialize locals.  The problem here was that the incoming parameters are actually the first locals from a Machine perspective.  So the fix was to assign all parameters as first locals and then add the locals declared in CodeSegment after those.  As a result this removes all need to check for missing locals.  That in turn allows the use of a single primitive array.

There is one outstanding question of how to initialize (zero) out a local for V128.  I added a TODO and guard against trying to zero it.  I expect there is some crash potential here since webasm says all locals must be initialized but it is probably not crashing due to lack of coverage for V128.