### PR TITLE
[chore] remove slf4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
 
     <junit.version>5.10.1</junit.version>
     <spotless.version>2.43.0</spotless.version>
-    <slf4j.version>2.0.9</slf4j.version>
     <javaparser.version>3.25.8</javaparser.version>
     <commons-compress.version>1.25.0</commons-compress.version>
     <jackson.version>2.16.1</jackson.version>


### PR DESCRIPTION
Super minor chore, but this is unused and we don't want `slf4j` to pop up accidentally as a dependency.