### PR TITLE
Some small improvements for bindings authors

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
@@ -11,6 +11,7 @@ import com.dylibso.chicory.wasm.types.PassiveDataSegment;
 import com.dylibso.chicory.wasm.types.Value;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
@@ -117,12 +118,36 @@ public final class Memory {
         write(dest, segment.data(), offset, size);
     }
 
+    public void writeString(int offset, String data, Charset charSet) {
+        write(offset, data.getBytes(charSet));
+    }
+
     public void writeString(int offset, String data) {
-        write(offset, data.getBytes(StandardCharsets.UTF_8));
+        writeString(offset, data, StandardCharsets.UTF_8);
     }
 
     public String readString(int addr, int len) {
-        return new String(readBytes(addr, len), StandardCharsets.UTF_8);
+        return readString(addr, len, StandardCharsets.UTF_8);
+    }
+
+    public String readString(int addr, int len, Charset charSet) {
+        return new String(readBytes(addr, len), charSet);
+    }
+
+    public void writeCString(int offset, String str) {
+        writeString(offset, str + '\0');
+    }
+
+    public String readCString(int addr, Charset charSet) {
+        int c = addr;
+        while (read(c) != '\0') {
+            c++;
+        }
+        return new String(readBytes(addr, c - addr), charSet);
+    }
+
+    public String readCString(int addr) {
+        return readCString(addr, StandardCharsets.UTF_8);
     }
 
     public void write(int addr, byte[] data) {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
@@ -135,7 +135,11 @@ public final class Memory {
     }
 
     public void writeCString(int offset, String str) {
-        writeString(offset, str + '\0');
+        writeCString(offset, str, StandardCharsets.UTF_8);
+    }
+
+    public void writeCString(int offset, String str, Charset charSet) {
+        writeString(offset, str + '\0', charSet);
     }
 
     public String readCString(int addr, Charset charSet) {


### PR DESCRIPTION
When interfacing with a libsqlite, i realized we don't really expose some of the types and interfaces that would make interoping with C simpler. This doesn't really address that but just adds some improvements around how we expose reading and writing strings (and adds support for c strings).

Perhaps a longer term solution would be to provide some wrapper interfaces that can wrap the memory. It would be nice to do things like, return a pointer which has these reader and writer methods on it. Like an FFI interface. But i'm not sure that belongs in the Memory class and I think that's a broader tasks. It could get bloated.