### PR TITLE
Implement more AOT opcodes

### DIFF
--- a/aot/pom.xml
+++ b/aot/pom.xml
@@ -77,7 +77,11 @@
             <wast>inline-module.wast</wast>
             <wast>int_exprs.wast</wast>
             <wast>int_literals.wast</wast>
+            <wast>memory_size.wast</wast>
+            <wast>ref_null.wast</wast>
             <wast>table.wast</wast>
+            <wast>table_fill.wast</wast>
+            <wast>table_size.wast</wast>
             <wast>token.wast</wast>
             <wast>traps.wast</wast>
             <wast>type.wast</wast>
@@ -189,13 +193,11 @@
             <wast>memory_grow.wast</wast>
             <wast>memory_init.wast</wast>
             <wast>memory_redundancy.wast</wast>
-            <wast>memory_size.wast</wast>
             <wast>memory_trap.wast</wast>
             <wast>names.wast</wast>
             <wast>nop.wast</wast>
             <wast>ref_func.wast</wast>
             <wast>ref_is_null.wast</wast>
-            <wast>ref_null.wast</wast>
             <wast>return.wast</wast>
             <wast>select.wast</wast>
 
@@ -266,12 +268,10 @@
             <wast>switch.wast</wast>
             <wast>table-sub.wast</wast>
             <wast>table_copy.wast</wast>
-            <wast>table_fill.wast</wast>
             <wast>table_get.wast</wast>
             <wast>table_grow.wast</wast>
             <wast>table_init.wast</wast>
             <wast>table_set.wast</wast>
