### PR TITLE
Update MStack to use pollFirst() instead of pop()

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
@@ -21,7 +21,7 @@ public class MStack {
     }
 
     public Value pop() {
-        var r = this.stack.pop();
+        var r = this.stack.pollFirst();
         if (r == null) throw new RuntimeException("Stack underflow exception");
         return r;
     }


### PR DESCRIPTION
This fixes the exception thrown on stack underflow.
ArrayDeque#pop throws a NoSuchElementException when stack is empty, whereas pollFirst returns null in such cases.