### PR TITLE
Rename `BlockType` to `BlockKind`

### DIFF
--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Ast.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Ast.java
@@ -9,7 +9,7 @@ public class Ast {
     // private List<Instruction> instructions;
 
     public Ast() {
-        this.root = new CodeBlock(BlockType.BLOCK);
+        this.root = new CodeBlock(BlockKind.BLOCK);
         this.stack = new ArrayDeque<>();
         this.stack.push(root);
     }
@@ -24,7 +24,7 @@ public class Ast {
             case BLOCK:
                 {
                     current.addInstruction(i);
-                    var next = new CodeBlock(BlockType.BLOCK);
+                    var next = new CodeBlock(BlockKind.BLOCK);
                     i.setCodeBlock(next);
                     push(next);
                     break;
@@ -32,7 +32,7 @@ public class Ast {
             case LOOP:
                 {
                     current.addInstruction(i);
-                    var next = new CodeBlock(BlockType.LOOP);
+                    var next = new CodeBlock(BlockKind.LOOP);
                     i.setCodeBlock(next);
                     push(next);
                     break;

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/BlockKind.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/BlockKind.java
@@ -1,6 +1,6 @@
 package com.dylibso.chicory.wasm.types;
 
-public enum BlockType {
+public enum BlockKind {
     BLOCK,
     LOOP,
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeBlock.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeBlock.java
@@ -4,11 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CodeBlock {
-    private BlockType type;
+    private BlockKind kind;
     private List<Instruction> instructions;
 
-    public CodeBlock(BlockType type) {
-        this.type = type;
+    public CodeBlock(BlockKind kind) {
+        this.kind = kind;
         this.instructions = new ArrayList<>();
     }
 


### PR DESCRIPTION
Blocks already have a "type", which is expressed as a function type (input and output type lists). So, disambiguate this terminology.