### PR TITLE
MStack internals changed.

### DIFF
--- a/jmh/README.md
+++ b/jmh/README.md
@@ -6,7 +6,7 @@ This module is used to run JMH performance tests on Chicory and make it easy to 
 
 There a few additional tools that are needed to see the benchmark results:
 
-- `wget`
+- [wget](https://www.gnu.org/software/wget/)
 - `http-server` install with: `npm install http-server -g`
 
 ## Locally

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
@@ -1,42 +1,107 @@
 package com.dylibso.chicory.runtime;
 
 import com.dylibso.chicory.wasm.types.Value;
-import java.util.ArrayDeque;
+import java.util.Arrays;
 
 /**
- * A temporary class that gives us a little more control over the interface.
- * It allows us to assert non-nulls as well as throw stack under and overflow exceptions
- * We should replace with something more idiomatic and performant.
+ * A temporary class that gives us a little more control over the interface. It allows us to assert
+ * non-nulls as well as throw stack under and overflow exceptions We should replace with something
+ * more idiomatic and performant.
  */
-public class MStack {
-    private final ArrayDeque<Value> stack;
+public final class MStack { // TODO: what about renaming to 'OperandStack'
+
+    private static final int MIN_STACK_SIZE = 16;
+
+    private Value[] arr;
+    private int topIdx;
 
     public MStack() {
-        this.stack = new ArrayDeque<>();
+        // create empty stack from the beginning, don't allocate any memory
+        arr = Value.EMPTY_VALUES;
     }
 
-    public void push(Value v) {
-        if (v == null) throw new RuntimeException("Can't push null value onto stack");
-        this.stack.push(v);
+    public void push(Value value) {
+        if (value == null) {
+            throw new RuntimeException("Can't push null value onto the stack");
+        }
+        pushValue(value);
     }
 
     public Value pop() {
-        var r = this.stack.pollFirst();
-        if (r == null) throw new RuntimeException("Stack underflow exception");
-        return r;
+        return pollValue();
     }
 
     public Value peek() {
-        var r = this.stack.peek();
-        if (r == null) throw new RuntimeException("Stack underflow exception");
-        return r;
+        return peekValue();
     }
 
     public int size() {
-        return this.stack.size();
+        return topIdx;
     }
 
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    private void pushValue(Value value) {
+        if (topIdx == arr.length) {
+            resize();
+        }
+        arr[topIdx] = value;
+        ++topIdx;
+    }
+
+    private Value pollValue() {
+        if (isEmpty()) {
+            throw new RuntimeException("Stack underflow occurred");
+        }
+        Value retValue = arr[topIdx - 1];
+        arr[topIdx - 1] = null;
+        --topIdx;
+
+        // shirk array if only 1/3 or less is occupied
+        if (size() * 3 <= arr.length) {
+            shrink();
+        }
+
+        return retValue;
+    }
+
+    private Value peekValue() {
+        if (isEmpty()) {
+            throw new RuntimeException("Stack underflow occurred");
+        }
+        return arr[topIdx - 1];
+    }
+
+    private void resize() {
+        // just double the array size
+        arr = Arrays.copyOf(arr, Math.max(MIN_STACK_SIZE, arr.length * 2));
+    }
+
+    private void shrink() {
+        // it's safe to cut half of array, b/c we shrink only if
+        // 1/3 or fewer elements are in use
+        arr = Arrays.copyOf(arr, arr.length / 2);
+    }
+
+    @Override
     public String toString() {
-        return this.stack.toString();
+        if (isEmpty()) {
+            return "[]";
+        }
+
+        StringBuilder buf = new StringBuilder(2 + size() * 16);
+        buf.append("[");
+
+        buf.append(arr[0]);
+
+        for (int i = 1; i < size(); ++i) {
+            buf.append(", ").append(arr[i]);
+        }
+
+        buf.append("]");
+
+        return buf.toString();
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -29,7 +29,6 @@ class Machine {
     public Machine(Instance instance) {
         this.instance = instance;
         stack = new MStack();
-
         this.callStack = new ArrayDeque<>();
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -29,6 +29,7 @@ class Machine {
     public Machine(Instance instance) {
         this.instance = instance;
         stack = new MStack();
+
         this.callStack = new ArrayDeque<>();
     }
 

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/MStackTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/MStackTest.java
@@ -1,0 +1,91 @@
+package com.dylibso.chicory.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.dylibso.chicory.wasm.types.Value;
+import org.junit.jupiter.api.Test;
+
+public class MStackTest {
+
+    @Test
+    public void push() {
+        var stack = new MStack();
+
+        assertTrue(stack.isEmpty());
+        assertEquals(0, stack.size());
+
+        stack.push(Value.i32(5));
+        stack.push(Value.i32(10));
+
+        assertFalse(stack.isEmpty());
+        assertEquals(2, stack.size());
+    }
+
+    @Test
+    public void pushWithResizing() {
+        var stack = new MStack();
+
+        for (int i = 0; i < 30; ++i) {
+            stack.push(Value.i32(i));
+        }
+
+        assertFalse(stack.isEmpty());
+        assertEquals(30, stack.size());
+    }
+
+    @Test
+    public void pushNullValueThrowsException() {
+        var stack = new MStack();
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> stack.push(null));
+
+        assertEquals("Can't push null value onto the stack", ex.getMessage());
+    }
+
+    @Test
+    public void pushWithPeekAndPoll() {
+        var stack = new MStack();
+
+        for (int i = 0; i < 10; ++i) {
+            stack.push(Value.i32(i));
+        }
+
+        for (int it = 0; it < 5; ++it) {
+            assertEquals(Value.i32(9), stack.peek());
+        }
+
+        for (int i = 9; i >= 1; --i) {
+            assertEquals(Value.i32(i), stack.pop());
+        }
+
+        assertEquals(Value.i32(0), stack.peek());
+        assertEquals(Value.i32(0), stack.pop());
+    }
+
+    @Test
+    public void peekFromEmptyStackThrowsException() {
+        var stack = new MStack();
+
+        RuntimeException ex = assertThrows(RuntimeException.class, stack::peek);
+
+        assertEquals("Stack underflow occurred", ex.getMessage());
+    }
+
+    @Test
+    public void popFromEmptyStackThrowsException() {
+        var stack = new MStack();
+
+        stack.push(Value.TRUE);
+        stack.push(Value.FALSE);
+
+        stack.pop();
+        stack.pop();
+
+        RuntimeException ex = assertThrows(RuntimeException.class, stack::pop);
+
+        assertEquals("Stack underflow occurred", ex.getMessage());
+    }
+}

--- a/scripts/build-jmh-main.sh
+++ b/scripts/build-jmh-main.sh
@@ -1,10 +1,11 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 (
-  cd "${SCRIPT_DIR}/.."
-  git clone --depth 1 --branch main https://github.com/dylibso/chicory.git main
-  mvn -Pbenchmarks spotless:apply clean package -DskipTests
+  cd "${SCRIPT_DIR}/.." || exit 1
+  rm -rf main
+  git clone --depth 1 --branch main https://github.com/dylibso/chicory.git main || exit 1
+  mvn -Pbenchmarks spotless:apply clean package -DskipTests || exit 1
 )

--- a/scripts/build-jmh.sh
+++ b/scripts/build-jmh.sh
@@ -1,9 +1,9 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 (
-  cd "${SCRIPT_DIR}/.."
-  mvn -Pbenchmarks spotless:apply clean package -DskipTests
+  cd "${SCRIPT_DIR}/.." || exit 1
+  mvn -Pbenchmarks spotless:apply clean package -DskipTests || exit 1
 )

--- a/scripts/run-jmh-main.sh
+++ b/scripts/run-jmh-main.sh
@@ -1,9 +1,9 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 (
-  cd "${SCRIPT_DIR}/../main"
-  java -jar "${SCRIPT_DIR}/../jmh/target/benchmarks.jar" -rf json
+  cd "${SCRIPT_DIR}/../main" || exit 1
+  java -jar "${SCRIPT_DIR}/../jmh/target/benchmarks.jar" -rf json || exit 1
 )

--- a/scripts/run-jmh.sh
+++ b/scripts/run-jmh.sh
@@ -1,6 +1,6 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-java -jar "${SCRIPT_DIR}/../jmh/target/benchmarks.jar" -rf json
+java -jar "${SCRIPT_DIR}/../jmh/target/benchmarks.jar" -rf json || exit 1

--- a/scripts/show-results.sh
+++ b/scripts/show-results.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 # Two options: run locally or download from GH Actions


### PR DESCRIPTION
1. `MStack` class internals changed from ArrayDeque usage to hand-crafter Stack using an array.
2. Additional unit tests added.
3. Minor improvements in JMH scripts.

The current JMH benchmark doesn't show any improvements (no changes), but that's because `MStack` is not used extensively during micro-benchmark tests.

I want to receive initial feedback if it makes sense or not.