### PR TITLE
Fix FunctionType#toString implementation

### DIFF
--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionType.java
@@ -46,8 +46,8 @@ public class FunctionType {
         if (nReturns == 0) {
             builder.append("nil");
         } else {
-            for (var i = 0; i < nParams; i++) {
-                builder.append(this.params[i].toString());
+            for (var i = 0; i < nReturns; i++) {
+                builder.append(this.returns[i].toString());
                 if (i < nReturns - 1) {
                     builder.append(',');
                 }

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/types/FunctionTypeTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/types/FunctionTypeTest.java
@@ -1,0 +1,20 @@
+package com.dylibso.chicory.wasm.types;
+
+import static com.dylibso.chicory.wasm.types.ValueType.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class FunctionTypeTest {
+    @Test
+    public void toStringContract() {
+        var emptyToNil = new FunctionType(new ValueType[0], new ValueType[0]);
+        assertEquals("() -> nil", emptyToNil.toString());
+
+        var i32I64ToF32 = new FunctionType(new ValueType[] {I32, I64}, new ValueType[] {F32});
+        assertEquals("(I32,I64) -> F32", i32I64ToF32.toString());
+
+        var v128ToI32I32 = new FunctionType(new ValueType[] {V128}, new ValueType[] {I32, I32});
+        assertEquals("(V128) -> I32,I32", v128ToI32I32.toString());
+    }
+}


### PR DESCRIPTION
Fixed copy-paste typo in the `FunctionType#toString` implementation. Added a test
