### PR TITLE
[chore] use fileName in wat2wasm

### DIFF
--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
@@ -60,7 +60,7 @@ public final class Wat2Wasm {
 
                 Path target = fs.getPath("tmp");
                 java.nio.file.Files.createDirectory(target);
-                Path path = target.resolve("test.wast");
+                Path path = target.resolve(fileName);
                 copy(is, path, StandardCopyOption.REPLACE_EXISTING);
 
                 WasiOptions wasiOpts =


### PR DESCRIPTION
I noticed it in the IDE, just a nitpick :slightly_smiling_face: 