### PR TITLE
Add an ExecutionListener interface for optional runtime monitoring

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExecutionListener.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExecutionListener.java
@@ -4,5 +4,14 @@ import com.dylibso.chicory.wasm.types.Instruction;
 
 @FunctionalInterface
 public interface ExecutionListener {
+    /*
+     * WARNING:
+     *
+     * Implementing this function you will be executing code on the very hot path of the interpreter for each and every instruction.
+     * Any issue or performance degradation caused by this code is not going to be supported.
+     * This interface along with its usage is experimental and we might drop it at a later stage.
+     *
+     * If you have a specific use case for this functionality, please, open an Issue at: https://github.com/dylibso/chicory/issues
+     */
     void onExecution(Instruction instruction, long[] operands, MStack stack);
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExecutionListener.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExecutionListener.java
@@ -1,0 +1,8 @@
+package com.dylibso.chicory.runtime;
+
+import com.dylibso.chicory.wasm.types.Instruction;
+
+@FunctionalInterface
+public interface ExecutionListener {
+    void onExecution(Instruction instruction, long[] operands, MStack stack);
+}

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -37,6 +37,7 @@ public class Instance {
     private TableInstance[] tables;
     private final Element[] elements;
     private final boolean start;
+    private final ExecutionListener listener;
 
     public Instance(
             Module module,
@@ -53,7 +54,8 @@ public class Instance {
             Table[] tables,
             Element[] elements,
             boolean initialize,
-            boolean start) {
+            boolean start,
+            ExecutionListener listener) {
         this.module = module;
         this.globalInitializers = globalInitializers.clone();
         this.globals = new GlobalInstance[globalInitializers.length + importedGlobalsOffset];
@@ -70,6 +72,7 @@ public class Instance {
         this.roughTables = tables.clone();
         this.elements = elements.clone();
         this.start = start;
+        this.listener = listener;
 
         if (initialize) {
             initialize(this.start);
@@ -279,5 +282,11 @@ public class Instance {
 
     public void setElement(int idx, Element val) {
         elements[idx] = val;
+    }
+
+    public void onExecution(Instruction instruction, long[] operands, MStack stack) {
+        if (listener != null) {
+            listener.onExecution(instruction, operands, stack);
+        }
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -118,6 +118,7 @@ class Machine {
                 //                                + stack);
                 var opcode = instruction.opcode();
                 var operands = instruction.operands();
+                instance.onExecution(instruction, operands, stack);
                 switch (opcode) {
                     case UNREACHABLE:
                         throw new TrapException("Trapped on unreachable instruction", callStack);

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
@@ -89,7 +89,10 @@ public class Module {
         return this;
     }
 
-    public Module withExecutionListener(ExecutionListener listener) {
+    /*
+     * This method is experimental and might be dropped without notice in future releases.
+     */
+    public Module withUnsafeExecutionListener(ExecutionListener listener) {
         this.listener = listener;
         return this;
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
@@ -42,6 +42,7 @@ public class Module {
 
     private boolean initialize = true;
     private boolean start = true;
+    private ExecutionListener listener = null;
     private HostImports hostImports;
 
     protected Module(com.dylibso.chicory.wasm.Module module, Logger logger) {
@@ -88,6 +89,11 @@ public class Module {
         return this;
     }
 
+    public Module withExecutionListener(ExecutionListener listener) {
+        this.listener = listener;
+        return this;
+    }
+
     public Module withHostImports(HostImports hostImports) {
         this.hostImports = hostImports;
         return this;
@@ -97,10 +103,14 @@ public class Module {
         if (hostImports == null) {
             hostImports = new HostImports();
         }
-        return this.instantiate(hostImports, initialize, start);
+        return this.instantiate(hostImports, initialize, start, listener);
     }
 
-    protected Instance instantiate(HostImports hostImports, boolean initialize, boolean start) {
+    protected Instance instantiate(
+            HostImports hostImports,
+            boolean initialize,
+            boolean start,
+            ExecutionListener listener) {
         var globalInitializers = new Global[] {};
         if (this.module.globalSection() != null) {
             globalInitializers = this.module.globalSection().globals();
@@ -254,7 +264,8 @@ public class Module {
                 tables,
                 elements,
                 initialize,
-                start);
+                start,
+                listener);
     }
 
     private HostImports mapHostImports(Import[] imports, HostImports hostImports) {

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
@@ -326,7 +326,7 @@ public class ModuleTest {
         var module =
                 Module.builder("compiled/iterfact.wat.wasm")
                         .build()
-                        .withExecutionListener(
+                        .withUnsafeExecutionListener(
                                 (Instruction instruction, long[] operands, MStack stack) ->
                                         count.getAndIncrement())
                         .instantiate();


### PR DESCRIPTION
Related to the discussion in #233 

Considerations:
- this is a basic mechanism to enable external and pluggable "monitoring" of the execution
- is pretty primitive and low-level intentionally as it's supposed to be an "advanced" functionality
- is on the most critical hot path, the user is on it's own performance wise
- I'd prefer to have a clear API other than having users forking the project

Looking for feedback!
(Took the occasion to address a little [this comment](https://github.com/dylibso/chicory/pull/278#discussion_r1576495990) too)