### PR TITLE
func_ptrs.wast passing

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -70,6 +70,9 @@
             binary-leb128.wast,
             binary.wast,
             left-to-right.wast,
+            tokens.wast,
+            type.wast,
+            func_ptrs.wast,
             ref_null.wast</wastToProcess>
           <orderedWastToProcess>switch.wast,
             memory_grow.wast,

--- a/runtime/src/test/java/com/dylibso/chicory/imports/SpecV1FuncPtrsHostFuncs.java
+++ b/runtime/src/test/java/com/dylibso/chicory/imports/SpecV1FuncPtrsHostFuncs.java
@@ -1,0 +1,25 @@
+package com.dylibso.chicory.imports;
+
+import com.dylibso.chicory.runtime.HostFunction;
+import com.dylibso.chicory.runtime.HostImports;
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasm.types.Value;
+import com.dylibso.chicory.wasm.types.ValueType;
+import java.util.List;
+
+public class SpecV1FuncPtrsHostFuncs {
+
+    public static HostImports fallback() {
+        return new HostImports(
+                new HostFunction[] {
+                    new HostFunction(
+                            (Instance instance, Value... args) -> {
+                                return null;
+                            },
+                            "spectest",
+                            "print_i32",
+                            List.of(ValueType.I32),
+                            List.of())
+                });
+    }
+}


### PR DESCRIPTION
Those are the low-hanging fruits, found out that we still don't pass some tests in `func.wast`, maybe, that's the cause of the issue with arg types matching ...