### PR TITLE
Make FunctionBody more final

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -107,10 +107,7 @@ class Machine {
     }
 
     static void eval(
-            MStack stack,
-            Instance instance,
-            ArrayDeque<StackFrame> callStack,
-            List<Instruction> code)
+            MStack stack, Instance instance, ArrayDeque<StackFrame> callStack, Instruction[] code)
             throws ChicoryException {
 
         try {
@@ -118,9 +115,9 @@ class Machine {
             boolean shouldReturn = false;
 
             loop:
-            while (frame.pc < code.size()) {
+            while (frame.pc < code.length) {
                 if (shouldReturn) return;
-                var instruction = code.get(frame.pc);
+                var instruction = code[frame.pc];
                 frame.pc++;
                 //                LOGGER.log(
                 //                        System.Logger.Level.DEBUG,

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -749,7 +749,8 @@ public final class Parser {
             } while (!lastInstruction);
 
             var localTypes = locals.toArray(ValueType[]::new);
-            functionBodies[i] = new FunctionBody(localTypes, instructions);
+            var instructionsArray = instructions.toArray(Instruction[]::new);
+            functionBodies[i] = new FunctionBody(localTypes, instructionsArray);
         }
 
         return new CodeSection(functionBodies);

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Ast.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Ast.java
@@ -14,6 +14,14 @@ public class Ast {
         this.stack.push(root);
     }
 
+    public static Ast fromInstructions(Instruction[] instructions) {
+        var ast = new Ast();
+        for (var i : instructions) {
+            ast.addInstruction(i);
+        }
+        return ast;
+    }
+
     public CodeBlock root() {
         return root;
     }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionBody.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionBody.java
@@ -1,12 +1,10 @@
 package com.dylibso.chicory.wasm.types;
 
-import java.util.List;
-
 public class FunctionBody {
     private final ValueType[] locals;
-    private List<Instruction> instructions;
+    private final Instruction[] instructions;
 
-    public FunctionBody(ValueType[] locals, List<Instruction> instructions) {
+    public FunctionBody(ValueType[] locals, Instruction[] instructions) {
         this.locals = locals;
         this.instructions = instructions;
     }
@@ -15,15 +13,7 @@ public class FunctionBody {
         return locals;
     }
 
-    public List<Instruction> instructions() {
+    public Instruction[] instructions() {
         return instructions;
-    }
-
-    public Ast ast() {
-        var ast = new Ast();
-        for (var i : instructions) {
-            ast.addInstruction(i);
-        }
-        return ast;
     }
 }

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
@@ -78,14 +78,14 @@ public class ParserTest {
             var func = codeSection.getFunctionBody(0);
             assertEquals(0, func.localTypes().length);
             var instructions = func.instructions();
-            assertEquals(3, instructions.size());
+            assertEquals(3, instructions.length);
 
-            assertEquals("0x00000032: I32_CONST [42]", instructions.get(0).toString());
-            assertEquals(OpCode.I32_CONST, instructions.get(0).opcode());
-            assertEquals(42L, (long) instructions.get(0).operands()[0]);
-            assertEquals(OpCode.CALL, instructions.get(1).opcode());
-            assertEquals(0L, (long) instructions.get(1).operands()[0]);
-            assertEquals(OpCode.END, instructions.get(2).opcode());
+            assertEquals("0x00000032: I32_CONST [42]", instructions[0].toString());
+            assertEquals(OpCode.I32_CONST, instructions[0].opcode());
+            assertEquals(42L, instructions[0].operands()[0]);
+            assertEquals(OpCode.CALL, instructions[1].opcode());
+            assertEquals(0L, instructions[1].operands()[0]);
+            assertEquals(OpCode.END, instructions[2].opcode());
         }
     }
 
@@ -114,8 +114,7 @@ public class ParserTest {
             var locals = func.localTypes();
             assertEquals(1, locals.length);
             assertEquals(ValueType.I32, locals[0]);
-            var instructions = func.instructions();
-            assertEquals(22, instructions.size());
+            assertEquals(22, func.instructions().length);
         }
     }
 
@@ -189,9 +188,9 @@ public class ParserTest {
             var module = parser.parseModule(is);
             var codeSection = module.codeSection();
             var fbody = codeSection.getFunctionBody(0);
-            var f32 = Float.intBitsToFloat((int) fbody.instructions().get(0).operands()[0]);
+            var f32 = Float.intBitsToFloat((int) fbody.instructions()[0].operands()[0]);
             assertEquals(0.12345678f, f32, 0.0);
-            var f64 = Double.longBitsToDouble(fbody.instructions().get(1).operands()[0]);
+            var f64 = Double.longBitsToDouble(fbody.instructions()[1].operands()[0]);
             assertEquals(0.123456789012345d, f64, 0.0);
         }
     }
@@ -205,20 +204,21 @@ public class ParserTest {
             var module = parser.parseModule(is);
             var codeSection = module.codeSection();
             var fbody = codeSection.getFunctionBody(0);
-            assertEquals(-2147483648L, fbody.instructions().get(0).operands()[0]);
-            assertEquals(0L, fbody.instructions().get(2).operands()[0]);
-            assertEquals(2147483647L, fbody.instructions().get(4).operands()[0]);
-            assertEquals(-9223372036854775808L, fbody.instructions().get(6).operands()[0]);
-            assertEquals(0L, fbody.instructions().get(8).operands()[0]);
-            assertEquals(9223372036854775807L, fbody.instructions().get(10).operands()[0]);
-            assertEquals(-2147483647L, fbody.instructions().get(12).operands()[0]);
-            assertEquals(2147483646L, fbody.instructions().get(14).operands()[0]);
-            assertEquals(-9223372036854775807L, fbody.instructions().get(16).operands()[0]);
-            assertEquals(9223372036854775806L, fbody.instructions().get(18).operands()[0]);
-            assertEquals(-1L, fbody.instructions().get(20).operands()[0]);
-            assertEquals(1L, fbody.instructions().get(22).operands()[0]);
-            assertEquals(-1L, fbody.instructions().get(24).operands()[0]);
-            assertEquals(1L, fbody.instructions().get(26).operands()[0]);
+            var instructions = fbody.instructions();
+            assertEquals(-2147483648L, instructions[0].operands()[0]);
+            assertEquals(0L, instructions[2].operands()[0]);
+            assertEquals(2147483647L, instructions[4].operands()[0]);
+            assertEquals(-9223372036854775808L, instructions[6].operands()[0]);
+            assertEquals(0L, instructions[8].operands()[0]);
+            assertEquals(9223372036854775807L, instructions[10].operands()[0]);
+            assertEquals(-2147483647L, instructions[12].operands()[0]);
+            assertEquals(2147483646L, instructions[14].operands()[0]);
+            assertEquals(-9223372036854775807L, instructions[16].operands()[0]);
+            assertEquals(9223372036854775806L, instructions[18].operands()[0]);
+            assertEquals(-1L, instructions[20].operands()[0]);
+            assertEquals(1L, instructions[22].operands()[0]);
+            assertEquals(-1L, instructions[24].operands()[0]);
+            assertEquals(1L, instructions[26].operands()[0]);
         }
     }
 


### PR DESCRIPTION
In my last PR I recognized I made localTypes as a final primitive array and thought it looked a bit weird that instructions were also not a final primitive array.  Unless there is a need to mutably update instructions this feels like it shows intent that this is a set in stone definition as an artifact of parsing.

I also moved the unused ast into Ast and renamed it.  The benefit of this new definition is it is uncoupled from FunctionBody and it obviously already needs to know what Instructions are.  This may just be dead code though?

Not sure if this is needed but I figured I may as well tie up what looked like a loose end to me.