### PR TITLE
Cleaner separation in Module.Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Now we just need to pass this host function in during our instantiation phase:
 ```java
 import com.dylibso.chicory.runtime.HostImports;
 var imports = new HostImports(new HostFunction[] {func});
-var instance = Module.builder(new File("./logger.wasm")).build().withHostImports(imports).instantiate();
+var instance = Module.builder(new File("./logger.wasm")).withHostImports(imports).build().instantiate();
 var logIt = instance.export("logIt");
 logIt.apply();
 // should print "Hello, World!" 10 times

--- a/aot/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/aot/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -69,9 +69,14 @@ public class TestModule {
     }
 
     public TestModule build() {
-        if (this.module == null) {
-            this.module = builder.build();
-        }
+        this.module =
+                builder.withInitialize(false)
+                        .withStart(false)
+                        // TODO: enable me!
+                        .withTypeValidation(false)
+                        .withHostImports(imports)
+                        .withMachineFactory(instance -> new AotMachine(module, instance))
+                        .build();
         return this;
     }
 
@@ -87,12 +92,7 @@ public class TestModule {
 
     public TestModule instantiate() {
         if (this.instance == null) {
-            this.instance =
-                    module.withMachineFactory(instance -> new AotMachine(module, instance))
-                            .withInitialize(false)
-                            .withStart(false)
-                            .withHostImports(imports)
-                            .instantiate();
+            this.instance = module.instantiate();
         }
         return this;
     }

--- a/cli/src/main/java/com/dylibso/chicory/cli/Cli.java
+++ b/cli/src/main/java/com/dylibso/chicory/cli/Cli.java
@@ -61,12 +61,18 @@ public class Cli implements Runnable {
                 wasi
                         ? new HostImports(
                                 new WasiPreview1(
-                                                module.logger(),
+                                                logger,
                                                 WasiOptions.builder().inheritSystem().build())
                                         .toHostFunctions())
                         : new HostImports();
         var instance =
-                module.withInitialize(true).withStart(false).withHostImports(imports).instantiate();
+                Module.builder(file)
+                        .withLogger(logger)
+                        .withInitialize(true)
+                        .withStart(false)
+                        .withHostImports(imports)
+                        .build()
+                        .instantiate();
 
         if (functionName != null) {
             var exportSig = module.export(functionName);

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -12,7 +12,6 @@ public class TestModule {
 
     private Module.Builder builder;
     private Module module;
-
     private Instance instance;
 
     private HostImports imports;
@@ -68,9 +67,12 @@ public class TestModule {
     }
 
     public TestModule build() {
-        if (this.module == null) {
-            this.module = builder.build();
-        }
+        this.module =
+                builder.withInitialize(false)
+                        .withStart(false)
+                        .withTypeValidation(typeValidation)
+                        .withHostImports(imports)
+                        .build();
         return this;
     }
 
@@ -86,12 +88,7 @@ public class TestModule {
 
     public TestModule instantiate() {
         if (this.instance == null) {
-            this.instance =
-                    module.withInitialize(false)
-                            .withStart(false)
-                            .withHostImports(imports)
-                            .withTypeValidation(typeValidation)
-                            .instantiate();
+            this.instance = module.instantiate();
         }
         return this;
     }

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
@@ -93,8 +93,8 @@ public class ModuleTest {
         var funcs = new HostFunction[] {func};
         var instance =
                 Module.builder("compiled/host-function.wat.wasm")
-                        .build()
                         .withHostImports(new HostImports(funcs))
+                        .build()
                         .instantiate();
         var logIt = instance.export("logIt");
         logIt.apply();
@@ -143,8 +143,11 @@ public class ModuleTest {
                         List.of(ValueType.I32),
                         List.of());
         var funcs = new HostFunction[] {func};
-        var module = Module.builder("compiled/start.wat.wasm").build();
-        module.withHostImports(new HostImports(funcs)).instantiate();
+        var module =
+                Module.builder("compiled/start.wat.wasm")
+                        .withHostImports(new HostImports(funcs))
+                        .build();
+        module.instantiate();
 
         assertTrue(count.get() > 0);
     }
@@ -283,14 +286,17 @@ public class ModuleTest {
                         List.of());
         var memory = new HostMemory("env", "memory", new Memory(new MemoryLimits(1)));
 
-        var module = Module.builder("compiled/mixed-imports.wat.wasm").build();
         var hostImports =
                 new HostImports(
                         new HostFunction[] {cbrtFunc, logFunc},
                         new HostGlobal[0],
                         memory,
                         new HostTable[0]);
-        var instance = module.withHostImports(hostImports).instantiate();
+        var module =
+                Module.builder("compiled/mixed-imports.wat.wasm")
+                        .withHostImports(hostImports)
+                        .build();
+        var instance = module.instantiate();
 
         var run = instance.export("main");
         run.apply();
@@ -324,14 +330,14 @@ public class ModuleTest {
     @Test
     public void shouldCountNumberOfInstructions() {
         AtomicLong count = new AtomicLong(0);
-        var module =
+        var instance =
                 Module.builder("compiled/iterfact.wat.wasm")
-                        .build()
                         .withUnsafeExecutionListener(
                                 (Instruction instruction, long[] operands, MStack stack) ->
                                         count.getAndIncrement())
+                        .build()
                         .instantiate();
-        var iterFact = module.export("iterFact");
+        var iterFact = instance.export("iterFact");
 
         iterFact.apply(Value.i32(100));
 
@@ -345,8 +351,8 @@ public class ModuleTest {
         assertDoesNotThrow(
                 () ->
                         Module.builder("compiled/i32.wat.wasm")
-                                .build()
                                 .withTypeValidation(true)
+                                .build()
                                 .instantiate());
     }
 }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
@@ -358,8 +358,6 @@ public class JavaTestGen {
                         + "\")"
                         + additionalParam
                         + ")\n"
-                        + INDENT
-                        + ".build()\n"
                         + ((excludeInvalid) ? "" : INDENT + ".withTypeValidation(true)\n")
                         + ((hostFuncs != null)
                                 ? INDENT
@@ -369,6 +367,8 @@ public class JavaTestGen {
                                         + hostFuncs
                                         + "())\n"
                                 : "")
+                        + INDENT
+                        + ".build()\n"
                         + INDENT
                         + ".instantiate()\n"
                         + INDENT

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
@@ -33,6 +33,12 @@ public class Wast2Json {
                     return false;
                 }
             };
+    private static final com.dylibso.chicory.wasm.Module wasmModule =
+            Module.builder(Wast2Json.class.getResourceAsStream("/wast2json"))
+                    .withInitialize(false)
+                    .withStart(false)
+                    .build()
+                    .wasmModule();
 
     private final File input;
     private final File output;
@@ -49,7 +55,6 @@ public class Wast2Json {
     }
 
     public void process() {
-        Module module = Module.builder(getClass().getResourceAsStream("/wast2json")).build();
         try (ByteArrayOutputStream stdoutStream = new ByteArrayOutputStream();
                 ByteArrayOutputStream stderrStream = new ByteArrayOutputStream()) {
             try (FileInputStream fis = new FileInputStream(input);
@@ -84,7 +89,8 @@ public class Wast2Json {
 
                 try (var wasi = new WasiPreview1(logger, wasiOpts.build())) {
                     HostImports imports = new HostImports(wasi.toHostFunctions());
-                    module.withHostImports(imports).instantiate();
+                    Module module = Module.builder(wasmModule).withHostImports(imports).build();
+                    module.instantiate();
                 }
 
                 createDirectories(output.toPath().getParent());

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
@@ -29,6 +29,12 @@ import java.util.List;
 
 public final class Wat2Wasm {
     private static final Logger logger = new SystemLogger();
+    private static final com.dylibso.chicory.wasm.Module wasmModule =
+            Module.builder(Wat2Wasm.class.getResourceAsStream("/wat2wasm"))
+                    .withInitialize(false)
+                    .withStart(false)
+                    .build()
+                    .wasmModule();
 
     private Wat2Wasm() {}
 
@@ -49,8 +55,6 @@ public final class Wat2Wasm {
     }
 
     private static byte[] parse(InputStream is, String fileName) {
-        Module module = Module.builder(Wat2Wasm.class.getResourceAsStream("/wat2wasm")).build();
-
         try (ByteArrayOutputStream stdoutStream = new ByteArrayOutputStream();
                 ByteArrayOutputStream stderrStream = new ByteArrayOutputStream()) {
 
@@ -73,7 +77,8 @@ public final class Wat2Wasm {
 
                 try (var wasi = new WasiPreview1(logger, wasiOpts)) {
                     HostImports imports = new HostImports(wasi.toHostFunctions());
-                    module.withHostImports(imports).instantiate();
+                    Module module = Module.builder(wasmModule).withHostImports(imports).build();
+                    module.instantiate();
                 }
 
                 return stdoutStream.toByteArray();

--- a/wabt/src/test/java/com/dylibso/chicory/wabt/Wat2WasmTest.java
+++ b/wabt/src/test/java/com/dylibso/chicory/wabt/Wat2WasmTest.java
@@ -28,10 +28,10 @@ public class Wat2WasmTest {
                                         "(module (func (export \"add\") (param $x i32) (param $y"
                                                 + " i32) (result i32) (i32.add (local.get $x)"
                                                 + " (local.get $y))))"))
-                        .build()
                         .withTypeValidation(true)
-                        .instantiate()
-                        .initialize(true);
+                        .withInitialize(true)
+                        .build()
+                        .instantiate();
 
         var addFunction = moduleInstance.export("add");
         var results =

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
@@ -20,8 +20,9 @@ public class WasiPreview1Test {
         var wasi =
                 new WasiPreview1(this.logger, WasiOptions.builder().withStdout(fakeStdout).build());
         var imports = new HostImports(wasi.toHostFunctions());
-        var module = Module.builder("compiled/hello-wasi.wat.wasm").build();
-        module.withHostImports(imports).instantiate();
+        var module =
+                Module.builder("compiled/hello-wasi.wat.wasm").withHostImports(imports).build();
+        module.instantiate();
         assertEquals(fakeStdout.output().strip(), "hello world");
     }
 
@@ -32,8 +33,8 @@ public class WasiPreview1Test {
         var stdout = new MockPrintStream();
         var wasi = new WasiPreview1(this.logger, WasiOptions.builder().withStdout(stdout).build());
         var imports = new HostImports(wasi.toHostFunctions());
-        var module = Module.builder("compiled/hello-wasi.rs.wasm").build();
-        module.withHostImports(imports).instantiate(); // run _start and prints Hello, World!
+        var module = Module.builder("compiled/hello-wasi.rs.wasm").withHostImports(imports).build();
+        module.instantiate(); // run _start and prints Hello, World!
         assertEquals(expected, stdout.output().strip());
     }
 
@@ -44,8 +45,8 @@ public class WasiPreview1Test {
         var wasiOpts = WasiOptions.builder().withStdout(System.out).withStdin(fakeStdin).build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
         var imports = new HostImports(wasi.toHostFunctions());
-        var module = Module.builder("compiled/greet-wasi.rs.wasm").build();
-        module.withHostImports(imports).instantiate();
+        var module = Module.builder("compiled/greet-wasi.rs.wasm").withHostImports(imports).build();
+        module.instantiate();
     }
 
     @Test
@@ -57,8 +58,9 @@ public class WasiPreview1Test {
         var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).withStdin(fakeStdin).build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
         var imports = new HostImports(wasi.toHostFunctions());
-        var module = Module.builder("compiled/javy-demo.js.javy.wasm").build();
-        module.withHostImports(imports).instantiate();
+        var module =
+                Module.builder("compiled/javy-demo.js.javy.wasm").withHostImports(imports).build();
+        module.instantiate();
 
         assertEquals(fakeStdout.output(), "{\"foo\":3,\"newBar\":\"baz!\"}");
     }
@@ -68,8 +70,8 @@ public class WasiPreview1Test {
         var wasiOpts = WasiOptions.builder().build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
         var imports = new HostImports(wasi.toHostFunctions());
-        var module = Module.builder("compiled/sum.go.tiny.wasm").build();
-        var instance = module.withHostImports(imports).instantiate();
+        var module = Module.builder("compiled/sum.go.tiny.wasm").withHostImports(imports).build();
+        var instance = module.instantiate();
         var sum = instance.export("add");
         var result = sum.apply(Value.i32(20), Value.i32(22))[0];
 

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiTestRunner.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiTestRunner.java
@@ -81,8 +81,11 @@ public final class WasiTestRunner {
 
     private static int execute(File test, WasiOptions wasiOptions) {
         try (var wasi = new WasiPreview1(LOGGER, wasiOptions)) {
-            Module module = Module.builder(test).build();
-            module.withHostImports(new HostImports(wasi.toHostFunctions())).instantiate();
+            Module module =
+                    Module.builder(test)
+                            .withHostImports(new HostImports(wasi.toHostFunctions()))
+                            .build();
+            module.instantiate();
         } catch (WASMMachineException e) {
             if (e.getCause() instanceof WasiExitException) {
                 return ((WasiExitException) e.getCause()).exitCode();

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -74,7 +74,7 @@ public final class Parser {
     }
 
     public Parser(Logger logger, BitSet includeSections) {
-        this(logger, includeSections, Map.of("name", NameCustomSection::new));
+        this(logger, includeSections, Map.of("name", NameCustomSection::parse));
     }
 
     public Parser(
@@ -502,10 +502,7 @@ public final class Parser {
     }
 
     private static StartSection parseStartSection(ByteBuffer buffer) {
-
-        var startSection = new StartSection();
-        startSection.setStartIndex(readVarUInt32(buffer));
-        return startSection;
+        return new StartSection(readVarUInt32(buffer));
     }
 
     private static ElementSection parseElementSection(ByteBuffer buffer, long sectionSize) {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionSection.java
@@ -1,17 +1,16 @@
 package com.dylibso.chicory.wasm.types;
 
-import java.util.Arrays;
-import java.util.Objects;
+import java.util.ArrayList;
+import java.util.List;
 
 public class FunctionSection extends Section {
-    private int[] typeIndices;
-    private int count;
+    private final List<Integer> typeIndices;
 
     /**
      * Construct a new, empty section instance.
      */
     public FunctionSection() {
-        this(new int[8]);
+        this(new ArrayList());
     }
 
     /**
@@ -20,22 +19,20 @@ public class FunctionSection extends Section {
      * @param estimatedSize the estimated number of functions to reserve space for
      */
     public FunctionSection(int estimatedSize) {
-        this(new int[Math.max(8, estimatedSize)]);
+        this(new ArrayList<>(estimatedSize));
     }
 
-    private FunctionSection(int[] typeIndices) {
+    private FunctionSection(ArrayList<Integer> typeIndices) {
         super(SectionId.FUNCTION);
         this.typeIndices = typeIndices;
-        count = 0;
-    }
-
-    public int functionCount() {
-        return count;
     }
 
     public int getFunctionType(int idx) {
-        Objects.checkIndex(idx, count);
-        return typeIndices[idx];
+        return typeIndices.get(idx);
+    }
+
+    public int functionCount() {
+        return typeIndices.size();
     }
 
     public FunctionType getFunctionType(int idx, TypeSection typeSection) {
@@ -49,12 +46,8 @@ public class FunctionSection extends Section {
      * @return the index of the function whose type index was added
      */
     public int addFunctionType(int typeIndex) {
-        int count = this.count;
-        if (count == typeIndices.length) {
-            typeIndices = Arrays.copyOf(typeIndices, count + (count >> 1));
-        }
-        typeIndices[count] = typeIndex;
-        this.count = count + 1;
-        return count;
+        int idx = typeIndices.size();
+        typeIndices.add(typeIndex);
+        return idx;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/StartSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/StartSection.java
@@ -1,17 +1,14 @@
 package com.dylibso.chicory.wasm.types;
 
 public class StartSection extends Section {
-    private long startIndex;
+    private final long startIndex;
 
-    public StartSection() {
+    public StartSection(long startIndex) {
         super(SectionId.START);
+        this.startIndex = startIndex;
     }
 
     public long startIndex() {
         return startIndex;
-    }
-
-    public void setStartIndex(long startIndex) {
-        this.startIndex = startIndex;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Table.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Table.java
@@ -1,15 +1,10 @@
 package com.dylibso.chicory.wasm.types;
 
-import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
-
-import com.dylibso.chicory.wasm.exceptions.ChicoryException;
-import java.util.Arrays;
 import java.util.Objects;
 
 public class Table {
     private final ValueType elementType;
     private final Limits limits;
-    private int[] refs;
 
     public Table(final ValueType elementType, final Limits limits) {
         this.elementType = Objects.requireNonNull(elementType, "elementType");
@@ -17,8 +12,6 @@ public class Table {
             throw new IllegalArgumentException("Table element type must be a reference type");
         }
         this.limits = Objects.requireNonNull(limits, "limits");
-        refs = new int[(int) limits.min()];
-        Arrays.fill(refs, REF_NULL_VALUE);
     }
 
     public ValueType elementType() {
@@ -27,49 +20,5 @@ public class Table {
 
     public Limits limits() {
         return limits;
-    }
-
-    public int size() {
-        return refs.length;
-    }
-
-    public int grow(int size, int value) {
-        var oldSize = refs.length;
-        var targetSize = oldSize + size;
-        if (size < 0 || targetSize > limits().max()) {
-            return -1;
-        }
-        var newRefs = Arrays.copyOf(refs, targetSize);
-        Arrays.fill(newRefs, oldSize, targetSize, value);
-        refs = newRefs;
-        return oldSize;
-    }
-
-    public Value ref(int index) {
-        int res;
-        try {
-            res = this.refs[index];
-        } catch (IndexOutOfBoundsException e) {
-            throw new ChicoryException("undefined element", e);
-        }
-        if (this.elementType() == ValueType.FuncRef) {
-            return Value.funcRef(res);
-        } else {
-            return Value.externRef(res);
-        }
-    }
-
-    public void setRef(int index, int value) {
-        try {
-            this.refs[index] = value;
-        } catch (IndexOutOfBoundsException e) {
-            throw new ChicoryException("out of bounds table access", e);
-        }
-    }
-
-    public void reset() {
-        for (int i = 0; i < refs.length; i++) {
-            this.refs[i] = REF_NULL_VALUE;
-        }
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -20,7 +20,7 @@ public class Value {
 
     private final ValueType type;
 
-    private long data;
+    private final long data;
 
     public static Value fromFloat(float data) {
         return Value.f32(Float.floatToRawIntBits(data));


### PR DESCRIPTION
Suggestion from @lburgazzoli , these changes makes the builder API for building modules much nicer and better defined.
The `runtime.Module` class is now immutable and this should fix #344 if I'm not missing details.

To be able to re-use(hence memoize) Parsed WASM Modules I added a builder from `wasm.Module`, this way one can instantiate a "dummy" module and re-use it; the usage is in the `wabt` tools module.
