### PR TITLE
Apply spotless during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-.idea/
+# IntelliJ IDEA files
+.idea
+*.iml
+
 target/
 testsuite/
 wasi-testsuite/

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Some nice to have but probably separate items:
 ### Building the Runtime
 
 Contributors and other advanced users may want to build the runtime from source. To do so, you'll need to have Maven installed.
+`Java version 11` required for a proper build. You can download and install [Java 11 Temurin](https://adoptium.net/temurin/releases/?version=11)
 
 Basic steps:
 

--- a/README.md
+++ b/README.md
@@ -246,11 +246,12 @@ Some nice to have but probably separate items:
 ### Building the Runtime
 
 Contributors and other advanced users may want to build the runtime from source. To do so, you'll need to have Maven installed.
-`Java version 11` required for a proper build. You can download and install [Java 11 Temurin](https://adoptium.net/temurin/releases/?version=11)
+`Java version 11+` required for a proper build. You can download and install [Java 11 Temurin](https://adoptium.net/temurin/releases/?version=11)
 
 Basic steps:
 
-* `mvn clean install` to run all of the project's tests and install the library in your local repo
+* For the 1st build you need to create `testsuite` folder manually `mkdir testsuite`
+* `mvn clean install` to run all the project's tests and install the library in your local repo
 * `mvn spotless:apply` to autoformat the code
 * `./scripts/compile-resources.sh` will recompile and regenerate the `resources/compiled` folders
 

--- a/pom.xml
+++ b/pom.xml
@@ -364,9 +364,9 @@
         </configuration>
         <executions>
           <execution>
-            <id>format</id>
+            <id>format-sources</id>
             <goals>
-              <goal>check</goal>
+              <goal>apply</goal>
             </goals>
             <phase>process-sources</phase>
           </execution>


### PR DESCRIPTION
1. I propose always formatting code during the build process, this will completely remove any code formatting issues.
2. Added a few additional patterns for IntelliJ IDEA-related files in `.gitignore`
3. Proper java version specified in README(b/c I initially used 17 LTS)
4. Minor update related to 1st build added to README.