### PR TITLE
Add Bill of Materials (BOM) artifact

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.dylibso.chicory</groupId>
+    <artifactId>chicory</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <artifactId>bom</artifactId>
+  <packaging>pom</packaging>
+  <name>Chicory - BOM</name>
+  <description>Bill of Materials (BOM)</description>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.dylibso.chicory</groupId>
+        <artifactId>log</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.dylibso.chicory</groupId>
+        <artifactId>runtime</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.dylibso.chicory</groupId>
+        <artifactId>wasi</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.dylibso.chicory</groupId>
+        <artifactId>wasm</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <outputDirectory>${project.build.directory}</outputDirectory>
+          <flattenedPomFilename>pom.xml</flattenedPomFilename>
+          <flattenMode>bom</flattenMode>
+          <pomElements>
+            <properties>remove</properties>
+            <distributionManagement>remove</distributionManagement>
+          </pomElements>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <phase>process-resources</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <module>wasi</module>
     <module>wasm-corpus</module>
     <module>cli</module>
+    <module>bom</module>
   </modules>
 
   <scm>
@@ -104,6 +105,7 @@
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     <templating-maven-plugin.version>3.0.0</templating-maven-plugin.version>
     <maven-shade-plugin.version>3.5.3</maven-shade-plugin.version>
+    <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -264,6 +266,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>${maven-shade-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>${flatten-maven-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This makes it easier to use and ensures that the same version is used for all artifacts:
```xml
<dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>com.dylibso.chicory</groupId>
      <artifactId>bom</artifactId>
      <version>XXX</version>
      <type>pom</type>
      <scope>import</scope>
    </dependency>
  </dependencies>
</dependencyManagement>

<!-- no need to specify versions for the artifacts -->
<dependencies>
  <dependency>
    <groupId>com.dylibso.chicory</groupId>
    <artifactId>log</artifactId>
  </dependency>
  <dependency>
    <groupId>com.dylibso.chicory</groupId>
    <artifactId>runtime</artifactId>
  </dependency>
  <dependency>
    <groupId>com.dylibso.chicory</groupId>
    <artifactId>wasi</artifactId>
  </dependency>
  <dependency>
    <groupId>com.dylibso.chicory</groupId>
    <artifactId>wasm</artifactId>
  </dependency>
</dependencies>