-            <wast>table_size.wast</wast>
             <wast>tokens.wast</wast>
             <wast>unreachable.wast</wast>
             <wast>unreached-invalid.wast</wast>

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotContext.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotContext.java
@@ -19,8 +19,6 @@ public class AotContext {
     protected final FunctionBody body;
     protected final List<Integer> slots;
     protected final int memorySlot;
-    protected final int longSlot;
-    protected final int doubleSlot;
     protected final Deque<StackSize> stackSizes = new ArrayDeque<>();
 
     public AotContext(int funcId, FunctionType type, FunctionBody body) {
@@ -29,8 +27,6 @@ public class AotContext {
         this.body = body;
         this.slots = computeSlots(type, body);
         this.memorySlot = slots.get(slots.size() - 1);
-        this.longSlot = memorySlot + 1;
-        this.doubleSlot = longSlot + 2;
     }
 
     public int getId() {
@@ -51,14 +47,6 @@ public class AotContext {
 
     public int memorySlot() {
         return memorySlot;
-    }
-
-    public int longSlot() {
-        return longSlot;
-    }
-
-    public int doubleSlot() {
-        return doubleSlot;
     }
 
     public Deque<StackSize> stackSizes() {

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotContext.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotContext.java
@@ -14,19 +14,28 @@ import java.util.List;
  */
 public class AotContext {
 
+    protected final List<ValueType> globalTypes;
     protected final int funcId;
     protected final FunctionType type;
     protected final FunctionBody body;
     protected final List<Integer> slots;
     protected final int memorySlot;
+    protected final int instanceSlot;
     protected final Deque<StackSize> stackSizes = new ArrayDeque<>();
 
-    public AotContext(int funcId, FunctionType type, FunctionBody body) {
+    public AotContext(
+            List<ValueType> globalTypes, int funcId, FunctionType type, FunctionBody body) {
+        this.globalTypes = globalTypes;
         this.funcId = funcId;
         this.type = type;
         this.body = body;
         this.slots = computeSlots(type, body);
         this.memorySlot = slots.get(slots.size() - 1);
+        this.instanceSlot = memorySlot + 1;
+    }
+
+    public List<ValueType> globalTypes() {
+        return globalTypes;
     }
 
     public int getId() {
@@ -47,6 +56,10 @@ public class AotContext {
 
     public int memorySlot() {
         return memorySlot;
+    }
+
+    public int instanceSlot() {
+        return instanceSlot;
     }
 
     public Deque<StackSize> stackSizes() {
@@ -87,6 +100,8 @@ public class AotContext {
         switch (type) {
             case I32:
             case F32:
+            case ExternRef:
+            case FuncRef:
                 return 1;
             case I64:
             case F64:

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
@@ -412,28 +412,15 @@ public class AotEmitters {
     }
 
     public static void I64_STORE(AotContext ctx, Instruction ins, MethodVisitor asm) {
-        emitX64StoreSetup(ctx, ins, asm);
-
-        // memory.writeLong(address, value)
-        asm.visitVarInsn(Opcodes.LSTORE, ctx.longSlot());
-        asm.visitVarInsn(Opcodes.ALOAD, ctx.memorySlot());
-        asm.visitInsn(Opcodes.SWAP);
-        asm.visitVarInsn(Opcodes.LLOAD, ctx.longSlot());
-        emitInvokeVirtual(asm, MEMORY_WRITE_LONG);
+        emitX64Store(ctx, ins, asm, MEMORY_WRITE_LONG);
     }
 
     public static void F64_STORE(AotContext ctx, Instruction ins, MethodVisitor asm) {
-        emitX64StoreSetup(ctx, ins, asm);
-
-        // memory.writeF64(address, value)
-        asm.visitVarInsn(Opcodes.DSTORE, ctx.doubleSlot());
-        asm.visitVarInsn(Opcodes.ALOAD, ctx.memorySlot());
-        asm.visitInsn(Opcodes.SWAP);
-        asm.visitVarInsn(Opcodes.DLOAD, ctx.doubleSlot());
-        emitInvokeVirtual(asm, MEMORY_WRITE_DOUBLE);
+        emitX64Store(ctx, ins, asm, MEMORY_WRITE_DOUBLE);
     }
 
-    private static void emitX64StoreSetup(AotContext ctx, Instruction ins, MethodVisitor asm) {
+    private static void emitX64Store(
+            AotContext ctx, Instruction ins, MethodVisitor asm, Method method) {
         long offset = ins.operands()[1];
         emitThrowIfInvalidOffset(asm, offset);
 
@@ -447,9 +434,9 @@ public class AotEmitters {
         asm.visitLdcInsn((int) offset);
         asm.visitInsn(Opcodes.IADD);
 
-        // move value to top of stack
-        asm.visitInsn(Opcodes.DUP_X2);
-        asm.visitInsn(Opcodes.POP);
+        // memory.writeType(address, value)
+        asm.visitVarInsn(Opcodes.ALOAD, ctx.memorySlot());
+        emitInvokeStatic(asm, method);
     }
 
     /**

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
@@ -35,9 +35,13 @@ public final class AotMethods {
             MEMORY_WRITE_BYTE = Memory.class.getMethod("writeByte", int.class, byte.class);
             MEMORY_WRITE_SHORT = Memory.class.getMethod("writeShort", int.class, short.class);
             MEMORY_WRITE_INT = Memory.class.getMethod("writeI32", int.class, int.class);
-            MEMORY_WRITE_LONG = Memory.class.getMethod("writeLong", int.class, long.class);
+            MEMORY_WRITE_LONG =
+                    AotMethods.class.getMethod(
+                            "memoryWriteLong", long.class, int.class, Memory.class);
             MEMORY_WRITE_FLOAT = Memory.class.getMethod("writeF32", int.class, float.class);
-            MEMORY_WRITE_DOUBLE = Memory.class.getMethod("writeF64", int.class, double.class);
+            MEMORY_WRITE_DOUBLE =
+                    AotMethods.class.getMethod(
+                            "memoryWriteDouble", double.class, int.class, Memory.class);
             VALIDATE_BASE = AotMethods.class.getMethod("validateBase", int.class);
             THROW_OUT_OF_BOUNDS_MEMORY_ACCESS =
                     AotMethods.class.getMethod("throwOutOfBoundsMemoryAccess");
@@ -48,6 +52,16 @@ public final class AotMethods {
     }
 
     private AotMethods() {}
+
+    @UsedByGeneratedCode
+    public static void memoryWriteLong(long value, int address, Memory memory) {
+        memory.writeLong(address, value);
+    }
+
+    @UsedByGeneratedCode
+    public static void memoryWriteDouble(double value, int address, Memory memory) {
+        memory.writeF64(address, value);
+    }
 
     @UsedByGeneratedCode
     public static void validateBase(int base) {

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
@@ -1,0 +1,68 @@
+package com.dylibso.chicory.aot;
+
+import com.dylibso.chicory.runtime.Memory;
+import com.dylibso.chicory.runtime.TrapException;
+import com.dylibso.chicory.runtime.exceptions.WASMRuntimeException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+public final class AotMethods {
+
+    static final Method MEMORY_READ_BYTE;
+    static final Method MEMORY_READ_SHORT;
+    static final Method MEMORY_READ_INT;
+    static final Method MEMORY_READ_LONG;
+    static final Method MEMORY_READ_FLOAT;
+    static final Method MEMORY_READ_DOUBLE;
+    static final Method MEMORY_WRITE_BYTE;
+    static final Method MEMORY_WRITE_SHORT;
+    static final Method MEMORY_WRITE_INT;
+    static final Method MEMORY_WRITE_LONG;
+    static final Method MEMORY_WRITE_FLOAT;
+    static final Method MEMORY_WRITE_DOUBLE;
+    static final Method VALIDATE_BASE;
+    static final Method THROW_OUT_OF_BOUNDS_MEMORY_ACCESS;
+    static final Method THROW_TRAP_EXCEPTION;
+
+    static {
+        try {
+            MEMORY_READ_BYTE = Memory.class.getMethod("read", int.class);
+            MEMORY_READ_SHORT = Memory.class.getMethod("readShort", int.class);
+            MEMORY_READ_INT = Memory.class.getMethod("readInt", int.class);
+            MEMORY_READ_LONG = Memory.class.getMethod("readLong", int.class);
+            MEMORY_READ_FLOAT = Memory.class.getMethod("readFloat", int.class);
+            MEMORY_READ_DOUBLE = Memory.class.getMethod("readDouble", int.class);
+            MEMORY_WRITE_BYTE = Memory.class.getMethod("writeByte", int.class, byte.class);
+            MEMORY_WRITE_SHORT = Memory.class.getMethod("writeShort", int.class, short.class);
+            MEMORY_WRITE_INT = Memory.class.getMethod("writeI32", int.class, int.class);
+            MEMORY_WRITE_LONG = Memory.class.getMethod("writeLong", int.class, long.class);
+            MEMORY_WRITE_FLOAT = Memory.class.getMethod("writeF32", int.class, float.class);
+            MEMORY_WRITE_DOUBLE = Memory.class.getMethod("writeF64", int.class, double.class);
+            VALIDATE_BASE = AotMethods.class.getMethod("validateBase", int.class);
+            THROW_OUT_OF_BOUNDS_MEMORY_ACCESS =
+                    AotMethods.class.getMethod("throwOutOfBoundsMemoryAccess");
+            THROW_TRAP_EXCEPTION = AotMethods.class.getMethod("throwTrapException");
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private AotMethods() {}
+
+    @UsedByGeneratedCode
+    public static void validateBase(int base) {
+        if (base < 0) {
+            throwOutOfBoundsMemoryAccess();
+        }
+    }
+
+    @UsedByGeneratedCode
+    public static RuntimeException throwOutOfBoundsMemoryAccess() {
+        throw new WASMRuntimeException("out of bounds memory access");
+    }
+
+    @UsedByGeneratedCode
+    public static RuntimeException throwTrapException() {
+        throw new TrapException("Trapped on unreachable instruction", List.of());
+    }
+}

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
@@ -1,13 +1,28 @@
 package com.dylibso.chicory.aot;
 
+import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
+
+import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Memory;
+import com.dylibso.chicory.runtime.OpcodeImpl;
 import com.dylibso.chicory.runtime.TrapException;
 import com.dylibso.chicory.runtime.exceptions.WASMRuntimeException;
+import com.dylibso.chicory.wasm.types.Element;
+import com.dylibso.chicory.wasm.types.Value;
 import java.lang.reflect.Method;
 import java.util.List;
 
 public final class AotMethods {
 
+    static final Method INSTANCE_READ_GLOBAL;
+    static final Method INSTANCE_WRITE_GLOBAL;
+    static final Method INSTANCE_SET_ELEMENT;
+    static final Method MEMORY_COPY;
+    static final Method MEMORY_FILL;
+    static final Method MEMORY_INIT;
+    static final Method MEMORY_GROW;
+    static final Method MEMORY_DROP;
+    static final Method MEMORY_PAGES;
     static final Method MEMORY_READ_BYTE;
     static final Method MEMORY_READ_SHORT;
     static final Method MEMORY_READ_INT;
@@ -20,12 +35,35 @@ public final class AotMethods {
     static final Method MEMORY_WRITE_LONG;
     static final Method MEMORY_WRITE_FLOAT;
     static final Method MEMORY_WRITE_DOUBLE;
+    static final Method REF_IS_NULL;
+    static final Method TABLE_GET;
+    static final Method TABLE_SET;
+    static final Method TABLE_SIZE;
+    static final Method TABLE_GROW;
+    static final Method TABLE_FILL;
+    static final Method TABLE_COPY;
+    static final Method TABLE_INIT;
     static final Method VALIDATE_BASE;
     static final Method THROW_OUT_OF_BOUNDS_MEMORY_ACCESS;
     static final Method THROW_TRAP_EXCEPTION;
 
     static {
         try {
+            INSTANCE_READ_GLOBAL = Instance.class.getMethod("readGlobal", int.class);
+            INSTANCE_WRITE_GLOBAL = Instance.class.getMethod("writeGlobal", int.class, Value.class);
+            INSTANCE_SET_ELEMENT = Instance.class.getMethod("setElement", int.class, Element.class);
+            MEMORY_COPY =
+                    AotMethods.class.getMethod(
+                            "memoryCopy", int.class, int.class, int.class, Memory.class);
+            MEMORY_FILL =
+                    AotMethods.class.getMethod(
+                            "memoryFill", int.class, byte.class, int.class, Memory.class);
+            MEMORY_INIT =
+                    AotMethods.class.getMethod(
+                            "memoryInit", int.class, int.class, int.class, int.class, Memory.class);
+            MEMORY_GROW = Memory.class.getMethod("grow", int.class);
+            MEMORY_DROP = Memory.class.getMethod("drop", int.class);
+            MEMORY_PAGES = Memory.class.getMethod("pages");
             MEMORY_READ_BYTE = Memory.class.getMethod("read", int.class);
             MEMORY_READ_SHORT = Memory.class.getMethod("readShort", int.class);
             MEMORY_READ_INT = Memory.class.getMethod("readInt", int.class);
@@ -42,6 +80,42 @@ public final class AotMethods {
             MEMORY_WRITE_DOUBLE =
                     AotMethods.class.getMethod(
                             "memoryWriteDouble", double.class, int.class, Memory.class);
+            REF_IS_NULL = AotMethods.class.getMethod("isRefNull", int.class);
+            TABLE_GET =
+                    AotMethods.class.getMethod("tableGet", int.class, int.class, Instance.class);
+            TABLE_SET =
+                    AotMethods.class.getMethod(
+                            "tableSet", int.class, int.class, int.class, Instance.class);
+            TABLE_SIZE = AotMethods.class.getMethod("tableSize", int.class, Instance.class);
+            TABLE_GROW =
+                    AotMethods.class.getMethod(
+                            "tableGrow", int.class, int.class, int.class, Instance.class);
+            TABLE_FILL =
+                    AotMethods.class.getMethod(
+                            "tableFill",
+                            int.class,
+                            int.class,
+                            int.class,
+                            int.class,
+                            Instance.class);
+            TABLE_COPY =
+                    AotMethods.class.getMethod(
+                            "tableCopy",
+                            int.class,
+                            int.class,
+                            int.class,
+                            int.class,
+                            int.class,
+                            Instance.class);
+            TABLE_INIT =
+                    AotMethods.class.getMethod(
+                            "tableInit",
+                            int.class,
+                            int.class,
+                            int.class,
+                            int.class,
+                            int.class,
+                            Instance.class);
             VALIDATE_BASE = AotMethods.class.getMethod("validateBase", int.class);
             THROW_OUT_OF_BOUNDS_MEMORY_ACCESS =
                     AotMethods.class.getMethod("throwOutOfBoundsMemoryAccess");
@@ -52,6 +126,66 @@ public final class AotMethods {
     }
 
     private AotMethods() {}
+
+    @UsedByGeneratedCode
+    public static boolean isRefNull(int ref) {
+        return ref == REF_NULL_VALUE;
+    }
+
+    @UsedByGeneratedCode
+    public static int tableGet(int index, int tableIndex, Instance instance) {
+        return OpcodeImpl.TABLE_GET(instance, tableIndex, index).asFuncRef();
+    }
+
+    @UsedByGeneratedCode
+    public static void tableSet(int index, int value, int tableIndex, Instance instance) {
+        instance.table(tableIndex).setRef(index, value, instance);
+    }
+
+    @UsedByGeneratedCode
+    public static int tableGrow(int value, int size, int tableIndex, Instance instance) {
+        return instance.table(tableIndex).grow(size, value, instance);
+    }
+
+    @UsedByGeneratedCode
+    public static int tableSize(int tableIndex, Instance instance) {
+        return instance.table(tableIndex).size();
+    }
+
+    @UsedByGeneratedCode
+    public static void tableFill(
+            int offset, int value, int size, int tableIndex, Instance instance) {
+        OpcodeImpl.TABLE_FILL(instance, tableIndex, size, value, offset);
+    }
+
+    @UsedByGeneratedCode
+    public static void tableCopy(
+            int d, int s, int size, int dstTableIndex, int srcTableIndex, Instance instance) {
+        OpcodeImpl.TABLE_COPY(instance, srcTableIndex, dstTableIndex, size, s, d);
+    }
+
+    @UsedByGeneratedCode
+    public static void tableInit(
+            int offset, int elemidx, int size, int elementidx, int tableidx, Instance instance) {
+        OpcodeImpl.TABLE_INIT(instance, tableidx, elementidx, size, elemidx, offset);
+    }
+
+    @UsedByGeneratedCode
+    public static void memoryCopy(int destination, int offset, int size, Memory memory) {
+        memory.copy(destination, offset, size);
+    }
+
+    @UsedByGeneratedCode
+    public static void memoryFill(int offset, byte value, int size, Memory memory) {
+        int end = size + offset;
+        memory.fill(value, offset, end);
+    }
+
+    @UsedByGeneratedCode
+    public static void memoryInit(
+            int destination, int offset, int size, int segmentId, Memory memory) {
+        memory.initPassiveSegment(segmentId, destination, offset, size);
+    }
 
     @UsedByGeneratedCode
     public static void memoryWriteLong(long value, int address, Memory memory) {

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
@@ -1,5 +1,6 @@
 package com.dylibso.chicory.aot;
 
+import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
 import static org.objectweb.asm.Type.getInternalName;
 import static org.objectweb.asm.Type.getMethodDescriptor;
 
@@ -24,10 +25,14 @@ public class AotUtil {
     private static final Method UNBOX_I64;
     private static final Method UNBOX_F32;
     private static final Method UNBOX_F64;
+    private static final Method UNBOX_EXTREF;
+    private static final Method UNBOX_FUNCREF;
     private static final Method BOX_I32;
     private static final Method BOX_I64;
     private static final Method BOX_F32;
     private static final Method BOX_F64;
+    private static final Method BOX_EXTREF;
+    private static final Method BOX_FUNCREF;
 
     static {
         try {
@@ -35,10 +40,14 @@ public class AotUtil {
             UNBOX_I64 = Value.class.getMethod("asLong");
             UNBOX_F32 = Value.class.getMethod("asFloat");
             UNBOX_F64 = Value.class.getMethod("asDouble");
+            UNBOX_EXTREF = Value.class.getMethod("asExtRef");
+            UNBOX_FUNCREF = Value.class.getMethod("asFuncRef");
             BOX_I32 = Value.class.getMethod("i32", int.class);
             BOX_I64 = Value.class.getMethod("i64", long.class);
             BOX_F32 = Value.class.getMethod("fromFloat", float.class);
             BOX_F64 = Value.class.getMethod("fromDouble", double.class);
+            BOX_EXTREF = Value.class.getMethod("externRef", int.class);
+            BOX_FUNCREF = Value.class.getMethod("funcRef", int.class);
         } catch (NoSuchMethodException e) {
             throw new AssertionError(e);
         }
@@ -47,6 +56,8 @@ public class AotUtil {
     public static Class<?> jvmType(ValueType type) {
         switch (type) {
             case I32:
+            case ExternRef:
+            case FuncRef:
                 return int.class;
             case I64:
                 return long.class;
@@ -77,6 +88,10 @@ public class AotUtil {
                 return UNBOX_F32;
             case F64:
                 return UNBOX_F64;
+            case ExternRef:
+                return UNBOX_EXTREF;
+            case FuncRef:
+                return UNBOX_FUNCREF;
             default:
                 throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
         }
@@ -92,6 +107,10 @@ public class AotUtil {
                 return BOX_F32;
             case F64:
                 return BOX_F64;
+            case ExternRef:
+                return BOX_EXTREF;
+            case FuncRef:
+                return BOX_FUNCREF;
             default:
                 throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
         }
@@ -125,6 +144,9 @@ public class AotUtil {
                 return 0.0f;
             case F64:
                 return 0.0d;
+            case ExternRef:
+            case FuncRef:
+                return REF_NULL_VALUE;
             default:
                 throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
         }

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
@@ -1,11 +1,17 @@
 package com.dylibso.chicory.aot;
 
+import static org.objectweb.asm.Type.getInternalName;
+import static org.objectweb.asm.Type.getMethodDescriptor;
+
 import com.dylibso.chicory.wasm.types.FunctionBody;
 import com.dylibso.chicory.wasm.types.FunctionType;
 import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 
 public class AotUtil {
 
@@ -137,5 +143,26 @@ public class AotUtil {
             return StackSize.TWO;
         }
         throw new IllegalArgumentException("Unsupported JVM type: " + clazz);
+    }
+
+    public static void emitInvokeStatic(MethodVisitor asm, Method method) {
+        assert Modifier.isStatic(method.getModifiers());
+        asm.visitMethodInsn(
+                Opcodes.INVOKESTATIC,
+                getInternalName(method.getDeclaringClass()),
+                method.getName(),
+                getMethodDescriptor(method),
+                false);
+    }
+
+    public static void emitInvokeVirtual(MethodVisitor asm, Method method) {
+        assert !Modifier.isStatic(method.getModifiers());
+        assert !method.getDeclaringClass().isInterface();
+        asm.visitMethodInsn(
+                Opcodes.INVOKEVIRTUAL,
+                getInternalName(method.getDeclaringClass()),
+                method.getName(),
+                getMethodDescriptor(method),
+                false);
     }
 }

--- a/aot/src/main/java/com/dylibso/chicory/aot/HostFunctionInvoker.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/HostFunctionInvoker.java
@@ -1,0 +1,29 @@
+package com.dylibso.chicory.aot;
+
+import static java.lang.invoke.MethodHandles.publicLookup;
+
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasm.types.Value;
+import java.lang.invoke.MethodHandle;
+
+public final class HostFunctionInvoker {
+    public static final MethodHandle HANDLE;
+
+    static {
+        try {
+            HANDLE =
+                    publicLookup()
+                            .unreflect(
+                                    HostFunctionInvoker.class.getMethod(
+                                            "invoke", Instance.class, int.class, Value[].class));
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private HostFunctionInvoker() {}
+
+    public static Value[] invoke(Instance instance, int funcId, Value[] args) {
+        return instance.callHostFunction(funcId, args);
+    }
+}

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ConstantEvaluators.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ConstantEvaluators.java
@@ -51,7 +51,7 @@ public class ConstantEvaluators {
                     }
                 case REF_FUNC:
                     {
-                        tos = Value.funcRef(instruction.operands()[0]);
+                        tos = Value.funcRef((int) instruction.operands()[0]);
                         break;
                     }
                 case GLOBAL_GET:

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -346,6 +346,14 @@ public class Instance {
         return machine;
     }
 
+    public Value[] callHostFunction(int funcId, Value[] args) {
+        var imprt = imports.function(funcId);
+        if (imprt == null) {
+            throw new ChicoryException("Missing host import, number: " + funcId);
+        }
+        return imprt.handle().apply(this, args);
+    }
+
     public void onExecution(Instruction instruction, long[] operands, MStack stack) {
         if (listener != null) {
             listener.onExecution(instruction, operands, stack);

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -186,7 +186,7 @@ public class Instance {
                     globals[i] = new GlobalInstance(Value.EXTREF_NULL);
                     break;
                 case REF_FUNC:
-                    globals[i] = new GlobalInstance(Value.funcRef(instr.operands()[0]));
+                    globals[i] = new GlobalInstance(Value.funcRef((int) instr.operands()[0]));
                     break;
                 default:
                     throw new RuntimeException(

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -62,12 +62,7 @@ class InterpreterMachine implements Machine {
             eval(stack, instance, callStack);
         } else {
             callStack.push(new StackFrame(instance, funcId, args, List.of()));
-            var imprt = instance.imports().function(funcId);
-            if (imprt == null) {
-                throw new ChicoryException("Missing host import, number: " + funcId);
-            }
-            var hostFunc = imprt.handle();
-            var results = hostFunc.apply(instance, args);
+            var results = instance.callHostFunction(funcId, args);
             // a host function can return null or an array of ints
             // which we will push onto the stack
             if (results != null) {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -724,7 +724,7 @@ class InterpreterMachine implements Machine {
                         TABLE_GROW(stack, instance, operands);
                         break;
                     case REF_FUNC:
-                        stack.push(Value.funcRef(operands[0]));
+                        stack.push(Value.funcRef((int) operands[0]));
                         break;
                     case REF_NULL:
                         REF_NULL(stack, operands);

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Module.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Module.java
@@ -23,17 +23,17 @@ import java.util.List;
 public class Module {
     private final HashMap<String, CustomSection> customSections;
 
-    private TypeSection typeSection;
-    private ImportSection importSection;
+    private TypeSection typeSection = new TypeSection();
+    private ImportSection importSection = new ImportSection();
     private FunctionSection functionSection = new FunctionSection();
-    private TableSection tableSection;
+    private TableSection tableSection = new TableSection();
     private MemorySection memorySection;
-    private GlobalSection globalSection;
-    private ExportSection exportSection;
+    private GlobalSection globalSection = new GlobalSection();
+    private ExportSection exportSection = new ExportSection();
     private StartSection startSection;
-    private ElementSection elementSection;
-    private CodeSection codeSection;
-    private DataSection dataSection;
+    private ElementSection elementSection = new ElementSection();
+    private CodeSection codeSection = new CodeSection();
+    private DataSection dataSection = new DataSection();
     private DataCountSection dataCountSection;
 
     public Module() {
@@ -41,7 +41,7 @@ public class Module {
     }
 
     public void setTypeSection(TypeSection typeSection) {
-        this.typeSection = typeSection;
+        this.typeSection = requireNonNull(typeSection);
     }
 
     public void setFunctionSection(FunctionSection functionSection) {
@@ -49,7 +49,7 @@ public class Module {
     }
 
     public void setExportSection(ExportSection exportSection) {
-        this.exportSection = exportSection;
+        this.exportSection = requireNonNull(exportSection);
     }
 
     public TypeSection typeSection() {
@@ -77,7 +77,7 @@ public class Module {
     }
 
     public void setImportSection(ImportSection importSection) {
-        this.importSection = importSection;
+        this.importSection = requireNonNull(importSection);
     }
 
     public CodeSection codeSection() {
@@ -85,11 +85,11 @@ public class Module {
     }
 
     public void setCodeSection(CodeSection codeSection) {
-        this.codeSection = codeSection;
+        this.codeSection = requireNonNull(codeSection);
     }
 
     public void setDataSection(DataSection dataSection) {
-        this.dataSection = dataSection;
+        this.dataSection = requireNonNull(dataSection);
     }
 
     public void setDataCountSection(DataCountSection dataCountSection) {
@@ -117,7 +117,7 @@ public class Module {
     }
 
     public void setGlobalSection(GlobalSection globalSection) {
-        this.globalSection = globalSection;
+        this.globalSection = requireNonNull(globalSection);
     }
 
     public TableSection tableSection() {
@@ -125,7 +125,7 @@ public class Module {
     }
 
     public void setTableSection(TableSection tableSection) {
-        this.tableSection = tableSection;
+        this.tableSection = requireNonNull(tableSection);
     }
 
     public void addCustomSection(CustomSection customSection) {
@@ -149,6 +149,6 @@ public class Module {
     }
 
     public void setElementSection(ElementSection elementSection) {
-        this.elementSection = elementSection;
+        this.elementSection = requireNonNull(elementSection);
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ImportSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ImportSection.java
@@ -40,6 +40,10 @@ public class ImportSection extends Section {
         return imports.stream();
     }
 
+    public int count(ExternalType type) {
+        return (int) imports.stream().filter(i -> i.importType() == type).count();
+    }
+
     /**
      * Add an import definition to this section.
      *

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -50,11 +50,11 @@ public class Value {
         return new Value(ValueType.F64, data);
     }
 
-    public static Value externRef(long data) {
+    public static Value externRef(int data) {
         return new Value(ValueType.ExternRef, data);
     }
 
-    public static Value funcRef(long data) {
+    public static Value funcRef(int data) {
         return new Value(ValueType.FuncRef, data);
     }
 
@@ -69,11 +69,15 @@ public class Value {
     }
 
     private static ValueType ensure32bitValueType(ValueType type) {
-        if (ValueType.I32.equals(type) || ValueType.F32.equals(type)) {
-            return type;
+        switch (type) {
+            case I32:
+            case F32:
+            case ExternRef:
+            case FuncRef:
+                return type;
+            default:
+                throw new IllegalArgumentException("Invalid type for 32 bit value: " + type);
         }
-        throw new IllegalArgumentException(
-                "Invalid type for 32 bit value, only I32 or F32 are allowed, given: " + type);
     }
 
     /**


### PR DESCRIPTION
Some notes:

* Use `java.lang.reflect.Method` rather than manually building descriptors. IntelliJ understands `Class.getMethod(...)` for usage reporting, refactoring, code completion, etc., and will warn if the method does not exist.
* Use static trampoline methods rather than generating code to rearrange items on the stack. This is simpler, easier to read, results in smaller bytecode, and should be completely inlined by the JIT.
* We can code generate globals with host accessors if the boxing turns out to be a performance issue.