### PR TITLE
docs: Add roadmap, update READMEs and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,46 @@
 # Contributing guide
 
 **Want to contribute? Great!**
+
 We try to make it easy, and all contributions, even the smaller ones, are more than welcome.
 This includes bug reports, fixes, documentation, examples...
 But first, read this page (including the small print at the end).
 
-* [Legal](#legal)
-* [Reporting an issue](#reporting-an-issue)
+* [Coding Philosophy](#coding-philosophy)
 * [Before you contribute](#before-you-contribute)
   + [Code reviews](#code-reviews)
   + [Coding Guidelines](#coding-guidelines)
   + [Continuous Integration](#continuous-integration)
   + [Tests and documentation are not optional](#tests-and-documentation-are-not-optional)
   + [Current status](#current-status)
+* [Reporting an issue](#reporting-an-issue)
+* [Legal](#legal)
 * [The small print](#the-small-print)
 
+## Coding Philosophy
 
-## Legal
+Writing a runtime is a big challenge. We want Chicory to always be a solid foundation
+for running Wasm in Java. In order to accomplish this, it's going to take a large team
+of diverse contributors. That's why our goal up front is to aim for writing "dumb" and
+simple code that's easy to understand and is as backwards compatible as possible.
 
-All original contributions to Chicory projects are licensed under the
-[ASL - Apache License](https://www.apache.org/licenses/LICENSE-2.0),
-version 2.0 or later, or, if another license is specified as governing the file or directory being
-modified, such other license.
+The reason is we want to optimize for:
 
-## Reporting an issue
+ * attracting more contributors
+ * supporting more users
+ * supporting more platforms
 
-This project uses GitHub issues to manage the issues. Open an issue directly in GitHub.
+It's important we focus on this in the beginning phase so that we can grow a large team
+of contributors. We also want to make it possible for people with deep Wasm and runtime experience,
+but maybe not the deepest Java experience, to contribute.
 
-If you believe you found a bug, and it's likely possible, please indicate a way to reproduce it, what you are seeing and what you would expect to see.
+This philosophy tends to lead us down what might seem like some non-optimal paths. We may ask you
+to simplify things, use older versions of Java, or reject improvements that we feel
+makes things more confusing without enough measurable benefits.
+
+We don't expect to be able to maintain this forever, and some parts of the codebase will 
+inevitably suffer from necessary complexity in the name of correctness, safety, or speed.
+But we are holding the line as long as we can.
 
 ## Before you contribute
 
@@ -66,15 +79,20 @@ Because we are all humans, and to ensure Chicory evolves in the right direction,
 Don't forget to include tests in your pull requests.
 Also don't forget the documentation (reference documentation, javadoc...).
 
-## Current status
+## Reporting an issue
 
-The project is still in a pre-alpha state, where a chunk of the official [testsuite](https://github.com/WebAssembly/testsuite) is not yet completed.
-Since there is some significant work to be ironed out we have been taking a few decisions to reduce the burden:
+This project uses GitHub issues to manage the issues. Open an issue directly in GitHub.
 
-- we are concentrating on the happy path: this means that we disabled most of the tests exercising validation of the input
-- we prioritize the inclusion of more `.wabt` files from the stable spec at `v1`: exception handling, GC, SIMD etc. will come in the future
-- we sync in Zulip: if you wanna contribute you are encouraged to drop a message in the chat and we are happy to assist
+If you believe you found a bug, and it's likely possible, please indicate a way to reproduce it, what you are seeing and what you would expect to see.
+
+## Legal
+
+All original contributions to Chicory projects are licensed under the
+[ASL - Apache License](https://www.apache.org/licenses/LICENSE-2.0),
+version 2.0 or later, or, if another license is specified as governing the file or directory being
+modified, such other license.
 
 ## The small print
 
 This project is an open source project. Please act responsibly, be nice, polite and enjoy!
+

--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ logIt.apply();
 
 ### Why is this needed?
 
+If you'd prefer to watch a video interested of read, see our [2024 Wasm I/O](https://2024.wasmio.tech/) on the subject:
+
+[![Wasm I/O Chicory talk](https://img.youtube.com/vi/00LYdZS0YlI/0.jpg)](https://www.youtube.com/watch?v=00LYdZS0YlI)
+
 There are a number of mature Wasm runtimes to choose from to execute a Wasm module.
 To name a few [v8](https://v8.dev/), [wasmtime](https://wasmtime.dev/), [wasmer](https://wasmer.io/), [wasmedge](https://wasmedge.org/), etc.
 
@@ -221,18 +225,42 @@ security and memory guarantees, and your tools, can stay in place.
 
 ### Roadmap
 
+Chicory development was started in September, 2023. The following are the milestones we're aiming for. These
+are subject to change but represent our best guesses with current information. These are not necessarily sequential
+and some may be happening in parallel. Unless specified, any unchecked box is still not planned or started.
+If you have an interest in working on any of these please reach out in Zulip!
+
+#### Bootstrap a bytecode interpreter and test suite (EOY 2023)
+
 * [x] Wasm binary parser [link](wasm/)
 * [x] Simple bytecode interpreter
+* [x] Establish basic coding and testing patterns
 * [x] Generate JUnit tests from wasm test suite [link](test-gen-plugin/)
-* [ ] Make all tests green with the interpreter
-* [ ] Implement validation logic
-* [ ] Performance improvements
-* [ ] AOT compiler (generate JVM bytecode from Wasm module)
 
-Some nice to have but probably separate items:
+#### Make the interpreter production ready (Summer 2024)
 
-* [ ] Off-heap linear memory
-* [ ] WASI Support
+* [ ] Make all tests green with the interpreter (important for correctness)
+  * Almost complete
+* [ ] Implement validation logic (important for safety)
+  * Started by [@andreaTP](https://github.com/andreatp)
+* [ ] Draft of the v1.0 API (important for stability and dx)
+
+#### Make it fast (EOY 2024)
+
+The primary goal here is to create an AOT compiler that generates JVM bytecode
+as interpreting bytecode can only be so fast.
+
+* [ ] Decouple interpreter and create separate compiler and interpreter "engines"
+* [ ] Proof of concept AOT compiler (run some subset of modules)
+* [ ] AOT engine passes all the same specs as interpreter (stretch goal)
+* [ ] Off-heap linear memory (stretch goal)
+
+### Make it compatible (EOY 2024)
+
+* [ ] WASIp1 Support (including test gen)
+  * We have [partial support for wasip1](wasi/) and [test generation](wasi-test-gen-plugin/)
+* [ ] SIMD Support
+  * Started as a GSoC project by [@zedbeit](https://github.com/zedbeit)
 * [ ] GC Support
 * [ ] Threads Support
 * [ ] Component Model Support

--- a/wasi/README.md
+++ b/wasi/README.md
@@ -1,0 +1,105 @@
+# WASI
+
+This library contains code for instantiating and running WASI modules.
+[WASI](https://wasi.dev/) is a virtual system interface that can give you some familiar posix-like syscalls and is supported
+by many of the compilers out there.
+
+## Version Support
+
+There are currently 2 versions of WASI at the moment, [preview1](https://github.com/WebAssembly/WASI/blob/main/legacy/README.md) and [preview2](https://github.com/WebAssembly/WASI/blob/main/preview2/README.md). This library is currently
+aimed at `preview1`.
+
+> **Note**: You may hear many names for referencing these versions. You might hear the terms `preview1/preview1` or `0.1/0.2` when referring to the versions inside the WASI docs.
+> And you might hear `wasip1` when being used as a flag to a compiler target. We tend to prefer the nomenclature wasip1 / wasip2.
+
+### wasip1
+
+Although `wasip1` is marked as "legacy", this is the version that nearly all compilers support when compiling to a Wasm target. For that reason we are aiming to have good support, but have no immediate plans to "complete" the implementation.
+Please reach out if you'd like to see more done to support wasip1.
+
+See the [WasiPreview1.java](https://github.com/dylibso/chicory/blob/main/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java) class
+to understand what we support today and what we do not support. Here are some features have basic coverage for currently:
+
+* stdin / stdout / stderr
+* environment variables
+* command arguments
+* clocks
+* random
+* basic reading and writing of files (through use of a [virtual file system](https://github.com/google/jimfs))
+
+If your module calls a wasi function that we don't support, or uses a feature that we don't support, we will throw a `WASMRuntimeException`.
+
+### wasip2
+
+We do have intentions to support wasip2 in the future, however this work has not been started. Please reach out to us on zulip if you are interested in helping plan and execute this work.
+
+## How to use
+
+As a host who is running Wasm modules, WASI is just a collection of host imports that you need to provide
+to a wasi-compiled module when instantiating it. You'll also need to configure some options for how
+these functions behave and what the module can and cannot do.
+
+### Bare-Bones Instantiation
+
+So to instantiate a WASI module you need an instance of `WasiPreview1`. You can turn this instance into
+import functions which can then be passed to the Module builder. 
+
+```java
+var logger = new SystemLogger();
+// let's just use the default options for now
+var options = WasiOptions.builder().build();
+// create our instance of wasip1
+var wasi = new WasiPreview1(this.logger, WasiOptions.builder().build());
+// turn those into host imports. Here we could add any other custom imports we have
+var imports = new HostImports(wasi.toHostFunctions());
+// create the module
+var module = Module.builder("hello-wasi.wasm").build();
+// instantiate and connect our imports, this will execute the module
+module.instantiate(imports);
+```
+
+> **Note**: Take note that we don't explicitly execute the module. The module will run when you instantiate it. This
+> is part of the WASI spec. They will implicitly call `_start`. To learn more [read this blog post](https://dylibso.com/blog/wasi-command-reactor/).
+
+### stdin, stdout, and stderr
+
+At the very least, you probably want to orchestrate stdin, stdout, and stderr of the module.
+Often, this is the way you communicate with basic WASI-enabled modules by way of the [command pattern](https://dylibso.com/blog/wasi-command-reactor/).
+In order to make it easy to manipulate these streams, we expose stdin as an [InputStream](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html)
+and stdout/stderr as an [OutputStream](https://docs.oracle.com/javase/8/docs/api/java/io/OutputStream.html).
+
+```java
+// Let's create a fake stdin stream with the bytes "Andrea"
+var fakeStdin = new ByteArrayInputStream("Andrea".getBytes());
+// We will create two output streams to capture stdout and stderr
+var fakeStdout = new ByteArrayOutputStream();
+var fakeStderr = new ByteArrayOutputStream();
+// now pass those to our wasi options builder
+var wasiOpts = WasiOptions
+        .builder()
+        .withStdout(fakeStdout)
+        .withStderr(fakeStderr)
+        .withStdin(fakeStdin)
+        .build();
+
+var wasi = new WasiPreview1(this.logger, wasiOpts);
+var imports = new HostImports(wasi.toHostFunctions());
+
+// greet-wasi is a rust program that greets the string passed in stdin
+var module = Module.builder("greet-wasi.rs.wasm").build();
+
+// instantiating will execute the module
+module.instantiate(imports);
+
+// check that we output the greeting
+assertEquals(fakeStdout.toString(), "Hello, Andrea!");
+// there should be no bytes in stderr!
+assertEquals(fakeStderr.toString(), "");
+```
+
+
+
+
+
+
+


### PR DESCRIPTION
I had some time this weekend to start working on readmes and add a roadmap. Here are my notes from the meeting where we identified this problem:

> the primary theme that kept emerging is we need to be more transparent about our roadmap and our motivations. we have a lot of ideas and features that we have signaled interest in, but it's time to put out clear signals about what we're aiming for this year, what would be nice to have community support for, and what we are not going to do. I'm taking it as my task to update the readme and get this started. 

I also took the time to add a readme to the wasi package. Mainly to document how it works but also document our plans for it. 

I'm at a conference this week but should be able to continue improving this through the week. Feel free to drop comments or ideas in this draft state.