### PR TITLE
Include most of the remaining wast specs

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -41,8 +41,7 @@
         <artifactId>test-gen-plugin</artifactId>
         <version>${project.version}</version>
         <configuration>
-          <wastToProcess>func.wast,
-            labels.wast,
+          <wastToProcess>labels.wast,
             i32.wast,
             i64.wast,
             f32.wast,
@@ -80,6 +79,21 @@
             tokens.wast,
             type.wast,
             func_ptrs.wast,
+            comments.wast,
+            custom.wast,
+            exports.wast,
+            inline-module.wast,
+            skip-stack-guard-page.wast,
+            token.wast,
+            traps.wast,
+            table-sub.wast,
+            unreachable.wast,
+            unreached-invalid.wast,
+            unreached-valid.wast,
+            utf8-custom-section-id.wast,
+            utf8-import-field.wast,
+            utf8-import-module.wast,
+            utf8-invalid-encoding.wast,
             ref_null.wast</wastToProcess>
           <orderedWastToProcess>select.wast,
             float_memory.wast,

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -252,7 +252,11 @@ public final class Parser {
                         {
                             // "Skipping Section with ID due to configuration: " + sectionId
                             listener.onSection(new Section(sectionId));
-                            buffer.position((int) Math.min(buffer.limit(), buffer.position() + sectionSize));
+                            buffer.position(
+                                    (int)
+                                            Math.min(
+                                                    buffer.limit(),
+                                                    buffer.position() + sectionSize));
                             break;
                         }
                 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -252,7 +252,7 @@ public final class Parser {
                         {
                             // "Skipping Section with ID due to configuration: " + sectionId
                             listener.onSection(new Section(sectionId));
-                            buffer.position((int) (buffer.position() + sectionSize));
+                            buffer.position((int) Math.min(buffer.limit(), buffer.position() + sectionSize));
                             break;
                         }
                 }


### PR DESCRIPTION
After this PR(and excluding SIMD) we have 2 outstanding wast files not included:

- `elem.wast` -> the test requires sharing a table across modules (getting an exported instance and injecting it later on)
- `linking.wast` -> need to have a closer look ...