### PR TITLE
Format code with Palantir Java Format

### DIFF
--- a/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
@@ -29,11 +29,10 @@ public class AotEmitters {
         protected final Map<OpCode, BytecodeEmitter> emitters = new EnumMap<>(OpCode.class);
 
         public Builder intrinsic(OpCode opCode, BytecodeEmitter emitter) {
-            BytecodeEmitter wrapped =
-                    (ctx, ins, asm) -> {
-                        emitter.emit(ctx, ins, asm);
-                        updateStackSize(ctx, opCode);
-                    };
+            BytecodeEmitter wrapped = (ctx, ins, asm) -> {
+                emitter.emit(ctx, ins, asm);
+                updateStackSize(ctx, opCode);
+            };
             emitters.put(opCode, wrapped);
             return this;
         }
@@ -622,11 +621,10 @@ public class AotEmitters {
                 };
             }
         }
-        throw new IllegalArgumentException(
-                "Static helper "
-                        + staticHelpers.getName()
-                        + " does not provide an implementation of opcode "
-                        + opcode.name());
+        throw new IllegalArgumentException("Static helper "
+                + staticHelpers.getName()
+                + " does not provide an implementation of opcode "
+                + opcode.name());
     }
 
     private static void updateStackSize(AotContext ctx, OpCode opCode) {

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
@@ -52,15 +52,12 @@ public final class AotMethods {
             INSTANCE_READ_GLOBAL = Instance.class.getMethod("readGlobal", int.class);
             INSTANCE_WRITE_GLOBAL = Instance.class.getMethod("writeGlobal", int.class, Value.class);
             INSTANCE_SET_ELEMENT = Instance.class.getMethod("setElement", int.class, Element.class);
-            MEMORY_COPY =
-                    AotMethods.class.getMethod(
-                            "memoryCopy", int.class, int.class, int.class, Memory.class);
-            MEMORY_FILL =
-                    AotMethods.class.getMethod(
-                            "memoryFill", int.class, byte.class, int.class, Memory.class);
-            MEMORY_INIT =
-                    AotMethods.class.getMethod(
-                            "memoryInit", int.class, int.class, int.class, int.class, Memory.class);
+            MEMORY_COPY = AotMethods.class.getMethod(
+                    "memoryCopy", int.class, int.class, int.class, Memory.class);
+            MEMORY_FILL = AotMethods.class.getMethod(
+                    "memoryFill", int.class, byte.class, int.class, Memory.class);
+            MEMORY_INIT = AotMethods.class.getMethod(
+                    "memoryInit", int.class, int.class, int.class, int.class, Memory.class);
             MEMORY_GROW = Memory.class.getMethod("grow", int.class);
             MEMORY_DROP = Memory.class.getMethod("drop", int.class);
             MEMORY_PAGES = Memory.class.getMethod("pages");
@@ -73,49 +70,37 @@ public final class AotMethods {
             MEMORY_WRITE_BYTE = Memory.class.getMethod("writeByte", int.class, byte.class);
             MEMORY_WRITE_SHORT = Memory.class.getMethod("writeShort", int.class, short.class);
             MEMORY_WRITE_INT = Memory.class.getMethod("writeI32", int.class, int.class);
-            MEMORY_WRITE_LONG =
-                    AotMethods.class.getMethod(
-                            "memoryWriteLong", long.class, int.class, Memory.class);
+            MEMORY_WRITE_LONG = AotMethods.class.getMethod(
+                    "memoryWriteLong", long.class, int.class, Memory.class);
             MEMORY_WRITE_FLOAT = Memory.class.getMethod("writeF32", int.class, float.class);
-            MEMORY_WRITE_DOUBLE =
-                    AotMethods.class.getMethod(
-                            "memoryWriteDouble", double.class, int.class, Memory.class);
+            MEMORY_WRITE_DOUBLE = AotMethods.class.getMethod(
+                    "memoryWriteDouble", double.class, int.class, Memory.class);
             REF_IS_NULL = AotMethods.class.getMethod("isRefNull", int.class);
             TABLE_GET =
                     AotMethods.class.getMethod("tableGet", int.class, int.class, Instance.class);
-            TABLE_SET =
-                    AotMethods.class.getMethod(
-                            "tableSet", int.class, int.class, int.class, Instance.class);
+            TABLE_SET = AotMethods.class.getMethod(
+                    "tableSet", int.class, int.class, int.class, Instance.class);
             TABLE_SIZE = AotMethods.class.getMethod("tableSize", int.class, Instance.class);
-            TABLE_GROW =
-                    AotMethods.class.getMethod(
-                            "tableGrow", int.class, int.class, int.class, Instance.class);
-            TABLE_FILL =
-                    AotMethods.class.getMethod(
-                            "tableFill",
-                            int.class,
-                            int.class,
-                            int.class,
-                            int.class,
-                            Instance.class);
-            TABLE_COPY =
-                    AotMethods.class.getMethod(
-                            "tableCopy",
-                            int.class,
-                            int.class,
-                            int.class,
-                            int.class,
-                            int.class,
-                            Instance.class);
-            TABLE_INIT =
-                    AotMethods.class.getMethod(
-                            "tableInit",
-                            int.class,
-                            int.class,
-                            int.class,
-                            int.class,
-                            int.class,
-                            Instance.class);
+            TABLE_GROW = AotMethods.class.getMethod(
+                    "tableGrow", int.class, int.class, int.class, Instance.class);
+            TABLE_FILL = AotMethods.class.getMethod(
+                    "tableFill", int.class, int.class, int.class, int.class, Instance.class);
+            TABLE_COPY = AotMethods.class.getMethod(
+                    "tableCopy",
+                    int.class,
+                    int.class,
+                    int.class,
+                    int.class,
+                    int.class,
+                    Instance.class);
+            TABLE_INIT = AotMethods.class.getMethod(
+                    "tableInit",
+                    int.class,
+                    int.class,
+                    int.class,
+                    int.class,
+                    int.class,
+                    Instance.class);
             VALIDATE_BASE = AotMethods.class.getMethod("validateBase", int.class);
             THROW_OUT_OF_BOUNDS_MEMORY_ACCESS =
                     AotMethods.class.getMethod("throwOutOfBoundsMemoryAccess");

--- a/aot/src/main/java/com/dylibso/chicory/aot/HostFunctionInvoker.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/HostFunctionInvoker.java
@@ -11,11 +11,9 @@ public final class HostFunctionInvoker {
 
     static {
         try {
-            HANDLE =
-                    publicLookup()
-                            .unreflect(
-                                    HostFunctionInvoker.class.getMethod(
-                                            "invoke", Instance.class, int.class, Value[].class));
+            HANDLE = publicLookup()
+                    .unreflect(HostFunctionInvoker.class.getMethod(
+                            "invoke", Instance.class, int.class, Value[].class));
         } catch (NoSuchMethodException | IllegalAccessException e) {
             throw new AssertionError(e);
         }

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1FuncPtrsHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1FuncPtrsHostFuncs.java
@@ -10,16 +10,15 @@ import java.util.List;
 public class SpecV1FuncPtrsHostFuncs {
 
     public static HostImports fallback() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> {
-                                return null;
-                            },
-                            "spectest",
-                            "print_i32",
-                            List.of(ValueType.I32),
-                            List.of())
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        return null;
+                    },
+                    "spectest",
+                    "print_i32",
+                    List.of(ValueType.I32),
+                    List.of())
+        });
     }
 }

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
@@ -8,10 +8,9 @@ import com.dylibso.chicory.wasm.types.Value;
 public class SpecV1GlobalHostFuncs {
 
     public static HostImports fallback() {
-        return new HostImports(
-                new HostGlobal[] {
-                    new HostGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),
-                    new HostGlobal("spectest", "global_i64", new GlobalInstance(Value.i64(666)))
-                });
+        return new HostImports(new HostGlobal[] {
+            new HostGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),
+            new HostGlobal("spectest", "global_i64", new GlobalInstance(Value.i64(666)))
+        });
     }
 }

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
@@ -20,110 +20,96 @@ import java.util.Map;
 public class SpecV1ImportsHostFuncs {
 
     private static HostImports base() {
-        var printI32 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i32",
-                        List.of(ValueType.I32),
-                        List.of());
-        var printI32_1 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i32_1",
-                        List.of(ValueType.I32),
-                        List.of());
-        var printI32_2 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i32_2",
-                        List.of(ValueType.I32),
-                        List.of());
-        var printF32 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_f32",
-                        List.of(ValueType.F32),
-                        List.of());
-        var printI32F32 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i32_f32",
-                        List.of(ValueType.I32, ValueType.F32),
-                        List.of());
-        var printI64 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i64",
-                        List.of(ValueType.I64),
-                        List.of());
-        var printI64_1 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i64_1",
-                        List.of(ValueType.I64),
-                        List.of());
-        var printI64_2 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i64_2",
-                        List.of(ValueType.I64),
-                        List.of());
-        var printF64 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_f64",
-                        List.of(ValueType.F64),
-                        List.of());
-        var printF64_1 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_f64_1",
-                        List.of(ValueType.F64),
-                        List.of());
-        var printF64F64 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_f64_f64",
-                        List.of(ValueType.F64, ValueType.F64),
-                        List.of());
-        var table =
-                new HostTable(
-                        "spectest",
-                        "table",
-                        Map.of(1, 1, 2, 2, 10, 10, 24, 24, 100, REF_NULL_VALUE));
+        var printI32 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i32",
+                List.of(ValueType.I32),
+                List.of());
+        var printI32_1 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i32_1",
+                List.of(ValueType.I32),
+                List.of());
+        var printI32_2 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i32_2",
+                List.of(ValueType.I32),
+                List.of());
+        var printF32 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_f32",
+                List.of(ValueType.F32),
+                List.of());
+        var printI32F32 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i32_f32",
+                List.of(ValueType.I32, ValueType.F32),
+                List.of());
+        var printI64 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i64",
+                List.of(ValueType.I64),
+                List.of());
+        var printI64_1 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i64_1",
+                List.of(ValueType.I64),
+                List.of());
+        var printI64_2 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i64_2",
+                List.of(ValueType.I64),
+                List.of());
+        var printF64 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_f64",
+                List.of(ValueType.F64),
+                List.of());
+        var printF64_1 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_f64_1",
+                List.of(ValueType.F64),
+                List.of());
+        var printF64F64 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_f64_f64",
+                List.of(ValueType.F64, ValueType.F64),
+                List.of());
+        var table = new HostTable(
+                "spectest", "table", Map.of(1, 1, 2, 2, 10, 10, 24, 24, 100, REF_NULL_VALUE));
         var mem = new Memory(new MemoryLimits(1, 2));
         var memory = new HostMemory("spectest", "memory", mem);
         return new HostImports(
@@ -145,22 +131,19 @@ public class SpecV1ImportsHostFuncs {
     }
 
     public static HostImports testModule11() {
-        return new HostImports(
-                new HostGlobal[] {
-                    new HostGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),
-                    new HostGlobal("spectest", "global_i32_1", new GlobalInstance(Value.i32(666))),
-                    new HostGlobal("spectest", "global_i32_2", new GlobalInstance(Value.i32(666))),
-                    new HostGlobal("spectest", "global_i32_3", new GlobalInstance(Value.i32(666))),
-                    new HostGlobal("spectest", "global_i64", new GlobalInstance(Value.i64(666))),
-                    new HostGlobal("spectest", "global_f32", new GlobalInstance(Value.f32(1))),
-                    new HostGlobal("spectest", "global_f64", new GlobalInstance(Value.f64(1))),
-                });
+        return new HostImports(new HostGlobal[] {
+            new HostGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),
+            new HostGlobal("spectest", "global_i32_1", new GlobalInstance(Value.i32(666))),
+            new HostGlobal("spectest", "global_i32_2", new GlobalInstance(Value.i32(666))),
+            new HostGlobal("spectest", "global_i32_3", new GlobalInstance(Value.i32(666))),
+            new HostGlobal("spectest", "global_i64", new GlobalInstance(Value.i64(666))),
+            new HostGlobal("spectest", "global_f32", new GlobalInstance(Value.f32(1))),
+            new HostGlobal("spectest", "global_f64", new GlobalInstance(Value.f64(1))),
+        });
     }
 
-    private static HostImports memory2Inf =
-            new HostImports(
-                    new HostMemory(
-                            "test", "memory-2-inf", new Memory(MemoryLimits.defaultLimits())));
+    private static HostImports memory2Inf = new HostImports(
+            new HostMemory("test", "memory-2-inf", new Memory(MemoryLimits.defaultLimits())));
 
     public static HostImports testModule40() {
         return memory2Inf;
@@ -185,24 +168,22 @@ public class SpecV1ImportsHostFuncs {
     }
 
     public static HostImports fallback() {
-        var testFunc =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "test",
-                        "func",
-                        List.of(ValueType.I64),
-                        List.of(ValueType.I64));
-        var testFuncI64 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return new Value[] {args[0]};
-                        },
-                        "test",
-                        "func-i64->i64",
-                        List.of(ValueType.I64),
-                        List.of(ValueType.I64));
+        var testFunc = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "test",
+                "func",
+                List.of(ValueType.I64),
+                List.of(ValueType.I64));
+        var testFuncI64 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return new Value[] {args[0]};
+                },
+                "test",
+                "func-i64->i64",
+                List.of(ValueType.I64),
+                List.of(ValueType.I64));
         var base = base().functions();
         var additional = new HostFunction[] {testFunc, testFuncI64};
         HostFunction[] hostFunctions = Arrays.copyOf(base, base.length + additional.length);

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1NamesHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1NamesHostFuncs.java
@@ -9,16 +9,15 @@ import java.util.List;
 
 public class SpecV1NamesHostFuncs {
     public static HostImports fallback() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> {
-                                return null;
-                            },
-                            "spectest",
-                            "print_i32",
-                            List.of(ValueType.I32),
-                            List.of())
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        return null;
+                    },
+                    "spectest",
+                    "print_i32",
+                    List.of(ValueType.I32),
+                    List.of())
+        });
     }
 }

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1RefFuncHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1RefFuncHostFuncs.java
@@ -10,14 +10,13 @@ import java.util.List;
 public class SpecV1RefFuncHostFuncs {
 
     public static HostImports fallback() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> args,
-                            "M",
-                            "f",
-                            List.of(ValueType.I32),
-                            List.of(ValueType.I32))
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> args,
+                    "M",
+                    "f",
+                    List.of(ValueType.I32),
+                    List.of(ValueType.I32))
+        });
     }
 }

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1StartHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1StartHostFuncs.java
@@ -9,24 +9,23 @@ import java.util.List;
 
 public class SpecV1StartHostFuncs {
     public static HostImports fallback() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> {
-                                return null;
-                            },
-                            "spectest",
-                            "print_i32",
-                            List.of(ValueType.I32),
-                            List.of()),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> {
-                                return null;
-                            },
-                            "spectest",
-                            "print",
-                            List.of(ValueType.I32),
-                            List.of())
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        return null;
+                    },
+                    "spectest",
+                    "print_i32",
+                    List.of(ValueType.I32),
+                    List.of()),
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        return null;
+                    },
+                    "spectest",
+                    "print",
+                    List.of(ValueType.I32),
+                    List.of())
+        });
     }
 }

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1TableCopyHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1TableCopyHostFuncs.java
@@ -10,38 +10,37 @@ import java.util.List;
 public class SpecV1TableCopyHostFuncs {
 
     public static HostImports fallback() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(0)},
-                            "a",
-                            "ef0",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(1)},
-                            "a",
-                            "ef1",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(2)},
-                            "a",
-                            "ef2",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(3)},
-                            "a",
-                            "ef3",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(4)},
-                            "a",
-                            "ef4",
-                            List.of(),
-                            List.of(ValueType.I32))
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(0)},
+                    "a",
+                    "ef0",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(1)},
+                    "a",
+                    "ef1",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(2)},
+                    "a",
+                    "ef2",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(3)},
+                    "a",
+                    "ef3",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(4)},
+                    "a",
+                    "ef4",
+                    List.of(),
+                    List.of(ValueType.I32))
+        });
     }
 }

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1TableInitHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1TableInitHostFuncs.java
@@ -10,38 +10,37 @@ import java.util.List;
 public class SpecV1TableInitHostFuncs {
 
     public static HostImports fallback() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(0)},
-                            "a",
-                            "ef0",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(1)},
-                            "a",
-                            "ef1",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(2)},
-                            "a",
-                            "ef2",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(3)},
-                            "a",
-                            "ef3",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(4)},
-                            "a",
-                            "ef4",
-                            List.of(),
-                            List.of(ValueType.I32))
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(0)},
+                    "a",
+                    "ef0",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(1)},
+                    "a",
+                    "ef1",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(2)},
+                    "a",
+                    "ef2",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(3)},
+                    "a",
+                    "ef3",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(4)},
+                    "a",
+                    "ef4",
+                    List.of(),
+                    List.of(ValueType.I32))
+        });
     }
 }

--- a/aot/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/aot/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -69,14 +69,13 @@ public class TestModule {
     }
 
     public TestModule build() {
-        this.module =
-                builder.withInitialize(false)
-                        .withStart(false)
-                        // TODO: enable me!
-                        .withTypeValidation(false)
-                        .withHostImports(imports)
-                        .withMachineFactory(instance -> new AotMachine(module, instance))
-                        .build();
+        this.module = builder.withInitialize(false)
+                .withStart(false)
+                // TODO: enable me!
+                .withTypeValidation(false)
+                .withHostImports(imports)
+                .withMachineFactory(instance -> new AotMachine(module, instance))
+                .build();
         return this;
     }
 

--- a/cli/src/main/java/com/dylibso/chicory/cli/Cli.java
+++ b/cli/src/main/java/com/dylibso/chicory/cli/Cli.java
@@ -48,31 +48,26 @@ public class Cli implements Runnable {
     @Override
     public void run() {
         // TODO: improve the handling of the logLevel
-        try (var is =
-                new ByteArrayInputStream(
-                        (".level = " + logLevel).getBytes(StandardCharsets.UTF_8))) {
+        try (var is = new ByteArrayInputStream(
+                (".level = " + logLevel).getBytes(StandardCharsets.UTF_8))) {
             LogManager.getLogManager().readConfiguration(is);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
         var logger = new SystemLogger();
         var module = Module.builder(file).withLogger(logger).build();
-        var imports =
-                wasi
-                        ? new HostImports(
-                                new WasiPreview1(
-                                                logger,
-                                                WasiOptions.builder().inheritSystem().build())
-                                        .toHostFunctions())
-                        : new HostImports();
-        var instance =
-                Module.builder(file)
-                        .withLogger(logger)
-                        .withInitialize(true)
-                        .withStart(false)
-                        .withHostImports(imports)
-                        .build()
-                        .instantiate();
+        var imports = wasi
+                ? new HostImports(new WasiPreview1(
+                                logger, WasiOptions.builder().inheritSystem().build())
+                        .toHostFunctions())
+                : new HostImports();
+        var instance = Module.builder(file)
+                .withLogger(logger)
+                .withInitialize(true)
+                .withStart(false)
+                .withHostImports(imports)
+                .build()
+                .instantiate();
 
         if (functionName != null) {
             var exportSig = module.export(functionName);
@@ -82,11 +77,10 @@ public class Cli implements Runnable {
             var type = instance.type(typeId);
 
             if (arguments.length != type.params().size()) {
-                throw new RuntimeException(
-                        "The function needs "
-                                + type.params().size()
-                                + " parameters, but found: "
-                                + arguments.length);
+                throw new RuntimeException("The function needs "
+                        + type.params().size()
+                        + " parameters, but found: "
+                        + arguments.length);
             }
             var params = new Value[type.params().size()];
             for (var i = 0; i < type.params().size(); i++) {

--- a/fuzz/src/main/java/com/dylibso/chicory/fuzz/InstructionTypes.java
+++ b/fuzz/src/main/java/com/dylibso/chicory/fuzz/InstructionTypes.java
@@ -24,17 +24,14 @@ public class InstructionTypes {
 
     // Extract the types from an env var
     public static InstructionTypes fromString(String values) {
-        return new InstructionTypes(
-                Arrays.stream(values.trim().split(","))
-                        .map(
-                                v -> {
-                                    var res = InstructionType.byValue(v.toLowerCase());
-                                    if (res == null) {
-                                        throw new RuntimeException(
-                                                "Cannot find a matching type for " + v);
-                                    }
-                                    return res;
-                                })
-                        .collect(Collectors.toSet()));
+        return new InstructionTypes(Arrays.stream(values.trim().split(","))
+                .map(v -> {
+                    var res = InstructionType.byValue(v.toLowerCase());
+                    if (res == null) {
+                        throw new RuntimeException("Cannot find a matching type for " + v);
+                    }
+                    return res;
+                })
+                .collect(Collectors.toSet()));
     }
 }

--- a/fuzz/src/main/java/com/dylibso/chicory/fuzz/WasmSmithWrapper.java
+++ b/fuzz/src/main/java/com/dylibso/chicory/fuzz/WasmSmithWrapper.java
@@ -47,10 +47,9 @@ public class WasmSmithWrapper {
         var command = new ArrayList<>(BINARY_NAME);
         // --ensure-termination true -> breaks the execution
         var defaultProperties = new ArrayList<String>();
-        var propsFile =
-                new String(
-                        getClass().getResourceAsStream(smithProperties).readAllBytes(),
-                        StandardCharsets.UTF_8);
+        var propsFile = new String(
+                getClass().getResourceAsStream(smithProperties).readAllBytes(),
+                StandardCharsets.UTF_8);
         var props = propsFile.split("\n");
         for (var prop : props) {
             if (!prop.isEmpty()) {
@@ -60,17 +59,15 @@ public class WasmSmithWrapper {
             }
         }
         command.addAll(defaultProperties);
-        command.addAll(
-                List.of(
-                        "--allowed-instructions",
-                        instructionTypes.toString(),
-                        "--output",
-                        targetFile.getAbsolutePath()));
-        logger.info(
-                "Going to execute command:\n"
-                        + String.join(" ", command)
-                        + " < "
-                        + seedFile.getAbsolutePath());
+        command.addAll(List.of(
+                "--allowed-instructions",
+                instructionTypes.toString(),
+                "--output",
+                targetFile.getAbsolutePath()));
+        logger.info("Going to execute command:\n"
+                + String.join(" ", command)
+                + " < "
+                + seedFile.getAbsolutePath());
 
         var retry = 3;
         // Trying to use the smallest possible seed for speed reasons

--- a/fuzz/src/test/java/com/dylibso/chicory/fuzz/FuzzTest.java
+++ b/fuzz/src/test/java/com/dylibso/chicory/fuzz/FuzzTest.java
@@ -44,17 +44,15 @@ public class FuzzTest extends TestModule {
 
         int totalRepetitions = repetitionInfo.getTotalRepetitions();
         String methodName = testInfo.getTestMethod().get().getName();
-        logger.info(
-                String.format(
-                        "About to execute repetition %d of %d for %s", //
-                        currentRepetition, totalRepetitions, methodName));
+        logger.info(String.format(
+                "About to execute repetition %d of %d for %s", //
+                currentRepetition, totalRepetitions, methodName));
     }
 
     @RepeatedTest(value = FUZZ_TEST_NUMERIC, failureThreshold = 1) // stop on first failure
     public void numericOnlyFuzz(RepetitionInfo repetitionInfo) throws Exception {
-        var targetWasm =
-                generateTestData(
-                        "numeric-", repetitionInfo.getCurrentRepetition(), InstructionType.NUMERIC);
+        var targetWasm = generateTestData(
+                "numeric-", repetitionInfo.getCurrentRepetition(), InstructionType.NUMERIC);
         var module = Module.builder(targetWasm).build();
         var instance = module.withInitialize(true).withStart(false).instantiate();
 
@@ -69,9 +67,8 @@ public class FuzzTest extends TestModule {
 
     @RepeatedTest(value = FUZZ_TEST_TABLE, failureThreshold = 1) // stop on first failure
     public void tableOnlyFuzz(RepetitionInfo repetitionInfo) throws Exception {
-        var targetWasm =
-                generateTestData(
-                        "table-", repetitionInfo.getCurrentRepetition(), InstructionType.TABLE);
+        var targetWasm = generateTestData(
+                "table-", repetitionInfo.getCurrentRepetition(), InstructionType.TABLE);
         var module = Module.builder(targetWasm).build();
         var instance = module.withInitialize(true).withStart(false).instantiate();
 

--- a/fuzz/src/test/java/com/dylibso/chicory/fuzz/SingleReproTest.java
+++ b/fuzz/src/test/java/com/dylibso/chicory/fuzz/SingleReproTest.java
@@ -23,9 +23,8 @@ public class SingleReproTest extends TestModule {
     @Test
     @EnabledIf("enableSingleReproducer")
     void singleReproducer() throws Exception {
-        var seed =
-                FileUtils.readFileToString(
-                        new File(System.getenv(CHICORY_FUZZ_SEED_KEY)), StandardCharsets.UTF_8);
+        var seed = FileUtils.readFileToString(
+                new File(System.getenv(CHICORY_FUZZ_SEED_KEY)), StandardCharsets.UTF_8);
         var types = InstructionTypes.fromString(System.getenv(CHICORY_FUZZ_TYPES_KEY));
         var targetWasm =
                 smith.run(seed.substring(0, Math.min(seed.length(), 32)), "test.wasm", types);

--- a/jmh/src/main/java/com/dylibso/chicory/bench/BenchmarkFactorialExecution.java
+++ b/jmh/src/main/java/com/dylibso/chicory/bench/BenchmarkFactorialExecution.java
@@ -33,12 +33,10 @@ public class BenchmarkFactorialExecution {
 
     @Setup
     public void setup() throws IOException {
-        var factorial =
-                Module.builder(
-                                new File(
-                                        "wasm-corpus/src/main/resources/compiled/iterfact.wat.wasm"))
-                        .build()
-                        .instantiate();
+        var factorial = Module.builder(
+                        new File("wasm-corpus/src/main/resources/compiled/iterfact.wat.wasm"))
+                .build()
+                .instantiate();
         iterFact = factorial.export("iterFact");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -377,12 +377,11 @@
               <include>**/src/main/java/**/*.java</include>
               <include>**/src/test/java/**/*.java</include>
             </includes>
-            <googleJavaFormat>
-              <version>1.18.1</version>
+            <palantirJavaFormat>
+              <version>2.47.0</version>
               <style>AOSP</style>
-              <reflowLongStrings>true</reflowLongStrings>
               <formatJavadoc>false</formatJavadoc>
-            </googleJavaFormat>
+            </palantirJavaFormat>
             <importOrder></importOrder>
             <replaceRegex>
               <name>Remove wildcard imports</name>

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ElemHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ElemHostFuncs.java
@@ -19,37 +19,33 @@ public class SpecV1ElemHostFuncs {
     }
 
     public static HostImports testModule3() {
-        return new HostImports(
-                new HostTable[] {
-                    new HostTable(
-                            "spectest",
-                            "table",
-                            new TableInstance(new Table(ValueType.FuncRef, new Limits(1))))
-                });
+        return new HostImports(new HostTable[] {
+            new HostTable(
+                    "spectest",
+                    "table",
+                    new TableInstance(new Table(ValueType.FuncRef, new Limits(1))))
+        });
     }
 
     public static HostImports testModule5() {
-        return new HostImports(
-                new HostTable[] {
-                    new HostTable(
-                            "spectest",
-                            "table",
-                            new TableInstance(new Table(ValueType.FuncRef, new Limits(10))))
-                });
+        return new HostImports(new HostTable[] {
+            new HostTable(
+                    "spectest",
+                    "table",
+                    new TableInstance(new Table(ValueType.FuncRef, new Limits(10))))
+        });
     }
 
     public static HostImports testModule6() {
-        return new HostImports(
-                new HostGlobal[] {
-                    new HostGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(123)))
-                });
+        return new HostImports(new HostGlobal[] {
+            new HostGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(123)))
+        });
     }
 
     public static HostImports testModule7() {
-        return new HostImports(
-                new HostGlobal[] {
-                    new HostGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(321)))
-                });
+        return new HostImports(new HostGlobal[] {
+            new HostGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(321)))
+        });
     }
 
     public static HostImports testModule11() {

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1FuncPtrsHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1FuncPtrsHostFuncs.java
@@ -10,16 +10,15 @@ import java.util.List;
 public class SpecV1FuncPtrsHostFuncs {
 
     public static HostImports fallback() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> {
-                                return null;
-                            },
-                            "spectest",
-                            "print_i32",
-                            List.of(ValueType.I32),
-                            List.of())
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        return null;
+                    },
+                    "spectest",
+                    "print_i32",
+                    List.of(ValueType.I32),
+                    List.of())
+        });
     }
 }

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
@@ -8,10 +8,9 @@ import com.dylibso.chicory.wasm.types.Value;
 public class SpecV1GlobalHostFuncs {
 
     public static HostImports fallback() {
-        return new HostImports(
-                new HostGlobal[] {
-                    new HostGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),
-                    new HostGlobal("spectest", "global_i64", new GlobalInstance(Value.i64(666)))
-                });
+        return new HostImports(new HostGlobal[] {
+            new HostGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),
+            new HostGlobal("spectest", "global_i64", new GlobalInstance(Value.i64(666)))
+        });
     }
 }

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
@@ -20,110 +20,96 @@ import java.util.Map;
 public class SpecV1ImportsHostFuncs {
 
     private static HostImports base() {
-        var printI32 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i32",
-                        List.of(ValueType.I32),
-                        List.of());
-        var printI32_1 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i32_1",
-                        List.of(ValueType.I32),
-                        List.of());
-        var printI32_2 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i32_2",
-                        List.of(ValueType.I32),
-                        List.of());
-        var printF32 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_f32",
-                        List.of(ValueType.F32),
-                        List.of());
-        var printI32F32 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i32_f32",
-                        List.of(ValueType.I32, ValueType.F32),
-                        List.of());
-        var printI64 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i64",
-                        List.of(ValueType.I64),
-                        List.of());
-        var printI64_1 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i64_1",
-                        List.of(ValueType.I64),
-                        List.of());
-        var printI64_2 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_i64_2",
-                        List.of(ValueType.I64),
-                        List.of());
-        var printF64 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_f64",
-                        List.of(ValueType.F64),
-                        List.of());
-        var printF64_1 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_f64_1",
-                        List.of(ValueType.F64),
-                        List.of());
-        var printF64F64 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "spectest",
-                        "print_f64_f64",
-                        List.of(ValueType.F64, ValueType.F64),
-                        List.of());
-        var table =
-                new HostTable(
-                        "spectest",
-                        "table",
-                        Map.of(1, 1, 2, 2, 10, 10, 24, 24, 100, REF_NULL_VALUE));
+        var printI32 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i32",
+                List.of(ValueType.I32),
+                List.of());
+        var printI32_1 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i32_1",
+                List.of(ValueType.I32),
+                List.of());
+        var printI32_2 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i32_2",
+                List.of(ValueType.I32),
+                List.of());
+        var printF32 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_f32",
+                List.of(ValueType.F32),
+                List.of());
+        var printI32F32 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i32_f32",
+                List.of(ValueType.I32, ValueType.F32),
+                List.of());
+        var printI64 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i64",
+                List.of(ValueType.I64),
+                List.of());
+        var printI64_1 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i64_1",
+                List.of(ValueType.I64),
+                List.of());
+        var printI64_2 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_i64_2",
+                List.of(ValueType.I64),
+                List.of());
+        var printF64 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_f64",
+                List.of(ValueType.F64),
+                List.of());
+        var printF64_1 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_f64_1",
+                List.of(ValueType.F64),
+                List.of());
+        var printF64F64 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "spectest",
+                "print_f64_f64",
+                List.of(ValueType.F64, ValueType.F64),
+                List.of());
+        var table = new HostTable(
+                "spectest", "table", Map.of(1, 1, 2, 2, 10, 10, 24, 24, 100, REF_NULL_VALUE));
         var mem = new Memory(new MemoryLimits(1, 2));
         var memory = new HostMemory("spectest", "memory", mem);
         return new HostImports(
@@ -145,22 +131,19 @@ public class SpecV1ImportsHostFuncs {
     }
 
     public static HostImports testModule11() {
-        return new HostImports(
-                new HostGlobal[] {
-                    new HostGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),
-                    new HostGlobal("spectest", "global_i32_1", new GlobalInstance(Value.i32(666))),
-                    new HostGlobal("spectest", "global_i32_2", new GlobalInstance(Value.i32(666))),
-                    new HostGlobal("spectest", "global_i32_3", new GlobalInstance(Value.i32(666))),
-                    new HostGlobal("spectest", "global_i64", new GlobalInstance(Value.i64(666))),
-                    new HostGlobal("spectest", "global_f32", new GlobalInstance(Value.f32(1))),
-                    new HostGlobal("spectest", "global_f64", new GlobalInstance(Value.f64(1))),
-                });
+        return new HostImports(new HostGlobal[] {
+            new HostGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),
+            new HostGlobal("spectest", "global_i32_1", new GlobalInstance(Value.i32(666))),
+            new HostGlobal("spectest", "global_i32_2", new GlobalInstance(Value.i32(666))),
+            new HostGlobal("spectest", "global_i32_3", new GlobalInstance(Value.i32(666))),
+            new HostGlobal("spectest", "global_i64", new GlobalInstance(Value.i64(666))),
+            new HostGlobal("spectest", "global_f32", new GlobalInstance(Value.f32(1))),
+            new HostGlobal("spectest", "global_f64", new GlobalInstance(Value.f64(1))),
+        });
     }
 
-    private static HostImports memory2Inf =
-            new HostImports(
-                    new HostMemory(
-                            "test", "memory-2-inf", new Memory(MemoryLimits.defaultLimits())));
+    private static HostImports memory2Inf = new HostImports(
+            new HostMemory("test", "memory-2-inf", new Memory(MemoryLimits.defaultLimits())));
 
     public static HostImports testModule40() {
         return memory2Inf;
@@ -185,24 +168,22 @@ public class SpecV1ImportsHostFuncs {
     }
 
     public static HostImports fallback() {
-        var testFunc =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return null;
-                        },
-                        "test",
-                        "func",
-                        List.of(ValueType.I64),
-                        List.of(ValueType.I64));
-        var testFuncI64 =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            return new Value[] {args[0]};
-                        },
-                        "test",
-                        "func-i64->i64",
-                        List.of(ValueType.I64),
-                        List.of(ValueType.I64));
+        var testFunc = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return null;
+                },
+                "test",
+                "func",
+                List.of(ValueType.I64),
+                List.of(ValueType.I64));
+        var testFuncI64 = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    return new Value[] {args[0]};
+                },
+                "test",
+                "func-i64->i64",
+                List.of(ValueType.I64),
+                List.of(ValueType.I64));
         var base = base().functions();
         var additional = new HostFunction[] {testFunc, testFuncI64};
         HostFunction[] hostFunctions = Arrays.copyOf(base, base.length + additional.length);

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1LinkingHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1LinkingHostFuncs.java
@@ -22,27 +22,25 @@ import java.util.List;
 public class SpecV1LinkingHostFuncs {
 
     public static HostImports Mf() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(2)},
-                            "Mf",
-                            "call",
-                            List.of(),
-                            List.of(ValueType.I32))
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(2)},
+                    "Mf",
+                    "call",
+                    List.of(),
+                    List.of(ValueType.I32))
+        });
     }
 
     public static HostImports Nf() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(2)},
-                            "Mf",
-                            "call",
-                            List.of(),
-                            List.of(ValueType.I32))
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(2)},
+                    "Mf",
+                    "call",
+                    List.of(),
+                    List.of(ValueType.I32))
+        });
     }
 
     public static HostImports Mg() {
@@ -64,25 +62,24 @@ public class SpecV1LinkingHostFuncs {
     }
 
     public static HostImports Nt() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> {
-                                return Mtcall().apply(args);
-                            },
-                            "Mt",
-                            "call",
-                            List.of(ValueType.I32),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> {
-                                return Mth().apply(args);
-                            },
-                            "Mt",
-                            "h",
-                            List.of(),
-                            List.of(ValueType.I32))
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        return Mtcall().apply(args);
+                    },
+                    "Mt",
+                    "call",
+                    List.of(ValueType.I32),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        return Mth().apply(args);
+                    },
+                    "Mt",
+                    "h",
+                    List.of(),
+                    List.of(ValueType.I32))
+        });
     }
 
     public static HostImports Ng() {
@@ -162,17 +159,16 @@ public class SpecV1LinkingHostFuncs {
     }
 
     public static HostImports Nm() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> {
-                                return new Value[] {Value.i32(167)};
-                            },
-                            "Mm",
-                            "load",
-                            List.of(ValueType.I32),
-                            List.of(ValueType.I32))
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        return new Value[] {Value.i32(167)};
+                    },
+                    "Mm",
+                    "load",
+                    List.of(ValueType.I32),
+                    List.of(ValueType.I32))
+        });
     }
 
     public static HostImports fallback() {

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1NamesHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1NamesHostFuncs.java
@@ -9,16 +9,15 @@ import java.util.List;
 
 public class SpecV1NamesHostFuncs {
     public static HostImports fallback() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> {
-                                return null;
-                            },
-                            "spectest",
-                            "print_i32",
-                            List.of(ValueType.I32),
-                            List.of())
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        return null;
+                    },
+                    "spectest",
+                    "print_i32",
+                    List.of(ValueType.I32),
+                    List.of())
+        });
     }
 }

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1RefFuncHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1RefFuncHostFuncs.java
@@ -10,14 +10,13 @@ import java.util.List;
 public class SpecV1RefFuncHostFuncs {
 
     public static HostImports fallback() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> args,
-                            "M",
-                            "f",
-                            List.of(ValueType.I32),
-                            List.of(ValueType.I32))
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> args,
+                    "M",
+                    "f",
+                    List.of(ValueType.I32),
+                    List.of(ValueType.I32))
+        });
     }
 }

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1StartHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1StartHostFuncs.java
@@ -9,24 +9,23 @@ import java.util.List;
 
 public class SpecV1StartHostFuncs {
     public static HostImports fallback() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> {
-                                return null;
-                            },
-                            "spectest",
-                            "print_i32",
-                            List.of(ValueType.I32),
-                            List.of()),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> {
-                                return null;
-                            },
-                            "spectest",
-                            "print",
-                            List.of(ValueType.I32),
-                            List.of())
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        return null;
+                    },
+                    "spectest",
+                    "print_i32",
+                    List.of(ValueType.I32),
+                    List.of()),
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        return null;
+                    },
+                    "spectest",
+                    "print",
+                    List.of(ValueType.I32),
+                    List.of())
+        });
     }
 }

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1TableCopyHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1TableCopyHostFuncs.java
@@ -10,38 +10,37 @@ import java.util.List;
 public class SpecV1TableCopyHostFuncs {
 
     public static HostImports fallback() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(0)},
-                            "a",
-                            "ef0",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(1)},
-                            "a",
-                            "ef1",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(2)},
-                            "a",
-                            "ef2",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(3)},
-                            "a",
-                            "ef3",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(4)},
-                            "a",
-                            "ef4",
-                            List.of(),
-                            List.of(ValueType.I32))
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(0)},
+                    "a",
+                    "ef0",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(1)},
+                    "a",
+                    "ef1",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(2)},
+                    "a",
+                    "ef2",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(3)},
+                    "a",
+                    "ef3",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(4)},
+                    "a",
+                    "ef4",
+                    List.of(),
+                    List.of(ValueType.I32))
+        });
     }
 }

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1TableInitHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1TableInitHostFuncs.java
@@ -10,38 +10,37 @@ import java.util.List;
 public class SpecV1TableInitHostFuncs {
 
     public static HostImports fallback() {
-        return new HostImports(
-                new HostFunction[] {
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(0)},
-                            "a",
-                            "ef0",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(1)},
-                            "a",
-                            "ef1",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(2)},
-                            "a",
-                            "ef2",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(3)},
-                            "a",
-                            "ef3",
-                            List.of(),
-                            List.of(ValueType.I32)),
-                    new HostFunction(
-                            (Instance instance, Value... args) -> new Value[] {Value.i32(4)},
-                            "a",
-                            "ef4",
-                            List.of(),
-                            List.of(ValueType.I32))
-                });
+        return new HostImports(new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(0)},
+                    "a",
+                    "ef0",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(1)},
+                    "a",
+                    "ef1",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(2)},
+                    "a",
+                    "ef2",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(3)},
+                    "a",
+                    "ef3",
+                    List.of(),
+                    List.of(ValueType.I32)),
+            new HostFunction(
+                    (Instance instance, Value... args) -> new Value[] {Value.i32(4)},
+                    "a",
+                    "ef4",
+                    List.of(),
+                    List.of(ValueType.I32))
+        });
     }
 }

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -67,12 +67,11 @@ public class TestModule {
     }
 
     public TestModule build() {
-        this.module =
-                builder.withInitialize(false)
-                        .withStart(false)
-                        .withTypeValidation(typeValidation)
-                        .withHostImports(imports)
-                        .build();
+        this.module = builder.withInitialize(false)
+                .withStart(false)
+                .withTypeValidation(typeValidation)
+                .withHostImports(imports)
+                .build();
         return this;
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ConstantEvaluators.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ConstantEvaluators.java
@@ -16,57 +16,48 @@ public class ConstantEvaluators {
         Value tos = null;
         for (Instruction instruction : expr) {
             switch (instruction.opcode()) {
-                case F32_CONST:
-                    {
-                        tos = Value.f32(instruction.operands()[0]);
-                        break;
+                case F32_CONST: {
+                    tos = Value.f32(instruction.operands()[0]);
+                    break;
+                }
+                case F64_CONST: {
+                    tos = Value.f64(instruction.operands()[0]);
+                    break;
+                }
+                case I32_CONST: {
+                    tos = Value.i32(instruction.operands()[0]);
+                    break;
+                }
+                case I64_CONST: {
+                    tos = Value.i64(instruction.operands()[0]);
+                    break;
+                }
+                case REF_NULL: {
+                    ValueType vt = ValueType.refTypeForId((int) instruction.operands()[0]);
+                    if (vt == ValueType.ExternRef) {
+                        tos = Value.EXTREF_NULL;
+                    } else if (vt == ValueType.FuncRef) {
+                        tos = Value.FUNCREF_NULL;
+                    } else {
+                        throw new IllegalStateException(
+                                "Unexpected wrong type for ref.null instruction");
                     }
-                case F64_CONST:
-                    {
-                        tos = Value.f64(instruction.operands()[0]);
-                        break;
-                    }
-                case I32_CONST:
-                    {
-                        tos = Value.i32(instruction.operands()[0]);
-                        break;
-                    }
-                case I64_CONST:
-                    {
-                        tos = Value.i64(instruction.operands()[0]);
-                        break;
-                    }
-                case REF_NULL:
-                    {
-                        ValueType vt = ValueType.refTypeForId((int) instruction.operands()[0]);
-                        if (vt == ValueType.ExternRef) {
-                            tos = Value.EXTREF_NULL;
-                        } else if (vt == ValueType.FuncRef) {
-                            tos = Value.FUNCREF_NULL;
-                        } else {
-                            throw new IllegalStateException(
-                                    "Unexpected wrong type for ref.null instruction");
-                        }
-                        break;
-                    }
-                case REF_FUNC:
-                    {
-                        tos = Value.funcRef((int) instruction.operands()[0]);
-                        break;
-                    }
-                case GLOBAL_GET:
-                    {
-                        return instance.readGlobal((int) instruction.operands()[0]);
-                    }
-                case END:
-                    {
-                        break;
-                    }
-                default:
-                    {
-                        throw new ChicoryException(
-                                "Non-constant instruction encountered: " + instruction);
-                    }
+                    break;
+                }
+                case REF_FUNC: {
+                    tos = Value.funcRef((int) instruction.operands()[0]);
+                    break;
+                }
+                case GLOBAL_GET: {
+                    return instance.readGlobal((int) instruction.operands()[0]);
+                }
+                case END: {
+                    break;
+                }
+                default: {
+                    throw new ChicoryException(
+                            "Non-constant instruction encountered: " + instruction);
+                }
             }
         }
         if (tos == null) {
@@ -78,10 +69,9 @@ public class ConstantEvaluators {
     public static Instance computeConstantInstance(Instance instance, List<Instruction> expr) {
         for (Instruction instruction : expr) {
             switch (instruction.opcode()) {
-                case GLOBAL_GET:
-                    {
-                        return instance.global((int) instruction.operands()[0]).getInstance();
-                    }
+                case GLOBAL_GET: {
+                    return instance.global((int) instruction.operands()[0]).getInstance();
+                }
             }
         }
         return instance;

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -173,15 +173,13 @@ public class Instance {
                 case F64_CONST:
                     globals[i] = new GlobalInstance(Value.f64(instr.operands()[0]));
                     break;
-                case GLOBAL_GET:
-                    {
-                        var idx = (int) instr.operands()[0];
-                        globals[i] =
-                                idx < imports.globalCount()
-                                        ? imports.global(idx).instance()
-                                        : globals[idx];
-                        break;
-                    }
+                case GLOBAL_GET: {
+                    var idx = (int) instr.operands()[0];
+                    globals[i] = idx < imports.globalCount()
+                            ? imports.global(idx).instance()
+                            : globals[idx];
+                    break;
+                }
                 case REF_NULL:
                     globals[i] = new GlobalInstance(Value.EXTREF_NULL);
                     break;
@@ -229,32 +227,29 @@ public class Instance {
         if (export == null) throw new ChicoryException("Unknown export with name " + name);
 
         switch (export.exportType()) {
-            case FUNCTION:
-                {
-                    var funcId = export.index();
-                    return (args) -> {
-                        this.module.logger().debug(() -> "Args: " + Arrays.toString(args));
-                        try {
-                            return machine.call(funcId, args);
-                        } catch (Exception e) {
-                            throw new WASMMachineException(machine.getStackTrace(), e);
-                        }
-                    };
-                }
-            case GLOBAL:
-                {
-                    return new ExportFunction() {
-                        @Override
-                        public Value[] apply(Value... args) throws ChicoryException {
-                            assert (args.length == 0);
-                            return new Value[] {readGlobal(export.index())};
-                        }
-                    };
-                }
-            default:
-                {
-                    throw new ChicoryException("not implemented");
-                }
+            case FUNCTION: {
+                var funcId = export.index();
+                return (args) -> {
+                    this.module.logger().debug(() -> "Args: " + Arrays.toString(args));
+                    try {
+                        return machine.call(funcId, args);
+                    } catch (Exception e) {
+                        throw new WASMMachineException(machine.getStackTrace(), e);
+                    }
+                };
+            }
+            case GLOBAL: {
+                return new ExportFunction() {
+                    @Override
+                    public Value[] apply(Value... args) throws ChicoryException {
+                        assert (args.length == 0);
+                        return new Value[] {readGlobal(export.index())};
+                    }
+                };
+            }
+            default: {
+                throw new ChicoryException("not implemented");
+            }
         }
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -153,21 +153,20 @@ class InterpreterMachine implements Machine {
                     case SELECT_T:
                         SELECT_T(stack, operands);
                         break;
-                    case END:
-                        {
-                            if (frame.doControlTransfer && frame.isControlFrame) {
-                                doControlTransfer(instance, stack, frame, instruction.scope());
-                            } else {
-                                frame.endOfNonControlBlock();
-                            }
-
-                            // if this is the last end, then we're done with
-                            // the function
-                            if (frame.isLastBlock()) {
-                                break loop;
-                            }
-                            break;
+                    case END: {
+                        if (frame.doControlTransfer && frame.isControlFrame) {
+                            doControlTransfer(instance, stack, frame, instruction.scope());
+                        } else {
+                            frame.endOfNonControlBlock();
                         }
+
+                        // if this is the last end, then we're done with
+                        // the function
+                        if (frame.isLastBlock()) {
+                            break loop;
+                        }
+                        break;
+                    }
                     case LOCAL_GET:
                         stack.push(frame.local((int) operands[0]));
                         break;
@@ -1787,10 +1786,9 @@ class InterpreterMachine implements Machine {
 
     private static void GLOBAL_SET(MStack stack, Instance instance, long[] operands) {
         var id = (int) operands[0];
-        var mutabilityType =
-                (instance.globalInitializer(id) == null)
-                        ? instance.imports().global(id).mutabilityType()
-                        : instance.globalInitializer(id);
+        var mutabilityType = (instance.globalInitializer(id) == null)
+                ? instance.imports().global(id).mutabilityType()
+                : instance.globalInitializer(id);
         if (mutabilityType == MutabilityType.Const) {
             throw new RuntimeException("Can't call GLOBAL_SET on immutable global");
         }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
@@ -95,9 +95,8 @@ public class Module {
         // TODO i guess we should explode if this is the case, is this possible?
         var types = module.typeSection().types();
 
-        int numFuncTypes =
-                module.functionSection().functionCount()
-                        + module.importSection().count(ExternalType.FUNCTION);
+        int numFuncTypes = module.functionSection().functionCount()
+                + module.importSection().count(ExternalType.FUNCTION);
 
         FunctionBody[] functions = module.codeSection().functionBodies();
 
@@ -110,16 +109,15 @@ public class Module {
         for (int i = 0; i < importCount; i++) {
             Import imprt = module.importSection().getImport(i);
             switch (imprt.importType()) {
-                case FUNCTION:
-                    {
-                        var type = ((FunctionImport) imprt).typeIndex();
-                        functionTypes[funcIdx] = type;
-                        // The global function id increases on this table
-                        // function ids are assigned on imports first
-                        imports[importId++] = imprt;
-                        funcIdx++;
-                        break;
-                    }
+                case FUNCTION: {
+                    var type = ((FunctionImport) imprt).typeIndex();
+                    functionTypes[funcIdx] = type;
+                    // The global function id increases on this table
+                    // function ids are assigned on imports first
+                    imports[importId++] = imprt;
+                    funcIdx++;
+                    break;
+                }
                 default:
                     imports[importId++] = imprt;
                     break;
@@ -129,11 +127,10 @@ public class Module {
         var mappedHostImports = mapHostImports(imports, hostImports);
 
         if (module.startSection() != null) {
-            var export =
-                    new Export(
-                            START_FUNCTION_NAME,
-                            (int) module.startSection().startIndex(),
-                            ExternalType.FUNCTION);
+            var export = new Export(
+                    START_FUNCTION_NAME,
+                    (int) module.startSection().startIndex(),
+                    ExternalType.FUNCTION);
             exports.put(START_FUNCTION_NAME, export);
         }
 
@@ -382,15 +379,13 @@ public class Module {
      * @return a {@link Builder} for reading the module definition from the specified file
      */
     public static Builder builder(File file) {
-        return new Builder(
-                () -> {
-                    try {
-                        return new FileInputStream(file);
-                    } catch (FileNotFoundException e) {
-                        throw new IllegalArgumentException(
-                                "File not found at path: " + file.getPath(), e);
-                    }
-                });
+        return new Builder(() -> {
+            try {
+                return new FileInputStream(file);
+            } catch (FileNotFoundException e) {
+                throw new IllegalArgumentException("File not found at path: " + file.getPath(), e);
+            }
+        });
     }
 
     /**
@@ -400,18 +395,16 @@ public class Module {
      * @return a {@link Builder}  for reading the module definition from the specified resource
      */
     public static Builder builder(String classpathResource) {
-        return new Builder(
-                () -> {
-                    InputStream is =
-                            Thread.currentThread()
-                                    .getContextClassLoader()
-                                    .getResourceAsStream(classpathResource);
-                    if (is == null) {
-                        throw new IllegalArgumentException(
-                                "Resource not found at classpath: " + classpathResource);
-                    }
-                    return is;
-                });
+        return new Builder(() -> {
+            InputStream is = Thread.currentThread()
+                    .getContextClassLoader()
+                    .getResourceAsStream(classpathResource);
+            if (is == null) {
+                throw new IllegalArgumentException(
+                        "Resource not found at classpath: " + classpathResource);
+            }
+            return is;
+        });
     }
 
     /**
@@ -421,14 +414,13 @@ public class Module {
      * @return a {@link Builder} for reading the module definition from the specified path
      */
     public static Builder builder(Path path) {
-        return new Builder(
-                () -> {
-                    try {
-                        return Files.newInputStream(path);
-                    } catch (IOException e) {
-                        throw new IllegalArgumentException("Error opening file: " + path, e);
-                    }
-                });
+        return new Builder(() -> {
+            try {
+                return Files.newInputStream(path);
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Error opening file: " + path, e);
+            }
+        });
     }
 
     public static class Builder {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
@@ -847,12 +847,11 @@ public class OpcodeImpl {
         var currentElement = instance.element(elementidx);
         var currentElementCount =
                 (currentElement instanceof PassiveElement) ? currentElement.elementCount() : 0;
-        boolean isOutOfBounds =
-                (size < 0
-                        || elementidx > elementCount
-                        || (size > 0 && !(currentElement instanceof PassiveElement))
-                        || elemidx + size > currentElementCount
-                        || end > table.size());
+        boolean isOutOfBounds = (size < 0
+                || elementidx > elementCount
+                || (size > 0 && !(currentElement instanceof PassiveElement))
+                || elemidx + size > currentElementCount
+                || end > table.size());
 
         if (isOutOfBounds) {
             throw new WASMRuntimeException("out of bounds table access");

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/TypeValidator.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/TypeValidator.java
@@ -111,93 +111,86 @@ public class TypeValidator {
             // control flow instructions handling
             switch (op.opcode()) {
                 case LOOP:
-                case BLOCK:
-                    {
-                        var typeId = (int) op.operands()[0];
-                        stackLimit.push(valueTypeStack.size());
-                        if (typeId == 0x40) { // epsilon
-                            returns.push(List.of());
-                        } else if (ValueType.isValid(typeId)) {
-                            returns.push(List.of(ValueType.forId(typeId)));
-                        } else {
-                            returns.push(instance.type(typeId).returns());
-                        }
-                        unwindStack.push(new ArrayDeque<>());
-                        break;
-                    }
-                case IF:
-                    {
-                        popAndVerifyType(ValueType.I32);
-                        stackLimit.push(valueTypeStack.size());
+                case BLOCK: {
+                    var typeId = (int) op.operands()[0];
+                    stackLimit.push(valueTypeStack.size());
+                    if (typeId == 0x40) { // epsilon
                         returns.push(List.of());
-                        unwindStack.push(new ArrayDeque<>());
-                        break;
+                    } else if (ValueType.isValid(typeId)) {
+                        returns.push(List.of(ValueType.forId(typeId)));
+                    } else {
+                        returns.push(instance.type(typeId).returns());
                     }
-                case ELSE:
-                    {
-                        var limit = stackLimit.pop();
-                        // remove anything evaluated in the IF branch
-                        while (valueTypeStack.size() > limit) {
-                            valueTypeStack.pop();
-                        }
-                        stackLimit.push(limit);
-                        break;
+                    unwindStack.push(new ArrayDeque<>());
+                    break;
+                }
+                case IF: {
+                    popAndVerifyType(ValueType.I32);
+                    stackLimit.push(valueTypeStack.size());
+                    returns.push(List.of());
+                    unwindStack.push(new ArrayDeque<>());
+                    break;
+                }
+                case ELSE: {
+                    var limit = stackLimit.pop();
+                    // remove anything evaluated in the IF branch
+                    while (valueTypeStack.size() > limit) {
+                        valueTypeStack.pop();
                     }
-                case RETURN:
-                    {
-                        var limit = stackLimit.peek();
+                    stackLimit.push(limit);
+                    break;
+                }
+                case RETURN: {
+                    var limit = stackLimit.peek();
 
-                        validateReturns(functionType.returns(), limit);
+                    validateReturns(functionType.returns(), limit);
 
-                        i = jumpToNextEndOrElse(body.instructions(), op, i);
-                        break;
-                    }
-                case BR:
-                    {
-                        // targetReturn should come from the label
-                        // peek is likely wrong, we should check the tracking destination label
-                        var expected = returns.peek();
-                        var limit = stackLimit.peek();
+                    i = jumpToNextEndOrElse(body.instructions(), op, i);
+                    break;
+                }
+                case BR: {
+                    // targetReturn should come from the label
+                    // peek is likely wrong, we should check the tracking destination label
+                    var expected = returns.peek();
+                    var limit = stackLimit.peek();
 
-                        //                    validateReturns(expected, limit);
+                    //                    validateReturns(expected, limit);
 
-                        // the remaining instructions are not going to be evaluated ever
-                        // but, if we are in an IF we should validate the other branch
-                        // if we are in a BLOCK should we follow the jump out instead?
-                        i = jumpToNextEndOrElse(body.instructions(), op, i);
-                        // i = op.labelTrue() - 1;
-                        break;
-                    }
+                    // the remaining instructions are not going to be evaluated ever
+                    // but, if we are in an IF we should validate the other branch
+                    // if we are in a BLOCK should we follow the jump out instead?
+                    i = jumpToNextEndOrElse(body.instructions(), op, i);
+                    // i = op.labelTrue() - 1;
+                    break;
+                }
                 case BR_IF:
-                case BR_TABLE:
-                    {
-                        popAndVerifyType(ValueType.I32);
-                        var expected = returns.peek();
-                        var limit = stackLimit.peek();
+                case BR_TABLE: {
+                    popAndVerifyType(ValueType.I32);
+                    var expected = returns.peek();
+                    var limit = stackLimit.peek();
 
-                        //                    validateReturns(expected, limit);
-                        break;
+                    //                    validateReturns(expected, limit);
+                    break;
+                }
+                case END: {
+                    var expected = returns.pop();
+                    var limit = stackLimit.pop();
+
+                    // TODO: here there are a ton of missing checks
+                    while (valueTypeStack.size() > limit) {
+                        valueTypeStack.pop();
                     }
-                case END:
-                    {
-                        var expected = returns.pop();
-                        var limit = stackLimit.pop();
-
-                        // TODO: here there are a ton of missing checks
-                        while (valueTypeStack.size() > limit) {
-                            valueTypeStack.pop();
-                        }
-                        var unwind = unwindStack.pop();
-                        while (unwind.size() > 0) {
-                            valueTypeStack.push(unwind.pop());
-                        }
-
-                        // need to push on the stack the results
-                        for (var ret : expected) {
-                            valueTypeStack.push(ret);
-                        }
-                        break;
+                    var unwind = unwindStack.pop();
+                    while (unwind.size() > 0) {
+                        valueTypeStack.push(unwind.pop());
                     }
+
+                    // need to push on the stack the results
+                    for (var ret : expected) {
+                        valueTypeStack.push(ret);
+                    }
+                    break;
+                }
                 default:
                     break;
             }
@@ -257,29 +250,26 @@ public class TypeValidator {
                 case BR:
                 case END:
                     break;
-                case DATA_DROP:
-                    {
-                        var index = (int) op.operands()[0];
-                        if (instance.memory() == null
-                                || instance.memory().dataSegments() == null
-                                || index >= instance.memory().dataSegments().length) {
-                            throw new InvalidException("unknown data segment");
-                        }
-                        break;
+                case DATA_DROP: {
+                    var index = (int) op.operands()[0];
+                    if (instance.memory() == null
+                            || instance.memory().dataSegments() == null
+                            || index >= instance.memory().dataSegments().length) {
+                        throw new InvalidException("unknown data segment");
                     }
-                case DROP:
-                    {
-                        popAndVerifyType(null);
-                        break;
-                    }
+                    break;
+                }
+                case DROP: {
+                    popAndVerifyType(null);
+                    break;
+                }
                 case I32_STORE:
                 case I32_STORE8:
-                case I32_STORE16:
-                    {
-                        popAndVerifyType(ValueType.I32);
-                        popAndVerifyType(ValueType.I32);
-                        break;
-                    }
+                case I32_STORE16: {
+                    popAndVerifyType(ValueType.I32);
+                    popAndVerifyType(ValueType.I32);
+                    break;
+                }
                 case I32_LOAD:
                 case I32_LOAD8_U:
                 case I32_LOAD8_S:
@@ -291,18 +281,16 @@ public class TypeValidator {
                 case I32_EXTEND_8_S:
                 case I32_EXTEND_16_S:
                 case I32_EQZ:
-                case MEMORY_GROW:
-                    {
-                        popAndVerifyType(ValueType.I32);
-                        valueTypeStack.push(ValueType.I32);
-                        break;
-                    }
+                case MEMORY_GROW: {
+                    popAndVerifyType(ValueType.I32);
+                    valueTypeStack.push(ValueType.I32);
+                    break;
+                }
                 case I32_CONST:
-                case MEMORY_SIZE:
-                    {
-                        valueTypeStack.push(ValueType.I32);
-                        break;
-                    }
+                case MEMORY_SIZE: {
+                    valueTypeStack.push(ValueType.I32);
+                    break;
+                }
                 case I32_ADD:
                 case I32_SUB:
                 case I32_MUL:
@@ -327,39 +315,35 @@ public class TypeValidator {
                 case I32_SHR_U:
                 case I32_SHR_S:
                 case I32_ROTL:
-                case I32_ROTR:
-                    {
-                        popAndVerifyType(ValueType.I32);
-                        popAndVerifyType(ValueType.I32);
-                        valueTypeStack.push(ValueType.I32);
-                        break;
-                    }
+                case I32_ROTR: {
+                    popAndVerifyType(ValueType.I32);
+                    popAndVerifyType(ValueType.I32);
+                    valueTypeStack.push(ValueType.I32);
+                    break;
+                }
                 case I32_WRAP_I64:
-                case I64_EQZ:
-                    {
-                        popAndVerifyType(ValueType.I64);
-                        valueTypeStack.push(ValueType.I32);
-                        break;
-                    }
+                case I64_EQZ: {
+                    popAndVerifyType(ValueType.I64);
+                    valueTypeStack.push(ValueType.I32);
+                    break;
+                }
                 case I32_TRUNC_F32_S:
                 case I32_TRUNC_F32_U:
                 case I32_TRUNC_SAT_F32_S:
                 case I32_TRUNC_SAT_F32_U:
-                case I32_REINTERPRET_F32:
-                    {
-                        popAndVerifyType(ValueType.F32);
-                        valueTypeStack.push(ValueType.I32);
-                        break;
-                    }
+                case I32_REINTERPRET_F32: {
+                    popAndVerifyType(ValueType.F32);
+                    valueTypeStack.push(ValueType.I32);
+                    break;
+                }
                 case I32_TRUNC_F64_S:
                 case I32_TRUNC_F64_U:
                 case I32_TRUNC_SAT_F64_S:
-                case I32_TRUNC_SAT_F64_U:
-                    {
-                        popAndVerifyType(ValueType.F64);
-                        valueTypeStack.push(ValueType.I32);
-                        break;
-                    }
+                case I32_TRUNC_SAT_F64_U: {
+                    popAndVerifyType(ValueType.F64);
+                    valueTypeStack.push(ValueType.I32);
+                    break;
+                }
                 case I64_LOAD:
                 case I64_LOAD8_S:
                 case I64_LOAD8_U:
@@ -368,26 +352,23 @@ public class TypeValidator {
                 case I64_LOAD32_S:
                 case I64_LOAD32_U:
                 case I64_EXTEND_I32_U:
-                case I64_EXTEND_I32_S:
-                    {
-                        popAndVerifyType(ValueType.I32);
-                        valueTypeStack.push(ValueType.I64);
-                        break;
-                    }
-                case I64_CONST:
-                    {
-                        valueTypeStack.push(ValueType.I64);
-                        break;
-                    }
+                case I64_EXTEND_I32_S: {
+                    popAndVerifyType(ValueType.I32);
+                    valueTypeStack.push(ValueType.I64);
+                    break;
+                }
+                case I64_CONST: {
+                    valueTypeStack.push(ValueType.I64);
+                    break;
+                }
                 case I64_STORE:
                 case I64_STORE8:
                 case I64_STORE16:
-                case I64_STORE32:
-                    {
-                        popAndVerifyType(ValueType.I64);
-                        popAndVerifyType(ValueType.I32);
-                        break;
-                    }
+                case I64_STORE32: {
+                    popAndVerifyType(ValueType.I64);
+                    popAndVerifyType(ValueType.I32);
+                    break;
+                }
                 case I64_ADD:
                 case I64_SUB:
                 case I64_MUL:
@@ -402,13 +383,12 @@ public class TypeValidator {
                 case I64_SHR_U:
                 case I64_SHR_S:
                 case I64_ROTL:
-                case I64_ROTR:
-                    {
-                        popAndVerifyType(ValueType.I64);
-                        popAndVerifyType(ValueType.I64);
-                        valueTypeStack.push(ValueType.I64);
-                        break;
-                    }
+                case I64_ROTR: {
+                    popAndVerifyType(ValueType.I64);
+                    popAndVerifyType(ValueType.I64);
+                    valueTypeStack.push(ValueType.I64);
+                    break;
+                }
                 case I64_EQ:
                 case I64_NE:
                 case I64_LT_S:
@@ -418,299 +398,264 @@ public class TypeValidator {
                 case I64_GT_S:
                 case I64_GT_U:
                 case I64_GE_S:
-                case I64_GE_U:
-                    {
-                        popAndVerifyType(ValueType.I64);
-                        popAndVerifyType(ValueType.I64);
-                        valueTypeStack.push(ValueType.I32);
-                        break;
-                    }
+                case I64_GE_U: {
+                    popAndVerifyType(ValueType.I64);
+                    popAndVerifyType(ValueType.I64);
+                    valueTypeStack.push(ValueType.I32);
+                    break;
+                }
                 case I64_CLZ:
                 case I64_CTZ:
                 case I64_POPCNT:
                 case I64_EXTEND_8_S:
                 case I64_EXTEND_16_S:
-                case I64_EXTEND_32_S:
-                    {
-                        popAndVerifyType(ValueType.I64);
-                        valueTypeStack.push(ValueType.I64);
-                        break;
-                    }
+                case I64_EXTEND_32_S: {
+                    popAndVerifyType(ValueType.I64);
+                    valueTypeStack.push(ValueType.I64);
+                    break;
+                }
                 case I64_REINTERPRET_F64:
                 case I64_TRUNC_F64_S:
                 case I64_TRUNC_F64_U:
                 case I64_TRUNC_SAT_F64_S:
-                case I64_TRUNC_SAT_F64_U:
-                    {
-                        popAndVerifyType(ValueType.F64);
-                        valueTypeStack.push(ValueType.I64);
-                        break;
-                    }
+                case I64_TRUNC_SAT_F64_U: {
+                    popAndVerifyType(ValueType.F64);
+                    valueTypeStack.push(ValueType.I64);
+                    break;
+                }
                 case I64_TRUNC_F32_S:
                 case I64_TRUNC_F32_U:
                 case I64_TRUNC_SAT_F32_S:
-                case I64_TRUNC_SAT_F32_U:
-                    {
-                        popAndVerifyType(ValueType.F32);
-                        valueTypeStack.push(ValueType.I64);
-                        break;
-                    }
-                case F32_STORE:
-                    {
-                        popAndVerifyType(ValueType.F32);
-                        popAndVerifyType(ValueType.I32);
-                        break;
-                    }
-                case F32_CONST:
-                    {
-                        valueTypeStack.push(ValueType.F32);
-                        break;
-                    }
+                case I64_TRUNC_SAT_F32_U: {
+                    popAndVerifyType(ValueType.F32);
+                    valueTypeStack.push(ValueType.I64);
+                    break;
+                }
+                case F32_STORE: {
+                    popAndVerifyType(ValueType.F32);
+                    popAndVerifyType(ValueType.I32);
+                    break;
+                }
+                case F32_CONST: {
+                    valueTypeStack.push(ValueType.F32);
+                    break;
+                }
                 case F32_LOAD:
                 case F32_CONVERT_I32_S:
                 case F32_CONVERT_I32_U:
-                case F32_REINTERPRET_I32:
-                    {
-                        popAndVerifyType(ValueType.I32);
-                        valueTypeStack.push(ValueType.F32);
-                        break;
-                    }
+                case F32_REINTERPRET_I32: {
+                    popAndVerifyType(ValueType.I32);
+                    valueTypeStack.push(ValueType.F32);
+                    break;
+                }
                 case F32_CONVERT_I64_S:
-                case F32_CONVERT_I64_U:
-                    {
-                        popAndVerifyType(ValueType.I64);
-                        valueTypeStack.push(ValueType.F32);
-                        break;
-                    }
+                case F32_CONVERT_I64_U: {
+                    popAndVerifyType(ValueType.I64);
+                    valueTypeStack.push(ValueType.F32);
+                    break;
+                }
                 case F64_LOAD:
                 case F64_CONVERT_I32_S:
-                case F64_CONVERT_I32_U:
-                    {
-                        popAndVerifyType(ValueType.I32);
-                        valueTypeStack.push(ValueType.F64);
-                        break;
-                    }
+                case F64_CONVERT_I32_U: {
+                    popAndVerifyType(ValueType.I32);
+                    valueTypeStack.push(ValueType.F64);
+                    break;
+                }
                 case F64_CONVERT_I64_S:
                 case F64_CONVERT_I64_U:
-                case F64_REINTERPRET_I64:
-                    {
-                        popAndVerifyType(ValueType.I64);
-                        valueTypeStack.push(ValueType.F64);
-                        break;
-                    }
-                case F64_PROMOTE_F32:
-                    {
-                        popAndVerifyType(ValueType.F32);
-                        valueTypeStack.push(ValueType.F64);
-                        break;
-                    }
-                case F32_DEMOTE_F64:
-                    {
-                        popAndVerifyType(ValueType.F64);
-                        valueTypeStack.push(ValueType.F32);
-                        break;
-                    }
+                case F64_REINTERPRET_I64: {
+                    popAndVerifyType(ValueType.I64);
+                    valueTypeStack.push(ValueType.F64);
+                    break;
+                }
+                case F64_PROMOTE_F32: {
+                    popAndVerifyType(ValueType.F32);
+                    valueTypeStack.push(ValueType.F64);
+                    break;
+                }
+                case F32_DEMOTE_F64: {
+                    popAndVerifyType(ValueType.F64);
+                    valueTypeStack.push(ValueType.F32);
+                    break;
+                }
                 case F32_SQRT:
                 case F32_ABS:
                 case F32_NEG:
                 case F32_CEIL:
                 case F32_FLOOR:
                 case F32_TRUNC:
-                case F32_NEAREST:
-                    {
-                        popAndVerifyType(ValueType.F32);
-                        valueTypeStack.push(ValueType.F32);
-                        break;
-                    }
+                case F32_NEAREST: {
+                    popAndVerifyType(ValueType.F32);
+                    valueTypeStack.push(ValueType.F32);
+                    break;
+                }
                 case F32_ADD:
                 case F32_SUB:
                 case F32_MUL:
                 case F32_DIV:
                 case F32_MIN:
                 case F32_MAX:
-                case F32_COPYSIGN:
-                    {
-                        popAndVerifyType(ValueType.F32);
-                        popAndVerifyType(ValueType.F32);
-                        valueTypeStack.push(ValueType.F32);
-                        break;
-                    }
+                case F32_COPYSIGN: {
+                    popAndVerifyType(ValueType.F32);
+                    popAndVerifyType(ValueType.F32);
+                    valueTypeStack.push(ValueType.F32);
+                    break;
+                }
                 case F32_EQ:
                 case F32_NE:
                 case F32_LT:
                 case F32_LE:
                 case F32_GT:
-                case F32_GE:
-                    {
-                        popAndVerifyType(ValueType.F32);
-                        popAndVerifyType(ValueType.F32);
-                        valueTypeStack.push(ValueType.I32);
-                        break;
-                    }
-                case F64_STORE:
-                    {
-                        popAndVerifyType(ValueType.F64);
-                        popAndVerifyType(ValueType.I32);
-                        break;
-                    }
-                case F64_CONST:
-                    {
-                        valueTypeStack.push(ValueType.F64);
-                        break;
-                    }
+                case F32_GE: {
+                    popAndVerifyType(ValueType.F32);
+                    popAndVerifyType(ValueType.F32);
+                    valueTypeStack.push(ValueType.I32);
+                    break;
+                }
+                case F64_STORE: {
+                    popAndVerifyType(ValueType.F64);
+                    popAndVerifyType(ValueType.I32);
+                    break;
+                }
+                case F64_CONST: {
+                    valueTypeStack.push(ValueType.F64);
+                    break;
+                }
                 case F64_SQRT:
                 case F64_ABS:
                 case F64_NEG:
                 case F64_CEIL:
                 case F64_FLOOR:
                 case F64_TRUNC:
-                case F64_NEAREST:
-                    {
-                        popAndVerifyType(ValueType.F64);
-                        valueTypeStack.push(ValueType.F64);
-                        break;
-                    }
+                case F64_NEAREST: {
+                    popAndVerifyType(ValueType.F64);
+                    valueTypeStack.push(ValueType.F64);
+                    break;
+                }
                 case F64_ADD:
                 case F64_SUB:
                 case F64_MUL:
                 case F64_DIV:
                 case F64_MIN:
                 case F64_MAX:
-                case F64_COPYSIGN:
-                    {
-                        popAndVerifyType(ValueType.F64);
-                        popAndVerifyType(ValueType.F64);
-                        valueTypeStack.push(ValueType.F64);
-                        break;
-                    }
+                case F64_COPYSIGN: {
+                    popAndVerifyType(ValueType.F64);
+                    popAndVerifyType(ValueType.F64);
+                    valueTypeStack.push(ValueType.F64);
+                    break;
+                }
                 case F64_EQ:
                 case F64_NE:
                 case F64_LT:
                 case F64_LE:
                 case F64_GT:
-                case F64_GE:
-                    {
-                        popAndVerifyType(ValueType.F64);
-                        popAndVerifyType(ValueType.F64);
-                        valueTypeStack.push(ValueType.I32);
-                        break;
+                case F64_GE: {
+                    popAndVerifyType(ValueType.F64);
+                    popAndVerifyType(ValueType.F64);
+                    valueTypeStack.push(ValueType.I32);
+                    break;
+                }
+                case LOCAL_SET: {
+                    var index = (int) op.operands()[0];
+                    ValueType expectedType = (index < inputLen)
+                            ? functionType.params().get(index)
+                            : localTypes.get(index - inputLen);
+                    popAndVerifyType(expectedType);
+                    break;
+                }
+                case LOCAL_GET: {
+                    var index = (int) op.operands()[0];
+                    ValueType expectedType = (index < inputLen)
+                            ? functionType.params().get(index)
+                            : localTypes.get(index - inputLen);
+                    valueTypeStack.push(expectedType);
+                    break;
+                }
+                case LOCAL_TEE: {
+                    var index = (int) op.operands()[0];
+                    ValueType expectedType = (index < inputLen)
+                            ? functionType.params().get(index)
+                            : localTypes.get(index - inputLen);
+                    popAndVerifyType(expectedType);
+                    valueTypeStack.push(expectedType);
+                    break;
+                }
+                case GLOBAL_GET: {
+                    var type = instance.readGlobal((int) op.operands()[0]).type();
+                    valueTypeStack.push(type);
+                    break;
+                }
+                case GLOBAL_SET: {
+                    popAndVerifyType(instance.readGlobal((int) op.operands()[0]).type());
+                    break;
+                }
+                case CALL: {
+                    var index = (int) op.operands()[0];
+                    var types = instance.type(instance.functionType(index));
+                    for (int j = types.params().size() - 1; j >= 0; j--) {
+                        popAndVerifyType(types.params().get(j));
                     }
-                case LOCAL_SET:
-                    {
-                        var index = (int) op.operands()[0];
-                        ValueType expectedType =
-                                (index < inputLen)
-                                        ? functionType.params().get(index)
-                                        : localTypes.get(index - inputLen);
-                        popAndVerifyType(expectedType);
-                        break;
+                    // TODO: verify the order
+                    for (var resultType : types.returns()) {
+                        valueTypeStack.push(resultType);
                     }
-                case LOCAL_GET:
-                    {
-                        var index = (int) op.operands()[0];
-                        ValueType expectedType =
-                                (index < inputLen)
-                                        ? functionType.params().get(index)
-                                        : localTypes.get(index - inputLen);
-                        valueTypeStack.push(expectedType);
-                        break;
-                    }
-                case LOCAL_TEE:
-                    {
-                        var index = (int) op.operands()[0];
-                        ValueType expectedType =
-                                (index < inputLen)
-                                        ? functionType.params().get(index)
-                                        : localTypes.get(index - inputLen);
-                        popAndVerifyType(expectedType);
-                        valueTypeStack.push(expectedType);
-                        break;
-                    }
-                case GLOBAL_GET:
-                    {
-                        var type = instance.readGlobal((int) op.operands()[0]).type();
-                        valueTypeStack.push(type);
-                        break;
-                    }
-                case GLOBAL_SET:
-                    {
-                        popAndVerifyType(instance.readGlobal((int) op.operands()[0]).type());
-                        break;
-                    }
-                case CALL:
-                    {
-                        var index = (int) op.operands()[0];
-                        var types = instance.type(instance.functionType(index));
-                        for (int j = types.params().size() - 1; j >= 0; j--) {
-                            popAndVerifyType(types.params().get(j));
-                        }
-                        // TODO: verify the order
-                        for (var resultType : types.returns()) {
-                            valueTypeStack.push(resultType);
-                        }
-                        break;
-                    }
-                case CALL_INDIRECT:
-                    {
-                        var typeId = (int) op.operands()[0];
-                        popAndVerifyType(ValueType.I32);
+                    break;
+                }
+                case CALL_INDIRECT: {
+                    var typeId = (int) op.operands()[0];
+                    popAndVerifyType(ValueType.I32);
 
-                        var types = instance.type(typeId);
-                        for (int j = types.params().size() - 1; j >= 0; j--) {
-                            popAndVerifyType(types.params().get(j));
-                        }
-                        // TODO: verify the order
-                        for (var resultType : types.returns()) {
-                            valueTypeStack.push(resultType);
-                        }
-                        break;
+                    var types = instance.type(typeId);
+                    for (int j = types.params().size() - 1; j >= 0; j--) {
+                        popAndVerifyType(types.params().get(j));
                     }
-                case REF_NULL:
-                    {
-                        valueTypeStack.push(ValueType.forId((int) op.operands()[0]));
-                        break;
+                    // TODO: verify the order
+                    for (var resultType : types.returns()) {
+                        valueTypeStack.push(resultType);
                     }
-                case REF_IS_NULL:
-                    {
-                        var ref = valueTypeStack.poll();
-                        if (!ref.isReference()) {
-                            throw new InvalidException(
-                                    "type mismatch: expected FuncRef or ExtRef, but was " + ref);
-                        }
-                        valueTypeStack.push(ValueType.I32);
-                        break;
+                    break;
+                }
+                case REF_NULL: {
+                    valueTypeStack.push(ValueType.forId((int) op.operands()[0]));
+                    break;
+                }
+                case REF_IS_NULL: {
+                    var ref = valueTypeStack.poll();
+                    if (!ref.isReference()) {
+                        throw new InvalidException(
+                                "type mismatch: expected FuncRef or ExtRef, but was " + ref);
                     }
-                case SELECT:
-                    {
-                        popAndVerifyType(ValueType.I32);
-                        var a = valueTypeStack.poll();
-                        var b = valueTypeStack.poll();
-                        // the result is polymorphic
-                        valueTypeStack.push(ValueType.UNKNOWN);
-                        break;
-                    }
-                case SELECT_T:
-                    {
-                        popAndVerifyType(ValueType.I32);
-                        var a = valueTypeStack.poll();
-                        var b = valueTypeStack.poll();
+                    valueTypeStack.push(ValueType.I32);
+                    break;
+                }
+                case SELECT: {
+                    popAndVerifyType(ValueType.I32);
+                    var a = valueTypeStack.poll();
+                    var b = valueTypeStack.poll();
+                    // the result is polymorphic
+                    valueTypeStack.push(ValueType.UNKNOWN);
+                    break;
+                }
+                case SELECT_T: {
+                    popAndVerifyType(ValueType.I32);
+                    var a = valueTypeStack.poll();
+                    var b = valueTypeStack.poll();
 
-                        if (a != b) {
-                            throw new InvalidException(
-                                    "type mismatch: expected " + a + ", but was " + b);
-                        }
-                        valueTypeStack.push(a);
-                        break;
+                    if (a != b) {
+                        throw new InvalidException(
+                                "type mismatch: expected " + a + ", but was " + b);
                     }
+                    valueTypeStack.push(a);
+                    break;
+                }
                 case MEMORY_COPY:
                 case MEMORY_FILL:
-                case MEMORY_INIT:
-                    {
-                        popAndVerifyType(ValueType.I32);
-                        popAndVerifyType(ValueType.I32);
-                        popAndVerifyType(ValueType.I32);
-                        break;
-                    }
+                case MEMORY_INIT: {
+                    popAndVerifyType(ValueType.I32);
+                    popAndVerifyType(ValueType.I32);
+                    popAndVerifyType(ValueType.I32);
+                    break;
+                }
                 default:
                     throw new IllegalArgumentException(
                             "Missing type validation opcode handling for " + op.opcode());

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/InterruptionTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/InterruptionTest.java
@@ -30,13 +30,12 @@ public class InterruptionTest {
 
     private static void assertInterruption(Runnable function) throws InterruptedException {
         AtomicBoolean interrupted = new AtomicBoolean();
-        Runnable runnable =
-                () -> {
-                    var e = assertThrows(WASMMachineException.class, function::run);
-                    var ex = assertInstanceOf(ChicoryException.class, e.getCause());
-                    assertEquals("Thread interrupted", ex.getMessage());
-                    interrupted.set(true);
-                };
+        Runnable runnable = () -> {
+            var e = assertThrows(WASMMachineException.class, function::run);
+            var ex = assertInstanceOf(ChicoryException.class, e.getCause());
+            assertEquals("Thread interrupted", ex.getMessage());
+            interrupted.set(true);
+        };
 
         // start the thread and wait for WASM execution
         Thread thread = new Thread(runnable);

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
@@ -71,31 +71,28 @@ public class ModuleTest {
         final AtomicInteger count = new AtomicInteger();
         final String expected = "Hello, World!";
 
-        var func =
-                new HostFunction(
-                        (Instance instance,
-                                Value... args) -> { // decompiled is: console_log(13, 0);
-                            Memory memory = instance.memory();
-                            var len = args[0].asInt();
-                            var offset = args[1].asInt();
-                            var message = memory.readString(offset, len);
+        var func = new HostFunction(
+                (Instance instance, Value... args) -> { // decompiled is: console_log(13, 0);
+                    Memory memory = instance.memory();
+                    var len = args[0].asInt();
+                    var offset = args[1].asInt();
+                    var message = memory.readString(offset, len);
 
-                            if (expected.equals(message)) {
-                                count.incrementAndGet();
-                            }
+                    if (expected.equals(message)) {
+                        count.incrementAndGet();
+                    }
 
-                            return null;
-                        },
-                        "console",
-                        "log",
-                        List.of(ValueType.I32, ValueType.I32),
-                        List.of());
+                    return null;
+                },
+                "console",
+                "log",
+                List.of(ValueType.I32, ValueType.I32),
+                List.of());
         var funcs = new HostFunction[] {func};
-        var instance =
-                Module.builder("compiled/host-function.wat.wasm")
-                        .withHostImports(new HostImports(funcs))
-                        .build()
-                        .instantiate();
+        var instance = Module.builder("compiled/host-function.wat.wasm")
+                .withHostImports(new HostImports(funcs))
+                .build()
+                .instantiate();
         var logIt = instance.export("logIt");
         logIt.apply();
 
@@ -127,26 +124,24 @@ public class ModuleTest {
     public void shouldWorkWithStartFunction() {
         final AtomicInteger count = new AtomicInteger();
 
-        var func =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            var val = args[0];
+        var func = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    var val = args[0];
 
-                            if (val.asInt() == 42) {
-                                count.incrementAndGet();
-                            }
+                    if (val.asInt() == 42) {
+                        count.incrementAndGet();
+                    }
 
-                            return null;
-                        },
-                        "env",
-                        "gotit",
-                        List.of(ValueType.I32),
-                        List.of());
+                    return null;
+                },
+                "env",
+                "gotit",
+                List.of(ValueType.I32),
+                List.of());
         var funcs = new HostFunction[] {func};
-        var module =
-                Module.builder("compiled/start.wat.wasm")
-                        .withHostImports(new HostImports(funcs))
-                        .build();
+        var module = Module.builder("compiled/start.wat.wasm")
+                .withHostImports(new HostImports(funcs))
+                .build();
         module.instantiate();
 
         assertTrue(count.get() > 0);
@@ -260,42 +255,38 @@ public class ModuleTest {
 
     @Test
     public void shouldRunMixedImports() {
-        var cbrtFunc =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            var x = args[0].asInt();
-                            var cbrt = Math.cbrt(x);
-                            return new Value[] {Value.fromDouble(cbrt)};
-                        },
-                        "env",
-                        "cbrt",
-                        List.of(ValueType.I32),
-                        List.of(ValueType.F64));
+        var cbrtFunc = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    var x = args[0].asInt();
+                    var cbrt = Math.cbrt(x);
+                    return new Value[] {Value.fromDouble(cbrt)};
+                },
+                "env",
+                "cbrt",
+                List.of(ValueType.I32),
+                List.of(ValueType.F64));
         var logResult = new AtomicReference<String>(null);
-        var logFunc =
-                new HostFunction(
-                        (Instance instance, Value... args) -> {
-                            var logLevel = args[0].asInt();
-                            var value = (int) args[1].asDouble();
-                            logResult.set(logLevel + ": " + value);
-                            return null;
-                        },
-                        "env",
-                        "log",
-                        List.of(ValueType.I32, ValueType.F64),
-                        List.of());
+        var logFunc = new HostFunction(
+                (Instance instance, Value... args) -> {
+                    var logLevel = args[0].asInt();
+                    var value = (int) args[1].asDouble();
+                    logResult.set(logLevel + ": " + value);
+                    return null;
+                },
+                "env",
+                "log",
+                List.of(ValueType.I32, ValueType.F64),
+                List.of());
         var memory = new HostMemory("env", "memory", new Memory(new MemoryLimits(1)));
 
-        var hostImports =
-                new HostImports(
-                        new HostFunction[] {cbrtFunc, logFunc},
-                        new HostGlobal[0],
-                        memory,
-                        new HostTable[0]);
-        var module =
-                Module.builder("compiled/mixed-imports.wat.wasm")
-                        .withHostImports(hostImports)
-                        .build();
+        var hostImports = new HostImports(
+                new HostFunction[] {cbrtFunc, logFunc},
+                new HostGlobal[0],
+                memory,
+                new HostTable[0]);
+        var module = Module.builder("compiled/mixed-imports.wat.wasm")
+                .withHostImports(hostImports)
+                .build();
         var instance = module.instantiate();
 
         var run = instance.export("main");
@@ -321,7 +312,8 @@ public class ModuleTest {
 
     @Test
     public void issue294_BRTABLE() {
-        var instance = Module.builder("compiled/issue294_brtable.wat.wasm").build().instantiate();
+        var instance =
+                Module.builder("compiled/issue294_brtable.wat.wasm").build().instantiate();
 
         var main = instance.export("main");
         assertEquals(4, main.apply()[0].asInt());
@@ -330,13 +322,12 @@ public class ModuleTest {
     @Test
     public void shouldCountNumberOfInstructions() {
         AtomicLong count = new AtomicLong(0);
-        var instance =
-                Module.builder("compiled/iterfact.wat.wasm")
-                        .withUnsafeExecutionListener(
-                                (Instruction instruction, long[] operands, MStack stack) ->
-                                        count.getAndIncrement())
-                        .build()
-                        .instantiate();
+        var instance = Module.builder("compiled/iterfact.wat.wasm")
+                .withUnsafeExecutionListener(
+                        (Instruction instruction, long[] operands, MStack stack) ->
+                                count.getAndIncrement())
+                .build()
+                .instantiate();
         var iterFact = instance.export("iterFact");
 
         iterFact.apply(Value.i32(100));
@@ -348,11 +339,9 @@ public class ModuleTest {
 
     @Test
     public void shouldValidateTypes() {
-        assertDoesNotThrow(
-                () ->
-                        Module.builder("compiled/i32.wat.wasm")
-                                .withTypeValidation(true)
-                                .build()
-                                .instantiate());
+        assertDoesNotThrow(() -> Module.builder("compiled/i32.wat.wasm")
+                .withTypeValidation(true)
+                .build()
+                .instantiate());
     }
 }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaParserMavenUtils.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaParserMavenUtils.java
@@ -9,24 +9,22 @@ import org.apache.maven.plugin.logging.Log;
 public class JavaParserMavenUtils {
 
     public static void makeJavaParserLogToMavenOutput(Log log) {
-        com.github.javaparser.utils.Log.setAdapter(
-                new com.github.javaparser.utils.Log.Adapter() {
-                    @Override
-                    public void info(Supplier<String> message) {
-                        log.info(message.get());
-                    }
+        com.github.javaparser.utils.Log.setAdapter(new com.github.javaparser.utils.Log.Adapter() {
+            @Override
+            public void info(Supplier<String> message) {
+                log.info(message.get());
+            }
 
-                    @Override
-                    public void trace(Supplier<String> message) {
-                        log.debug(message.get());
-                    }
+            @Override
+            public void trace(Supplier<String> message) {
+                log.debug(message.get());
+            }
 
-                    @Override
-                    public void error(
-                            Supplier<Throwable> throwableSupplier,
-                            Supplier<String> messageSupplier) {
-                        log.error(messageSupplier.get(), throwableSupplier.get());
-                    }
-                });
+            @Override
+            public void error(
+                    Supplier<Throwable> throwableSupplier, Supplier<String> messageSupplier) {
+                log.error(messageSupplier.get(), throwableSupplier.get());
+            }
+        });
     }
 }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
@@ -120,11 +120,10 @@ public class JavaTestGen {
         String lastModuleVarName = null;
         int fallbackVarNumber = 0;
 
-        var excludedMethods =
-                excludedTests.stream()
-                        .filter(t -> t.startsWith(testName))
-                        .map(t -> t.substring(testName.length() + 1))
-                        .collect(Collectors.toList());
+        var excludedMethods = excludedTests.stream()
+                .filter(t -> t.startsWith(testName))
+                .map(t -> t.substring(testName.length() + 1))
+                .collect(Collectors.toList());
 
         boolean excludeMalformed = excludedMalformedWasts.contains(name + ".wast");
         boolean excludeInvalid = excludedInvalidWasts.contains(name + ".wast");
@@ -159,18 +158,16 @@ public class JavaTestGen {
                     instantiateMethod.addSingleMemberAnnotation(
                             "Order", new IntegerLiteralExpr(Integer.toString(testNumber++)));
 
-                    instantiateMethod.setBody(
-                            new BlockStmt()
-                                    .addStatement(
-                                            new AssignExpr(
-                                                    new NameExpr(lastInstanceVarName),
-                                                    generateModuleInstantiation(
-                                                            cmd,
-                                                            currentWasmFile,
-                                                            importsName,
-                                                            hostFuncs,
-                                                            excludeInvalid),
-                                                    AssignExpr.Operator.ASSIGN)));
+                    instantiateMethod.setBody(new BlockStmt()
+                            .addStatement(new AssignExpr(
+                                    new NameExpr(lastInstanceVarName),
+                                    generateModuleInstantiation(
+                                            cmd,
+                                            currentWasmFile,
+                                            importsName,
+                                            hostFuncs,
+                                            excludeInvalid),
+                                    AssignExpr.Operator.ASSIGN)));
                     break;
                 case ACTION:
                 case ASSERT_RETURN:
@@ -229,9 +226,8 @@ public class JavaTestGen {
         var methodName = "test" + testNumber;
         var method = testClass.addMethod(methodName, Modifier.Keyword.PUBLIC);
         if (excludedTests.contains(methodName)) {
-            method.addAnnotation(
-                    new SingleMemberAnnotationExpr(
-                            new Name("Disabled"), new StringLiteralExpr("Test excluded")));
+            method.addAnnotation(new SingleMemberAnnotationExpr(
+                    new Name("Disabled"), new StringLiteralExpr("Test excluded")));
         }
         method.addAnnotation("Test");
         method.addSingleMemberAnnotation(
@@ -243,17 +239,13 @@ public class JavaTestGen {
     private Optional<Expression> generateFieldExport(
             String varName, Command cmd, String moduleName) {
         if (cmd.action() != null && cmd.action().field() != null) {
-            var declarator =
-                    new VariableDeclarator()
-                            .setName(varName)
-                            .setType(parseClassOrInterfaceType("ExportFunction"))
-                            .setInitializer(
-                                    new NameExpr(
-                                            moduleName
-                                                    + "Instance.export(\""
-                                                    + StringEscapeUtils.escapeJava(
-                                                            cmd.action().field())
-                                                    + "\")"));
+            var declarator = new VariableDeclarator()
+                    .setName(varName)
+                    .setType(parseClassOrInterfaceType("ExportFunction"))
+                    .setInitializer(new NameExpr(moduleName
+                            + "Instance.export(\""
+                            + StringEscapeUtils.escapeJava(cmd.action().field())
+                            + "\")"));
             Expression varDecl = new VariableDeclarationExpr(declarator);
             return Optional.of(varDecl);
         } else {
@@ -267,22 +259,19 @@ public class JavaTestGen {
         assert (cmd.expected().length > 0);
         assert (cmd.action().type() == INVOKE);
 
-        var args =
-                (cmd.action().args() != null)
-                        ? Arrays.stream(cmd.action().args())
-                                .map(WasmValue::toWasmValue)
-                                .collect(Collectors.joining(", "))
-                        : "";
+        var args = (cmd.action().args() != null)
+                ? Arrays.stream(cmd.action().args())
+                        .map(WasmValue::toWasmValue)
+                        .collect(Collectors.joining(", "))
+                : "";
 
         var invocationMethod = ".apply(" + args + ")";
         if (cmd.type() == CommandType.ASSERT_TRAP) {
-            var assertDecl =
-                    new NameExpr(
-                            "var exception ="
-                                    + " assertThrows(ChicoryException.class, () -> "
-                                    + varName
-                                    + invocationMethod
-                                    + ")");
+            var assertDecl = new NameExpr("var exception ="
+                    + " assertThrows(ChicoryException.class, () -> "
+                    + varName
+                    + invocationMethod
+                    + ")");
             if (cmd.text() != null) {
                 return List.of(assertDecl, exceptionMessageMatch(cmd.text()));
             } else {
@@ -297,16 +286,14 @@ public class JavaTestGen {
                 var returnVar = expected.toJavaValue();
                 var typeConversion = expected.extractType();
                 var deltaParam = expected.delta();
-                exprs.add(
-                        new NameExpr(
-                                "assertEquals("
-                                        + returnVar
-                                        + ", results["
-                                        + i
-                                        + "]"
-                                        + typeConversion
-                                        + deltaParam
-                                        + ")"));
+                exprs.add(new NameExpr("assertEquals("
+                        + returnVar
+                        + ", results["
+                        + i
+                        + "]"
+                        + typeConversion
+                        + deltaParam
+                        + ")"));
             }
 
             return exprs;
@@ -320,21 +307,17 @@ public class JavaTestGen {
 
         String invocationMethod;
         if (cmd.action().type() == INVOKE) {
-            var args =
-                    Arrays.stream(cmd.action().args())
-                            .map(WasmValue::toWasmValue)
-                            .collect(Collectors.joining(", "));
+            var args = Arrays.stream(cmd.action().args())
+                    .map(WasmValue::toWasmValue)
+                    .collect(Collectors.joining(", "));
             invocationMethod = ".apply(" + args + ")";
         } else {
-            throw new IllegalArgumentException("Unhandled action type " + cmd.action().type());
+            throw new IllegalArgumentException(
+                    "Unhandled action type " + cmd.action().type());
         }
 
-        var assertDecl =
-                new NameExpr(
-                        "var exception = assertDoesNotThrow(() -> "
-                                + varName
-                                + invocationMethod
-                                + ")");
+        var assertDecl = new NameExpr(
+                "var exception = assertDoesNotThrow(() -> " + varName + invocationMethod + ")");
         return List.of(assertDecl);
     }
 
@@ -347,45 +330,42 @@ public class JavaTestGen {
             String importsName,
             String hostFuncs,
             boolean excludeInvalid) {
-        var additionalParam =
-                cmd.moduleType() == null ? "" : ", ModuleType." + cmd.moduleType().toUpperCase();
-        return new NameExpr(
-                "TestModule.of(\n"
-                        + INDENT
-                        + TAB
-                        + "new File(\""
-                        + wasmFile
-                        + "\")"
-                        + additionalParam
-                        + ")\n"
-                        + ((excludeInvalid) ? "" : INDENT + ".withTypeValidation(true)\n")
-                        + ((hostFuncs != null)
-                                ? INDENT
-                                        + ".withHostImports("
-                                        + importsName
-                                        + "."
-                                        + hostFuncs
-                                        + "())\n"
-                                : "")
-                        + INDENT
-                        + ".build()\n"
-                        + INDENT
-                        + ".instantiate()\n"
-                        + INDENT
-                        + ".instance()\n"
-                        + INDENT
-                        + ".initialize(true)"); // TODO: verify start = true
+        var additionalParam = cmd.moduleType() == null
+                ? ""
+                : ", ModuleType." + cmd.moduleType().toUpperCase();
+        return new NameExpr("TestModule.of(\n"
+                + INDENT
+                + TAB
+                + "new File(\""
+                + wasmFile
+                + "\")"
+                + additionalParam
+                + ")\n"
+                + ((excludeInvalid) ? "" : INDENT + ".withTypeValidation(true)\n")
+                + ((hostFuncs != null)
+                        ? INDENT + ".withHostImports(" + importsName + "." + hostFuncs + "())\n"
+                        : "")
+                + INDENT
+                + ".build()\n"
+                + INDENT
+                + ".instantiate()\n"
+                + INDENT
+                + ".instance()\n"
+                + INDENT
+                + ".initialize(true)"); // TODO: verify start = true
     }
 
     private String detectImports(String importsName, String varName, SourceRoot testSourcesRoot) {
         String hostFuncs = null;
         try {
-            var parsed =
-                    testSourcesRoot.tryToParse(
-                            "com.dylibso.chicory.imports", importsName + ".java");
+            var parsed = testSourcesRoot.tryToParse(
+                    "com.dylibso.chicory.imports", importsName + ".java");
             if (parsed.isSuccessful()) {
-                var methods =
-                        parsed.getResult().get().getClassByName(importsName).get().getMethods();
+                var methods = parsed.getResult()
+                        .get()
+                        .getClassByName(importsName)
+                        .get()
+                        .getMethods();
 
                 for (int i = 0; i < methods.size(); i++) {
                     if (methods.get(i).getName().asString().equals(varName)) {
@@ -431,14 +411,12 @@ public class JavaTestGen {
 
         var assignementStmt = (cmd.text() != null) ? "var exception = " : "";
 
-        var assertThrows =
-                new NameExpr(
-                        assignementStmt
-                                + "assertThrows("
-                                + exceptionType
-                                + ".class, () -> "
-                                + generateModuleInstantiation(cmd, wasmFile, null, null, false)
-                                + ")");
+        var assertThrows = new NameExpr(assignementStmt
+                + "assertThrows("
+                + exceptionType
+                + ".class, () -> "
+                + generateModuleInstantiation(cmd, wasmFile, null, null, false)
+                + ")");
 
         method.getBody().get().addStatement(assertThrows);
         if (cmd.text() != null) {
@@ -446,18 +424,16 @@ public class JavaTestGen {
         }
 
         if (excluded) {
-            method.addAnnotation(
-                    new SingleMemberAnnotationExpr(
-                            new Name("Disabled"), new StringLiteralExpr("Test excluded")));
+            method.addAnnotation(new SingleMemberAnnotationExpr(
+                    new Name("Disabled"), new StringLiteralExpr("Test excluded")));
         }
     }
 
     private Expression exceptionMessageMatch(String text) {
-        return new NameExpr(
-                "assertTrue(exception.getMessage().contains(\""
-                        + text
-                        + "\"), \"'\" + exception.getMessage() + \"' doesn't contains: '"
-                        + text
-                        + "\")");
+        return new NameExpr("assertTrue(exception.getMessage().contains(\""
+                + text
+                + "\"), \"'\" + exception.getMessage() + \"' doesn't contains: '"
+                + text
+                + "\")");
     }
 }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
@@ -122,14 +122,13 @@ public class TestGenMojo extends AbstractMojo {
 
         // Instantiate the utilities
         var testSuiteDownloader = new TestSuiteDownloader(log);
-        var testGen =
-                new JavaTestGen(
-                        log,
-                        project.getBasedir(),
-                        sourceDestinationFolder,
-                        excludedTests,
-                        excludedMalformedWasts,
-                        excludedInvalidWasts);
+        var testGen = new JavaTestGen(
+                log,
+                project.getBasedir(),
+                sourceDestinationFolder,
+                excludedTests,
+                excludedMalformedWasts,
+                excludedInvalidWasts);
 
         JavaParserMavenUtils.makeJavaParserLogToMavenOutput(getLog());
 
@@ -228,7 +227,8 @@ public class TestGenMojo extends AbstractMojo {
             }
 
             var plainName = wastFile.getName().replace(".wast", "");
-            File wasmFilesFolder = compiledWastTargetFolder.toPath().resolve(plainName).toFile();
+            File wasmFilesFolder =
+                    compiledWastTargetFolder.toPath().resolve(plainName).toFile();
             File specFile = wasmFilesFolder.toPath().resolve(SPEC_JSON).toFile();
             if (!wasmFilesFolder.mkdirs()) {
                 log.warn("Could not create folder: " + wasmFilesFolder);

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestSuiteDownloader.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestSuiteDownloader.java
@@ -32,11 +32,10 @@ public class TestSuiteDownloader {
         if (!testSuiteFolder.exists()) {
             log.warn("Cloning the testsuite at ref: " + testSuiteRepoRef);
             SystemReader.getInstance().getUserConfig().clear();
-            try (Git git =
-                    Git.cloneRepository()
-                            .setURI(testSuiteRepo)
-                            .setDirectory(testSuiteFolder)
-                            .call()) {
+            try (Git git = Git.cloneRepository()
+                    .setURI(testSuiteRepo)
+                    .setDirectory(testSuiteFolder)
+                    .call()) {
                 git.checkout().setName(testSuiteRepoRef).call();
                 log.warn("Cloned the testsuite at ref: " + testSuiteRepoRef);
             }

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Files.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Files.java
@@ -15,17 +15,15 @@ public final class Files {
     private Files() {}
 
     public static void copyDirectory(Path source, Path target) throws IOException {
-        walkFileTree(
-                source,
-                new SimpleFileVisitor<>() {
-                    @Override
-                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                            throws IOException {
-                        String relative = source.relativize(file).toString().replace("\\", "/");
-                        Path path = target.resolve(relative);
-                        copy(file, path, StandardCopyOption.REPLACE_EXISTING);
-                        return FileVisitResult.CONTINUE;
-                    }
-                });
+        walkFileTree(source, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                    throws IOException {
+                String relative = source.relativize(file).toString().replace("\\", "/");
+                Path path = target.resolve(relative);
+                copy(file, path, StandardCopyOption.REPLACE_EXISTING);
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 }

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
@@ -26,19 +26,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Wast2Json {
-    private static final Logger logger =
-            new SystemLogger() {
-                @Override
-                public boolean isLoggable(Logger.Level level) {
-                    return false;
-                }
-            };
-    private static final com.dylibso.chicory.wasm.Module wasmModule =
-            Module.builder(Wast2Json.class.getResourceAsStream("/wast2json"))
-                    .withInitialize(false)
-                    .withStart(false)
-                    .build()
-                    .wasmModule();
+    private static final Logger logger = new SystemLogger() {
+        @Override
+        public boolean isLoggable(Logger.Level level) {
+            return false;
+        }
+    };
+    private static final com.dylibso.chicory.wasm.Module wasmModule = Module.builder(
+                    Wast2Json.class.getResourceAsStream("/wast2json"))
+            .withInitialize(false)
+            .withStart(false)
+            .build()
+            .wasmModule();
 
     private final File input;
     private final File output;
@@ -58,11 +57,9 @@ public class Wast2Json {
         try (ByteArrayOutputStream stdoutStream = new ByteArrayOutputStream();
                 ByteArrayOutputStream stderrStream = new ByteArrayOutputStream()) {
             try (FileInputStream fis = new FileInputStream(input);
-                    FileSystem fs =
-                            Jimfs.newFileSystem(
-                                    Configuration.unix().toBuilder()
-                                            .setAttributeViews("unix")
-                                            .build())) {
+                    FileSystem fs = Jimfs.newFileSystem(Configuration.unix().toBuilder()
+                            .setAttributeViews("unix")
+                            .build())) {
 
                 var wasiOpts = WasiOptions.builder();
 
@@ -89,7 +86,8 @@ public class Wast2Json {
 
                 try (var wasi = new WasiPreview1(logger, wasiOpts.build())) {
                     HostImports imports = new HostImports(wasi.toHostFunctions());
-                    Module module = Module.builder(wasmModule).withHostImports(imports).build();
+                    Module module =
+                            Module.builder(wasmModule).withHostImports(imports).build();
                     module.instantiate();
                 }
 

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
@@ -29,12 +29,12 @@ import java.util.List;
 
 public final class Wat2Wasm {
     private static final Logger logger = new SystemLogger();
-    private static final com.dylibso.chicory.wasm.Module wasmModule =
-            Module.builder(Wat2Wasm.class.getResourceAsStream("/wat2wasm"))
-                    .withInitialize(false)
-                    .withStart(false)
-                    .build()
-                    .wasmModule();
+    private static final com.dylibso.chicory.wasm.Module wasmModule = Module.builder(
+                    Wat2Wasm.class.getResourceAsStream("/wat2wasm"))
+            .withInitialize(false)
+            .withStart(false)
+            .build()
+            .wasmModule();
 
     private Wat2Wasm() {}
 
@@ -58,26 +58,25 @@ public final class Wat2Wasm {
         try (ByteArrayOutputStream stdoutStream = new ByteArrayOutputStream();
                 ByteArrayOutputStream stderrStream = new ByteArrayOutputStream()) {
 
-            try (FileSystem fs =
-                    Jimfs.newFileSystem(
-                            Configuration.unix().toBuilder().setAttributeViews("unix").build())) {
+            try (FileSystem fs = Jimfs.newFileSystem(
+                    Configuration.unix().toBuilder().setAttributeViews("unix").build())) {
 
                 Path target = fs.getPath("tmp");
                 java.nio.file.Files.createDirectory(target);
                 Path path = target.resolve(fileName);
                 copy(is, path, StandardCopyOption.REPLACE_EXISTING);
 
-                WasiOptions wasiOpts =
-                        WasiOptions.builder()
-                                .withStdout(stdoutStream)
-                                .withStderr(stdoutStream)
-                                .withDirectory(target.toString(), target)
-                                .withArguments(List.of("wat2wasm", path.toString(), "--output=-"))
-                                .build();
+                WasiOptions wasiOpts = WasiOptions.builder()
+                        .withStdout(stdoutStream)
+                        .withStderr(stdoutStream)
+                        .withDirectory(target.toString(), target)
+                        .withArguments(List.of("wat2wasm", path.toString(), "--output=-"))
+                        .build();
 
                 try (var wasi = new WasiPreview1(logger, wasiOpts)) {
                     HostImports imports = new HostImports(wasi.toHostFunctions());
-                    Module module = Module.builder(wasmModule).withHostImports(imports).build();
+                    Module module =
+                            Module.builder(wasmModule).withHostImports(imports).build();
                     module.instantiate();
                 }
 

--- a/wabt/src/test/java/com/dylibso/chicory/wabt/Wast2JsonTest.java
+++ b/wabt/src/test/java/com/dylibso/chicory/wabt/Wast2JsonTest.java
@@ -13,11 +13,10 @@ public class Wast2JsonTest {
     public void shouldRunWast2Json(@TempDir Path tempDir) throws Exception {
         // Arrange
         var outputFile = tempDir.resolve("fac").resolve("spec.json").toFile();
-        var wast2Json =
-                Wast2Json.builder()
-                        .withFile(new File("src/test/resources/fac.wast"))
-                        .withOutput(outputFile)
-                        .build();
+        var wast2Json = Wast2Json.builder()
+                .withFile(new File("src/test/resources/fac.wast"))
+                .withOutput(outputFile)
+                .build();
 
         // Act
         wast2Json.process();
@@ -25,6 +24,7 @@ public class Wast2JsonTest {
         System.out.println(outputFile.getAbsolutePath());
         // Assert
         assertTrue(outputFile.exists());
-        assertTrue(outputFile.toPath().getParent().resolve("spec.0.wasm").toFile().exists());
+        assertTrue(
+                outputFile.toPath().getParent().resolve("spec.0.wasm").toFile().exists());
     }
 }

--- a/wabt/src/test/java/com/dylibso/chicory/wabt/Wat2WasmTest.java
+++ b/wabt/src/test/java/com/dylibso/chicory/wabt/Wat2WasmTest.java
@@ -22,34 +22,28 @@ public class Wat2WasmTest {
 
     @Test
     public void shouldRunWat2WasmOnString() {
-        var moduleInstance =
-                Module.builder(
-                                Wat2Wasm.parse(
-                                        "(module (func (export \"add\") (param $x i32) (param $y"
-                                                + " i32) (result i32) (i32.add (local.get $x)"
-                                                + " (local.get $y))))"))
-                        .withTypeValidation(true)
-                        .withInitialize(true)
-                        .build()
-                        .instantiate();
+        var moduleInstance = Module.builder(
+                        Wat2Wasm.parse("(module (func (export \"add\") (param $x i32) (param $y"
+                                + " i32) (result i32) (i32.add (local.get $x)"
+                                + " (local.get $y))))"))
+                .withTypeValidation(true)
+                .withInitialize(true)
+                .build()
+                .instantiate();
 
         var addFunction = moduleInstance.export("add");
-        var results =
-                addFunction.apply(
-                        Value.i32(Integer.parseUnsignedInt("1")),
-                        Value.i32(Integer.parseUnsignedInt("41")));
+        var results = addFunction.apply(
+                Value.i32(Integer.parseUnsignedInt("1")),
+                Value.i32(Integer.parseUnsignedInt("41")));
         assertEquals(Integer.parseUnsignedInt("42"), results[0].asInt());
     }
 
     @Test
     public void shouldThrowMalformedException() throws Exception {
-        var malformedException =
-                assertThrows(
-                        MalformedException.class,
-                        () ->
-                                Wat2Wasm.parse(
-                                        new File(
-                                                "src/test/resources/utf8-invalid-encoding-spec.0.wat")));
+        var malformedException = assertThrows(
+                MalformedException.class,
+                () -> Wat2Wasm.parse(
+                        new File("src/test/resources/utf8-invalid-encoding-spec.0.wat")));
 
         assertTrue(malformedException.getMessage().contains("invalid utf-8 encoding"));
     }

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/Files.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/Files.java
@@ -20,42 +20,39 @@ public final class Files {
     private Files() {}
 
     public static void copyDirectory(Path source, Path target) throws IOException {
-        walkFileTree(
-                source,
-                new SimpleFileVisitor<>() {
-                    @Override
-                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
-                            throws IOException {
-                        if (isSymbolicLink(dir)) {
-                            return FileVisitResult.SKIP_SUBTREE;
-                        }
+        walkFileTree(source, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                    throws IOException {
+                if (isSymbolicLink(dir)) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
 
-                        Path directory = target.resolve(source.relativize(dir).toString());
+                Path directory = target.resolve(source.relativize(dir).toString());
 
-                        if (!directory.toString().equals("/")) {
-                            FileAttribute<?>[] attributes = new FileAttribute[0];
-                            var attributeView =
-                                    getFileAttributeView(dir, PosixFileAttributeView.class);
-                            if (attributeView != null) {
-                                var permissions = attributeView.readAttributes().permissions();
-                                var attribute = PosixFilePermissions.asFileAttribute(permissions);
-                                attributes = new FileAttribute[] {attribute};
-                            }
-
-                            createDirectory(directory, attributes);
-                        }
-
-                        return FileVisitResult.CONTINUE;
+                if (!directory.toString().equals("/")) {
+                    FileAttribute<?>[] attributes = new FileAttribute[0];
+                    var attributeView = getFileAttributeView(dir, PosixFileAttributeView.class);
+                    if (attributeView != null) {
+                        var permissions = attributeView.readAttributes().permissions();
+                        var attribute = PosixFilePermissions.asFileAttribute(permissions);
+                        attributes = new FileAttribute[] {attribute};
                     }
 
-                    @Override
-                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                            throws IOException {
-                        String relative = source.relativize(file).toString().replace("\\", "/");
-                        Path path = target.resolve(relative);
-                        copy(file, path, StandardCopyOption.COPY_ATTRIBUTES);
-                        return FileVisitResult.CONTINUE;
-                    }
-                });
+                    createDirectory(directory, attributes);
+                }
+
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                    throws IOException {
+                String relative = source.relativize(file).toString().replace("\\", "/");
+                Path path = target.resolve(relative);
+                copy(file, path, StandardCopyOption.COPY_ATTRIBUTES);
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 }

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
@@ -71,14 +71,9 @@ public class WasiPreview1 implements Closeable {
         this.logger = requireNonNull(logger);
         this.arguments =
                 opts.arguments().stream().map(value -> value.getBytes(UTF_8)).collect(toList());
-        this.environment =
-                opts.environment().entrySet().stream()
-                        .map(
-                                x ->
-                                        Map.entry(
-                                                x.getKey().getBytes(UTF_8),
-                                                x.getValue().getBytes(UTF_8)))
-                        .collect(toList());
+        this.environment = opts.environment().entrySet().stream()
+                .map(x -> Map.entry(x.getKey().getBytes(UTF_8), x.getValue().getBytes(UTF_8)))
+                .collect(toList());
 
         descriptors.allocate(new InStream(opts.stdin()));
         descriptors.allocate(new OutStream(opts.stdout()));
@@ -251,10 +246,9 @@ public class WasiPreview1 implements Closeable {
                     int environCount = args[0].asInt();
                     int environBufSize = args[1].asInt();
 
-                    int bufSize =
-                            environment.stream()
-                                    .mapToInt(x -> x.getKey().length + x.getValue().length + 2)
-                                    .sum();
+                    int bufSize = environment.stream()
+                            .mapToInt(x -> x.getKey().length + x.getValue().length + 2)
+                            .sum();
                     Memory memory = instance.memory();
                     memory.writeI32(environCount, environment.size());
                     memory.writeI32(environBufSize, bufSize);
@@ -447,15 +441,14 @@ public class WasiPreview1 implements Closeable {
                     }
 
                     if ((descriptor instanceof InStream) || (descriptor instanceof OutStream)) {
-                        Map<String, Object> attributes =
-                                Map.of(
-                                        "dev", 0L,
-                                        "ino", 0L,
-                                        "nlink", 1L,
-                                        "size", 0L,
-                                        "lastAccessTime", FileTime.from(Instant.EPOCH),
-                                        "lastModifiedTime", FileTime.from(Instant.EPOCH),
-                                        "ctime", FileTime.from(Instant.EPOCH));
+                        Map<String, Object> attributes = Map.of(
+                                "dev", 0L,
+                                "ino", 0L,
+                                "nlink", 1L,
+                                "size", 0L,
+                                "lastAccessTime", FileTime.from(Instant.EPOCH),
+                                "lastModifiedTime", FileTime.from(Instant.EPOCH),
+                                "ctime", FileTime.from(Instant.EPOCH));
                         writeFileStat(
                                 instance.memory(), buf, attributes, WasiFileType.CHARACTER_DEVICE);
                         return wasiResult(WasiErrno.ESUCCESS);
@@ -705,9 +698,8 @@ public class WasiPreview1 implements Closeable {
                                 continue;
                             }
 
-                            ByteBuffer entry =
-                                    ByteBuffer.allocate(24 + name.length)
-                                            .order(ByteOrder.LITTLE_ENDIAN);
+                            ByteBuffer entry = ByteBuffer.allocate(24 + name.length)
+                                    .order(ByteOrder.LITTLE_ENDIAN);
                             entry.putLong(0, cookie);
                             entry.putLong(8, ((Number) attributes.get("ino")).longValue());
                             entry.putInt(16, name.length);
@@ -1178,9 +1170,8 @@ public class WasiPreview1 implements Closeable {
                     }
 
                     try {
-                        var attributes =
-                                Files.readAttributes(
-                                        path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+                        var attributes = Files.readAttributes(
+                                path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
                         if (!attributes.isDirectory()) {
                             return wasiResult(WasiErrno.ENOTDIR);
                         }
@@ -1312,9 +1303,8 @@ public class WasiPreview1 implements Closeable {
                     }
 
                     try {
-                        var attributes =
-                                Files.readAttributes(
-                                        path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+                        var attributes = Files.readAttributes(
+                                path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
                         if (attributes.isDirectory()) {
                             return wasiResult(WasiErrno.EISDIR);
                         }
@@ -1630,6 +1620,7 @@ public class WasiPreview1 implements Closeable {
     }
 
     private static RuntimeException unhandledDescriptor(Descriptor descriptor) {
-        return new WASMRuntimeException("Unhandled descriptor: " + descriptor.getClass().getName());
+        return new WASMRuntimeException(
+                "Unhandled descriptor: " + descriptor.getClass().getName());
     }
 }

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiRights.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiRights.java
@@ -34,42 +34,40 @@ final class WasiRights {
     public static final int SOCK_SHUTDOWN = bit(28);
     public static final int SOCK_ACCEPT = bit(29);
 
-    public static final int FILE_RIGHTS_BASE =
-            FD_DATASYNC
-                    | FD_READ
-                    | FD_SEEK
-                    | FD_FDSTAT_SET_FLAGS
-                    | FD_SYNC
-                    | FD_TELL
-                    | FD_WRITE
-                    | FD_ADVISE
-                    | FD_ALLOCATE
-                    | FD_FILESTAT_GET
-                    | FD_FILESTAT_SET_SIZE
-                    | FD_FILESTAT_SET_TIMES
-                    | POLL_FD_READWRITE;
+    public static final int FILE_RIGHTS_BASE = FD_DATASYNC
+            | FD_READ
+            | FD_SEEK
+            | FD_FDSTAT_SET_FLAGS
+            | FD_SYNC
+            | FD_TELL
+            | FD_WRITE
+            | FD_ADVISE
+            | FD_ALLOCATE
+            | FD_FILESTAT_GET
+            | FD_FILESTAT_SET_SIZE
+            | FD_FILESTAT_SET_TIMES
+            | POLL_FD_READWRITE;
 
-    public static final int DIRECTORY_RIGHTS_BASE =
-            FD_DATASYNC
-                    | FD_FDSTAT_SET_FLAGS
-                    | FD_SYNC
-                    | PATH_CREATE_DIRECTORY
-                    | PATH_CREATE_FILE
-                    | PATH_LINK_SOURCE
-                    | PATH_LINK_TARGET
-                    | PATH_OPEN
-                    | FD_READDIR
-                    | PATH_READLINK
-                    | PATH_RENAME_SOURCE
-                    | PATH_RENAME_TARGET
-                    | PATH_FILESTAT_GET
-                    | PATH_FILESTAT_SET_SIZE
-                    | PATH_FILESTAT_SET_TIMES
-                    | FD_FILESTAT_GET
-                    | FD_FILESTAT_SET_TIMES
-                    | PATH_SYMLINK
-                    | PATH_REMOVE_DIRECTORY
-                    | PATH_UNLINK_FILE;
+    public static final int DIRECTORY_RIGHTS_BASE = FD_DATASYNC
+            | FD_FDSTAT_SET_FLAGS
+            | FD_SYNC
+            | PATH_CREATE_DIRECTORY
+            | PATH_CREATE_FILE
+            | PATH_LINK_SOURCE
+            | PATH_LINK_TARGET
+            | PATH_OPEN
+            | FD_READDIR
+            | PATH_READLINK
+            | PATH_RENAME_SOURCE
+            | PATH_RENAME_TARGET
+            | PATH_FILESTAT_GET
+            | PATH_FILESTAT_SET_SIZE
+            | PATH_FILESTAT_SET_TIMES
+            | FD_FILESTAT_GET
+            | FD_FILESTAT_SET_TIMES
+            | PATH_SYMLINK
+            | PATH_REMOVE_DIRECTORY
+            | PATH_UNLINK_FILE;
 
     private static int bit(int n) {
         return 1 << n;

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
@@ -17,11 +17,12 @@ public class WasiPreview1Test {
     public void shouldRunWasiModule() {
         // check with: wasmtime src/test/resources/compiled/hello-wasi.wat.wasm
         var fakeStdout = new MockPrintStream();
-        var wasi =
-                new WasiPreview1(this.logger, WasiOptions.builder().withStdout(fakeStdout).build());
+        var wasi = new WasiPreview1(
+                this.logger, WasiOptions.builder().withStdout(fakeStdout).build());
         var imports = new HostImports(wasi.toHostFunctions());
-        var module =
-                Module.builder("compiled/hello-wasi.wat.wasm").withHostImports(imports).build();
+        var module = Module.builder("compiled/hello-wasi.wat.wasm")
+                .withHostImports(imports)
+                .build();
         module.instantiate();
         assertEquals(fakeStdout.output().strip(), "hello world");
     }
@@ -31,9 +32,12 @@ public class WasiPreview1Test {
         // check with: wasmtime src/test/resources/compiled/hello-wasi.rs.wasm
         var expected = "Hello, World!";
         var stdout = new MockPrintStream();
-        var wasi = new WasiPreview1(this.logger, WasiOptions.builder().withStdout(stdout).build());
+        var wasi = new WasiPreview1(
+                this.logger, WasiOptions.builder().withStdout(stdout).build());
         var imports = new HostImports(wasi.toHostFunctions());
-        var module = Module.builder("compiled/hello-wasi.rs.wasm").withHostImports(imports).build();
+        var module = Module.builder("compiled/hello-wasi.rs.wasm")
+                .withHostImports(imports)
+                .build();
         module.instantiate(); // run _start and prints Hello, World!
         assertEquals(expected, stdout.output().strip());
     }
@@ -42,10 +46,15 @@ public class WasiPreview1Test {
     public void shouldRunWasiGreetRustModule() {
         // check with: wasmtime src/test/resources/compiled/greet-wasi.rs.wasm
         var fakeStdin = new ByteArrayInputStream("Benjamin".getBytes());
-        var wasiOpts = WasiOptions.builder().withStdout(System.out).withStdin(fakeStdin).build();
+        var wasiOpts = WasiOptions.builder()
+                .withStdout(System.out)
+                .withStdin(fakeStdin)
+                .build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
         var imports = new HostImports(wasi.toHostFunctions());
-        var module = Module.builder("compiled/greet-wasi.rs.wasm").withHostImports(imports).build();
+        var module = Module.builder("compiled/greet-wasi.rs.wasm")
+                .withHostImports(imports)
+                .build();
         module.instantiate();
     }
 
@@ -55,11 +64,15 @@ public class WasiPreview1Test {
         // wasi/src/test/resources/compiled/javy-demo.js.wasm
         var fakeStdin = new ByteArrayInputStream("{ \"n\": 2, \"bar\": \"baz\" }".getBytes());
         var fakeStdout = new MockPrintStream();
-        var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).withStdin(fakeStdin).build();
+        var wasiOpts = WasiOptions.builder()
+                .withStdout(fakeStdout)
+                .withStdin(fakeStdin)
+                .build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
         var imports = new HostImports(wasi.toHostFunctions());
-        var module =
-                Module.builder("compiled/javy-demo.js.javy.wasm").withHostImports(imports).build();
+        var module = Module.builder("compiled/javy-demo.js.javy.wasm")
+                .withHostImports(imports)
+                .build();
         module.instantiate();
 
         assertEquals(fakeStdout.output(), "{\"foo\":3,\"newBar\":\"baz!\"}");
@@ -70,7 +83,9 @@ public class WasiPreview1Test {
         var wasiOpts = WasiOptions.builder().build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
         var imports = new HostImports(wasi.toHostFunctions());
-        var module = Module.builder("compiled/sum.go.tiny.wasm").withHostImports(imports).build();
+        var module = Module.builder("compiled/sum.go.tiny.wasm")
+                .withHostImports(imports)
+                .build();
         var instance = module.instantiate();
         var sum = instance.export("add");
         var result = sum.apply(Value.i32(20), Value.i32(22))[0];

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiTestRunner.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiTestRunner.java
@@ -32,9 +32,8 @@ public final class WasiTestRunner {
             String stderr,
             String stdout) {
 
-        try (FileSystem fs =
-                Jimfs.newFileSystem(
-                        Configuration.unix().toBuilder().setAttributeViews("unix").build())) {
+        try (FileSystem fs = Jimfs.newFileSystem(
+                Configuration.unix().toBuilder().setAttributeViews("unix").build())) {
 
             var stdoutStream = new MockPrintStream();
             var stderrStream = new MockPrintStream();
@@ -43,11 +42,10 @@ public final class WasiTestRunner {
             allArgs.add("test");
             allArgs.addAll(args);
 
-            WasiOptions.Builder options =
-                    WasiOptions.builder()
-                            .withStdout(stdoutStream)
-                            .withStderr(stderrStream)
-                            .withArguments(allArgs);
+            WasiOptions.Builder options = WasiOptions.builder()
+                    .withStdout(stdoutStream)
+                    .withStderr(stderrStream)
+                    .withArguments(allArgs);
 
             env.forEach(options::withEnvironment);
 
@@ -81,10 +79,9 @@ public final class WasiTestRunner {
 
     private static int execute(File test, WasiOptions wasiOptions) {
         try (var wasi = new WasiPreview1(LOGGER, wasiOptions)) {
-            Module module =
-                    Module.builder(test)
-                            .withHostImports(new HostImports(wasi.toHostFunctions()))
-                            .build();
+            Module module = Module.builder(test)
+                    .withHostImports(new HostImports(wasi.toHostFunctions()))
+                    .build();
             module.instantiate();
         } catch (WASMMachineException e) {
             if (e.getCause() instanceof WasiExitException) {

--- a/wasm-support-plugin/src/main/java/OpCodeGenMojo.java
+++ b/wasm-support-plugin/src/main/java/OpCodeGenMojo.java
@@ -60,24 +60,22 @@ public class OpCodeGenMojo extends AbstractMojo {
         sourceDestinationFolder.mkdirs();
         List<String[]> lines = null;
         try {
-            lines =
-                    Files.lines(instructionsFile.toPath())
-                            .map(line -> line.split("\t"))
-                            .collect(Collectors.toList());
+            lines = Files.lines(instructionsFile.toPath())
+                    .map(line -> line.split("\t"))
+                    .collect(Collectors.toList());
         } catch (IOException e) {
             throw new MojoExecutionException(e);
         }
 
         var cu = new CompilationUnit("com.dylibso.chicory.wasm.types");
-        var destFile =
-                Path.of(
-                        sourceDestinationFolder.getAbsolutePath(),
-                        "com",
-                        "dylibso",
-                        "chicory",
-                        "wasm",
-                        "types",
-                        "OpCode.java");
+        var destFile = Path.of(
+                sourceDestinationFolder.getAbsolutePath(),
+                "com",
+                "dylibso",
+                "chicory",
+                "wasm",
+                "types",
+                "OpCode.java");
         cu.setStorage(destFile);
 
         cu.addImport("java.util.HashMap");
@@ -100,18 +98,15 @@ public class OpCodeGenMojo extends AbstractMojo {
             enumDef.addOrphanComment(new LineComment(line[0]));
             enumDef.addEntry(enumConstantDecl);
 
-            var staticAssignmentParams =
-                    Arrays.stream(line[0].split(" "))
-                            .skip(1)
-                            .map(a -> getType(a))
-                            .collect(Collectors.joining(", "));
-            staticAssignement.add(
-                    new NameExpr(
-                            "signature.put("
-                                    + enumName
-                                    + ", new WasmEncoding[] {"
-                                    + staticAssignmentParams
-                                    + "})"));
+            var staticAssignmentParams = Arrays.stream(line[0].split(" "))
+                    .skip(1)
+                    .map(a -> getType(a))
+                    .collect(Collectors.joining(", "));
+            staticAssignement.add(new NameExpr("signature.put("
+                    + enumName
+                    + ", new WasmEncoding[] {"
+                    + staticAssignmentParams
+                    + "})"));
         }
 
         var opcodeField =
@@ -119,23 +114,20 @@ public class OpCodeGenMojo extends AbstractMojo {
 
         var constructor = enumDef.addConstructor();
         constructor.addParameter("int", "opcode");
-        constructor.setBody(
-                new BlockStmt()
-                        .addStatement(
-                                new AssignExpr(
-                                        new NameExpr("this.opcode"),
-                                        new NameExpr("opcode"),
-                                        AssignExpr.Operator.ASSIGN)));
+        constructor.setBody(new BlockStmt()
+                .addStatement(new AssignExpr(
+                        new NameExpr("this.opcode"),
+                        new NameExpr("opcode"),
+                        AssignExpr.Operator.ASSIGN)));
         opcodeField.createGetter().setName("opcode");
 
-        var byOpCodeMap =
-                enumDef.addFieldWithInitializer(
-                        "Map<Integer, OpCode>",
-                        "byOpCode",
-                        new NameExpr("new HashMap<>()"),
-                        Modifier.Keyword.PRIVATE,
-                        Modifier.Keyword.STATIC,
-                        Modifier.Keyword.FINAL);
+        var byOpCodeMap = enumDef.addFieldWithInitializer(
+                "Map<Integer, OpCode>",
+                "byOpCode",
+                new NameExpr("new HashMap<>()"),
+                Modifier.Keyword.PRIVATE,
+                Modifier.Keyword.STATIC,
+                Modifier.Keyword.FINAL);
 
         var byOpCode =
                 enumDef.addMethod("byOpCode", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
@@ -144,14 +136,13 @@ public class OpCodeGenMojo extends AbstractMojo {
         byOpCode.setBody(
                 new BlockStmt().addStatement(new ReturnStmt(new NameExpr("byOpCode.get(opcode)"))));
 
-        var signature =
-                enumDef.addFieldWithInitializer(
-                        "Map<OpCode, WasmEncoding[]>",
-                        "signature",
-                        new NameExpr("new HashMap<>()"),
-                        Modifier.Keyword.PRIVATE,
-                        Modifier.Keyword.STATIC,
-                        Modifier.Keyword.FINAL);
+        var signature = enumDef.addFieldWithInitializer(
+                "Map<OpCode, WasmEncoding[]>",
+                "signature",
+                new NameExpr("new HashMap<>()"),
+                Modifier.Keyword.PRIVATE,
+                Modifier.Keyword.STATIC,
+                Modifier.Keyword.FINAL);
 
         var getSignature =
                 enumDef.addMethod("getSignature", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
@@ -163,9 +154,8 @@ public class OpCodeGenMojo extends AbstractMojo {
         var staticBlock = enumDef.addStaticInitializer();
 
         // byOpCode initialization
-        staticBlock.addStatement(
-                new NameExpr(
-                        "for (OpCode e: OpCode.values()) {" + " byOpCode.put(e.opcode(), e); }"));
+        staticBlock.addStatement(new NameExpr(
+                "for (OpCode e: OpCode.values()) {" + " byOpCode.put(e.opcode(), e); }"));
         for (var assign : staticAssignement) {
             staticBlock.addStatement(assign);
         }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -99,54 +99,52 @@ public final class Parser {
     public Module parseModule(InputStream in) {
         Module module = new Module();
 
-        parse(
-                in,
-                (s) -> {
-                    switch (s.sectionId()) {
-                        case SectionId.CUSTOM:
-                            module.addCustomSection((CustomSection) s);
-                            break;
-                        case SectionId.TYPE:
-                            module.setTypeSection((TypeSection) s);
-                            break;
-                        case SectionId.IMPORT:
-                            module.setImportSection((ImportSection) s);
-                            break;
-                        case SectionId.FUNCTION:
-                            module.setFunctionSection((FunctionSection) s);
-                            break;
-                        case SectionId.TABLE:
-                            module.setTableSection((TableSection) s);
-                            break;
-                        case SectionId.MEMORY:
-                            module.setMemorySection((MemorySection) s);
-                            break;
-                        case SectionId.GLOBAL:
-                            module.setGlobalSection((GlobalSection) s);
-                            break;
-                        case SectionId.EXPORT:
-                            module.setExportSection((ExportSection) s);
-                            break;
-                        case SectionId.START:
-                            module.setStartSection((StartSection) s);
-                            break;
-                        case SectionId.ELEMENT:
-                            module.setElementSection((ElementSection) s);
-                            break;
-                        case SectionId.CODE:
-                            module.setCodeSection((CodeSection) s);
-                            break;
-                        case SectionId.DATA:
-                            module.setDataSection((DataSection) s);
-                            break;
-                        case SectionId.DATA_COUNT:
-                            module.setDataCountSection((DataCountSection) s);
-                            break;
-                        default:
-                            logger.warnf("Ignoring section with id: %d", s.sectionId());
-                            break;
-                    }
-                });
+        parse(in, (s) -> {
+            switch (s.sectionId()) {
+                case SectionId.CUSTOM:
+                    module.addCustomSection((CustomSection) s);
+                    break;
+                case SectionId.TYPE:
+                    module.setTypeSection((TypeSection) s);
+                    break;
+                case SectionId.IMPORT:
+                    module.setImportSection((ImportSection) s);
+                    break;
+                case SectionId.FUNCTION:
+                    module.setFunctionSection((FunctionSection) s);
+                    break;
+                case SectionId.TABLE:
+                    module.setTableSection((TableSection) s);
+                    break;
+                case SectionId.MEMORY:
+                    module.setMemorySection((MemorySection) s);
+                    break;
+                case SectionId.GLOBAL:
+                    module.setGlobalSection((GlobalSection) s);
+                    break;
+                case SectionId.EXPORT:
+                    module.setExportSection((ExportSection) s);
+                    break;
+                case SectionId.START:
+                    module.setStartSection((StartSection) s);
+                    break;
+                case SectionId.ELEMENT:
+                    module.setElementSection((ElementSection) s);
+                    break;
+                case SectionId.CODE:
+                    module.setCodeSection((CodeSection) s);
+                    break;
+                case SectionId.DATA:
+                    module.setDataSection((DataSection) s);
+                    break;
+                case SectionId.DATA_COUNT:
+                    module.setDataCountSection((DataCountSection) s);
+                    break;
+                default:
+                    logger.warnf("Ignoring section with id: %d", s.sectionId());
+                    break;
+            }
+        });
 
         return module;
     }
@@ -160,11 +158,10 @@ public final class Parser {
 
         int magicNumber = buffer.getInt();
         if (magicNumber != MAGIC_BYTES) {
-            throw new MalformedException(
-                    "unexpected token: magic number mismatch, found: "
-                            + magicNumber
-                            + " expected: "
-                            + MAGIC_BYTES);
+            throw new MalformedException("unexpected token: magic number mismatch, found: "
+                    + magicNumber
+                    + " expected: "
+                    + MAGIC_BYTES);
         }
         int version = buffer.getInt();
         if (version != 1) {
@@ -182,89 +179,75 @@ public final class Parser {
             if (shouldParseSection(sectionId)) {
                 // Process different section types based on the sectionId
                 switch (sectionId) {
-                    case SectionId.CUSTOM:
-                        {
-                            var customSection = parseCustomSection(buffer, sectionSize, firstTime);
-                            firstTime = false;
-                            listener.onSection(customSection);
-                            break;
-                        }
-                    case SectionId.TYPE:
-                        {
-                            var typeSection = parseTypeSection(buffer);
-                            listener.onSection(typeSection);
-                            break;
-                        }
-                    case SectionId.IMPORT:
-                        {
-                            var importSection = parseImportSection(buffer);
-                            listener.onSection(importSection);
-                            break;
-                        }
-                    case SectionId.FUNCTION:
-                        {
-                            var funcSection = parseFunctionSection(buffer);
-                            listener.onSection(funcSection);
-                            break;
-                        }
-                    case SectionId.TABLE:
-                        {
-                            var tableSection = parseTableSection(buffer);
-                            listener.onSection(tableSection);
-                            break;
-                        }
-                    case SectionId.MEMORY:
-                        {
-                            var memorySection = parseMemorySection(buffer);
-                            listener.onSection(memorySection);
-                            break;
-                        }
-                    case SectionId.GLOBAL:
-                        {
-                            var globalSection = parseGlobalSection(buffer);
-                            listener.onSection(globalSection);
-                            break;
-                        }
-                    case SectionId.EXPORT:
-                        {
-                            var exportSection = parseExportSection(buffer);
-                            listener.onSection(exportSection);
-                            break;
-                        }
-                    case SectionId.START:
-                        {
-                            var startSection = parseStartSection(buffer);
-                            listener.onSection(startSection);
-                            break;
-                        }
-                    case SectionId.ELEMENT:
-                        {
-                            var elementSection = parseElementSection(buffer, sectionSize);
-                            listener.onSection(elementSection);
-                            break;
-                        }
-                    case SectionId.CODE:
-                        {
-                            var codeSection = parseCodeSection(buffer);
-                            listener.onSection(codeSection);
-                            break;
-                        }
-                    case SectionId.DATA:
-                        {
-                            var dataSection = parseDataSection(buffer);
-                            listener.onSection(dataSection);
-                            break;
-                        }
-                    case SectionId.DATA_COUNT:
-                        {
-                            var dataCountSection = parseDataCountSection(buffer);
-                            listener.onSection(dataCountSection);
-                            break;
-                        }
-                    default:
-                        {
-                            throw new MalformedException("malformed section id " + sectionId);
-                        }
+                    case SectionId.CUSTOM: {
+                        var customSection = parseCustomSection(buffer, sectionSize, firstTime);
+                        firstTime = false;
+                        listener.onSection(customSection);
+                        break;
+                    }
+                    case SectionId.TYPE: {
+                        var typeSection = parseTypeSection(buffer);
+                        listener.onSection(typeSection);
+                        break;
+                    }
+                    case SectionId.IMPORT: {
+                        var importSection = parseImportSection(buffer);
+                        listener.onSection(importSection);
+                        break;
+                    }
+                    case SectionId.FUNCTION: {
+                        var funcSection = parseFunctionSection(buffer);
+                        listener.onSection(funcSection);
+                        break;
+                    }
+                    case SectionId.TABLE: {
+                        var tableSection = parseTableSection(buffer);
+                        listener.onSection(tableSection);
+                        break;
+                    }
+                    case SectionId.MEMORY: {
+                        var memorySection = parseMemorySection(buffer);
+                        listener.onSection(memorySection);
+                        break;
+                    }
+                    case SectionId.GLOBAL: {
+                        var globalSection = parseGlobalSection(buffer);
+                        listener.onSection(globalSection);
+                        break;
+                    }
+                    case SectionId.EXPORT: {
+                        var exportSection = parseExportSection(buffer);
+                        listener.onSection(exportSection);
+                        break;
+                    }
+                    case SectionId.START: {
+                        var startSection = parseStartSection(buffer);
+                        listener.onSection(startSection);
+                        break;
+                    }
+                    case SectionId.ELEMENT: {
+                        var elementSection = parseElementSection(buffer, sectionSize);
+                        listener.onSection(elementSection);
+                        break;
+                    }
+                    case SectionId.CODE: {
+                        var codeSection = parseCodeSection(buffer);
+                        listener.onSection(codeSection);
+                        break;
+                    }
+                    case SectionId.DATA: {
+                        var dataSection = parseDataSection(buffer);
+                        listener.onSection(dataSection);
+                        break;
+                    }
+                    case SectionId.DATA_COUNT: {
+                        var dataCountSection = parseDataCountSection(buffer);
+                        listener.onSection(dataCountSection);
+                        break;
+                    }
+                    default: {
+                        throw new MalformedException("malformed section id " + sectionId);
+                    }
                 }
             } else {
                 System.out.println("Skipping Section with ID due to configuration: " + sectionId);
@@ -313,10 +296,9 @@ public final class Parser {
             var form = readVarUInt32(buffer);
 
             if (form != 0x60) {
-                throw new RuntimeException(
-                        "We don't support non func types. Form "
-                                + String.format("0x%02X", form)
-                                + " was given but we expected 0x60");
+                throw new RuntimeException("We don't support non func types. Form "
+                        + String.format("0x%02X", form)
+                        + " was given but we expected 0x60");
             }
 
             // Parse function types (form = 0x60)
@@ -353,50 +335,40 @@ public final class Parser {
             String importName = readName(buffer);
             var descType = ExternalType.byId((int) readVarUInt32(buffer));
             switch (descType) {
-                case FUNCTION:
-                    {
-                        importSection.addImport(
-                                new FunctionImport(
-                                        moduleName, importName, (int) readVarUInt32(buffer)));
-                        break;
-                    }
-                case TABLE:
-                    {
-                        var rawTableType = readVarUInt32(buffer);
-                        assert rawTableType == 0x70 || rawTableType == 0x6F;
-                        var tableType =
-                                (rawTableType == 0x70) ? ValueType.FuncRef : ValueType.ExternRef;
+                case FUNCTION: {
+                    importSection.addImport(new FunctionImport(
+                            moduleName, importName, (int) readVarUInt32(buffer)));
+                    break;
+                }
+                case TABLE: {
+                    var rawTableType = readVarUInt32(buffer);
+                    assert rawTableType == 0x70 || rawTableType == 0x6F;
+                    var tableType =
+                            (rawTableType == 0x70) ? ValueType.FuncRef : ValueType.ExternRef;
 
-                        var limitType = (int) readVarUInt32(buffer);
-                        assert limitType == 0x00 || limitType == 0x01;
-                        var min = (int) readVarUInt32(buffer);
-                        var limits =
-                                limitType > 0
-                                        ? new Limits(min, readVarUInt32(buffer))
-                                        : new Limits(min);
+                    var limitType = (int) readVarUInt32(buffer);
+                    assert limitType == 0x00 || limitType == 0x01;
+                    var min = (int) readVarUInt32(buffer);
+                    var limits = limitType > 0
+                            ? new Limits(min, readVarUInt32(buffer))
+                            : new Limits(min);
 
-                        importSection.addImport(
-                                new TableImport(moduleName, importName, tableType, limits));
-                        break;
-                    }
-                case MEMORY:
-                    {
-                        var limitType = (int) readVarUInt32(buffer);
-                        assert limitType == 0x00 || limitType == 0x01;
-                        var min = (int) Math.min(MemoryLimits.MAX_PAGES, readVarUInt32(buffer));
-                        var limits =
-                                limitType > 0
-                                        ? new MemoryLimits(
-                                                min,
-                                                (int)
-                                                        Math.min(
-                                                                MemoryLimits.MAX_PAGES,
-                                                                readVarUInt32(buffer)))
-                                        : new MemoryLimits(min, MemoryLimits.MAX_PAGES);
+                    importSection.addImport(
+                            new TableImport(moduleName, importName, tableType, limits));
+                    break;
+                }
+                case MEMORY: {
+                    var limitType = (int) readVarUInt32(buffer);
+                    assert limitType == 0x00 || limitType == 0x01;
+                    var min = (int) Math.min(MemoryLimits.MAX_PAGES, readVarUInt32(buffer));
+                    var limits = limitType > 0
+                            ? new MemoryLimits(min, (int)
+                                    Math.min(MemoryLimits.MAX_PAGES, readVarUInt32(buffer)))
+                            : new MemoryLimits(min, MemoryLimits.MAX_PAGES);
 
-                        importSection.addImport(new MemoryImport(moduleName, importName, limits));
-                        break;
-                    }
+                    importSection.addImport(new MemoryImport(moduleName, importName, limits));
+                    break;
+                }
                 case GLOBAL:
                     var globalValType = ValueType.forId((int) readVarUInt32(buffer));
                     var globalMut = MutabilityType.forId(buffer.get());
@@ -561,15 +533,13 @@ public final class Parser {
         } else if (hasElemKind) {
             int ek = (int) readVarUInt32(buffer);
             switch (ek) {
-                case 0x00:
-                    {
-                        type = ValueType.FuncRef;
-                        break;
-                    }
-                default:
-                    {
-                        throw new ChicoryException("Invalid element kind");
-                    }
+                case 0x00: {
+                    type = ValueType.FuncRef;
+                    break;
+                }
+                default: {
+                    throw new ChicoryException("Invalid element kind");
+                }
             }
         } else {
             assert hasRefType;
@@ -585,11 +555,9 @@ public final class Parser {
         } else {
             // read function references, and compose them as instruction lists
             for (int i = 0; i < initCnt; i++) {
-                inits.add(
-                        List.of(
-                                new Instruction(
-                                        -1, OpCode.REF_FUNC, new long[] {readVarUInt32(buffer)}),
-                                new Instruction(-1, OpCode.END, new long[0])));
+                inits.add(List.of(
+                        new Instruction(-1, OpCode.REF_FUNC, new long[] {readVarUInt32(buffer)}),
+                        new Instruction(-1, OpCode.END, new long[0])));
             }
         }
         if (declarative) {
@@ -663,109 +631,96 @@ public final class Parser {
                 switch (instruction.opcode()) {
                     case BLOCK:
                     case LOOP:
-                    case IF:
-                        {
-                            instruction.setDepth(++depth);
-                            blockScope.push(instruction);
-                            instruction.setScope(blockScope.peek());
-                            break;
-                        }
-                    case END:
-                        {
-                            instruction.setDepth(depth--);
-                            instruction.setScope(
-                                    blockScope.isEmpty() ? instruction : blockScope.pop());
-                            break;
-                        }
-                    default:
-                        {
-                            instruction.setDepth(depth);
-                            break;
-                        }
+                    case IF: {
+                        instruction.setDepth(++depth);
+                        blockScope.push(instruction);
+                        instruction.setScope(blockScope.peek());
+                        break;
+                    }
+                    case END: {
+                        instruction.setDepth(depth--);
+                        instruction.setScope(blockScope.isEmpty() ? instruction : blockScope.pop());
+                        break;
+                    }
+                    default: {
+                        instruction.setDepth(depth);
+                        break;
+                    }
                 }
 
                 // control-flow
                 switch (instruction.opcode()) {
                     case BLOCK:
-                    case LOOP:
-                        {
-                            currentControlFlow =
-                                    currentControlFlow.spawn(instructions.size(), instruction);
-                            break;
-                        }
-                    case IF:
-                        {
-                            currentControlFlow =
-                                    currentControlFlow.spawn(instructions.size(), instruction);
+                    case LOOP: {
+                        currentControlFlow =
+                                currentControlFlow.spawn(instructions.size(), instruction);
+                        break;
+                    }
+                    case IF: {
+                        currentControlFlow =
+                                currentControlFlow.spawn(instructions.size(), instruction);
 
-                            var defaultJmp = instructions.size() + 1;
-                            currentControlFlow.addCallback(
-                                    end -> {
-                                        // check that there is no "else" branch
-                                        if (instruction.labelFalse() == defaultJmp) {
-                                            instruction.setLabelFalse(end);
-                                        }
-                                    });
+                        var defaultJmp = instructions.size() + 1;
+                        currentControlFlow.addCallback(end -> {
+                            // check that there is no "else" branch
+                            if (instruction.labelFalse() == defaultJmp) {
+                                instruction.setLabelFalse(end);
+                            }
+                        });
 
-                            // defaults
-                            instruction.setLabelTrue(defaultJmp);
-                            instruction.setLabelFalse(defaultJmp);
-                            break;
-                        }
-                    case ELSE:
-                        {
-                            assert (currentControlFlow.instruction().opcode() == OpCode.IF);
-                            currentControlFlow.instruction().setLabelFalse(instructions.size() + 1);
+                        // defaults
+                        instruction.setLabelTrue(defaultJmp);
+                        instruction.setLabelFalse(defaultJmp);
+                        break;
+                    }
+                    case ELSE: {
+                        assert (currentControlFlow.instruction().opcode() == OpCode.IF);
+                        currentControlFlow.instruction().setLabelFalse(instructions.size() + 1);
 
-                            currentControlFlow.addCallback(instruction::setLabelTrue);
+                        currentControlFlow.addCallback(instruction::setLabelTrue);
 
-                            break;
+                        break;
+                    }
+                    case BR_IF: {
+                        instruction.setLabelFalse(instructions.size() + 1);
+                    }
+                    case BR: {
+                        var offset = (int) instruction.operands()[0];
+                        ControlTree reference = currentControlFlow;
+                        while (offset > 0) {
+                            reference = reference.parent();
+                            offset--;
                         }
-                    case BR_IF:
-                        {
-                            instruction.setLabelFalse(instructions.size() + 1);
-                        }
-                    case BR:
-                        {
-                            var offset = (int) instruction.operands()[0];
+                        reference.addCallback(instruction::setLabelTrue);
+                        break;
+                    }
+                    case BR_TABLE: {
+                        instruction.setLabelTable(new int[instruction.operands().length]);
+                        for (var idx = 0; idx < instruction.labelTable().length; idx++) {
+                            var offset = (int) instruction.operands()[idx];
                             ControlTree reference = currentControlFlow;
                             while (offset > 0) {
                                 reference = reference.parent();
                                 offset--;
                             }
-                            reference.addCallback(instruction::setLabelTrue);
-                            break;
+                            int finalIdx = idx;
+                            reference.addCallback(end -> instruction.labelTable()[finalIdx] = end);
                         }
-                    case BR_TABLE:
-                        {
-                            instruction.setLabelTable(new int[instruction.operands().length]);
-                            for (var idx = 0; idx < instruction.labelTable().length; idx++) {
-                                var offset = (int) instruction.operands()[idx];
-                                ControlTree reference = currentControlFlow;
-                                while (offset > 0) {
-                                    reference = reference.parent();
-                                    offset--;
-                                }
-                                int finalIdx = idx;
-                                reference.addCallback(
-                                        end -> instruction.labelTable()[finalIdx] = end);
-                            }
-                            break;
-                        }
-                    case END:
-                        {
-                            currentControlFlow.setFinalInstructionNumber(
-                                    instructions.size(), instruction);
-                            currentControlFlow = currentControlFlow.parent();
+                        break;
+                    }
+                    case END: {
+                        currentControlFlow.setFinalInstructionNumber(
+                                instructions.size(), instruction);
+                        currentControlFlow = currentControlFlow.parent();
 
-                            if (lastInstruction && instructions.size() > 1) {
-                                var former = instructions.get(instructions.size() - 1);
-                                if (former.opcode() == OpCode.END) {
-                                    instruction.setScope(former.scope());
-                                }
+                        if (lastInstruction && instructions.size() > 1) {
+                            var former = instructions.get(instructions.size() - 1);
+                            if (former.opcode() == OpCode.END) {
+                                instruction.setScope(former.scope());
                             }
-                            break;
                         }
+                        break;
+                    }
                 }
 
                 instructions.add(instruction);
@@ -850,14 +805,13 @@ public final class Parser {
                 case FLOAT32:
                     operands.add(readFloat32(buffer));
                     break;
-                case VEC_VARUINT:
-                    {
-                        var vcount = (int) readVarUInt32(buffer);
-                        for (var j = 0; j < vcount; j++) {
-                            operands.add(readVarUInt32(buffer));
-                        }
-                        break;
+                case VEC_VARUINT: {
+                    var vcount = (int) readVarUInt32(buffer);
+                    for (var j = 0; j < vcount; j++) {
+                        operands.add(readVarUInt32(buffer));
                     }
+                    break;
+                }
             }
         }
         var operandsArray = new long[operands.size()];

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalImport.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalImport.java
@@ -61,7 +61,11 @@ public final class GlobalImport extends Import {
     }
 
     public StringBuilder toString(final StringBuilder b) {
-        b.append("global (type=").append(type).append(",mut=").append(mutabilityType).append(')');
+        b.append("global (type=")
+                .append(type)
+                .append(",mut=")
+                .append(mutabilityType)
+                .append(')');
         return super.toString(b);
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameCustomSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameCustomSection.java
@@ -73,57 +73,47 @@ public class NameCustomSection extends CustomSection {
             ByteBuffer slice = slice(buf, (int) Parser.readVarUInt32(buf));
             // todo: IDs 4 and 10 are reserved for the Host GC spec
             switch (id) {
-                case 0:
-                    {
-                        assert (moduleName == null);
-                        moduleName = Parser.readName(slice);
-                        break;
-                    }
-                case 1:
-                    {
-                        oneLevelParse(slice, funcNames);
-                        break;
-                    }
-                case 2:
-                    {
-                        twoLevelParse(slice, localNames);
-                        break;
-                    }
-                case 3:
-                    {
-                        twoLevelParse(slice, labelNames);
-                        break;
-                    }
-                case 5:
-                    {
-                        oneLevelParse(slice, tableNames);
-                        break;
-                    }
-                case 6:
-                    {
-                        oneLevelParse(slice, memoryNames);
-                        break;
-                    }
-                case 7:
-                    {
-                        oneLevelParse(slice, globalNames);
-                        break;
-                    }
-                case 8:
-                    {
-                        oneLevelParse(slice, elementNames);
-                        break;
-                    }
-                case 9:
-                    {
-                        oneLevelParse(slice, dataNames);
-                        break;
-                    }
-                case 11:
-                    {
-                        oneLevelParse(slice, tagNames);
-                        break;
-                    }
+                case 0: {
+                    assert (moduleName == null);
+                    moduleName = Parser.readName(slice);
+                    break;
+                }
+                case 1: {
+                    oneLevelParse(slice, funcNames);
+                    break;
+                }
+                case 2: {
+                    twoLevelParse(slice, localNames);
+                    break;
+                }
+                case 3: {
+                    twoLevelParse(slice, labelNames);
+                    break;
+                }
+                case 5: {
+                    oneLevelParse(slice, tableNames);
+                    break;
+                }
+                case 6: {
+                    oneLevelParse(slice, memoryNames);
+                    break;
+                }
+                case 7: {
+                    oneLevelParse(slice, globalNames);
+                    break;
+                }
+                case 8: {
+                    oneLevelParse(slice, elementNames);
+                    break;
+                }
+                case 9: {
+                    oneLevelParse(slice, dataNames);
+                    break;
+                }
+                case 11: {
+                    oneLevelParse(slice, tagNames);
+                    break;
+                }
                 default:
                     // ignore unknown subsection for forwards-compatibility
             }

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
@@ -127,10 +127,8 @@ public class ParserTest {
         File compiledDir = new File("../wasm-corpus/src/main/resources/compiled/");
 
         List<File> files = new ArrayList<>();
-        files.addAll(
-                Arrays.asList(
-                        compiledDir.listFiles(
-                                (ignored, name) -> name.toLowerCase().endsWith(".wasm"))));
+        files.addAll(Arrays.asList(
+                compiledDir.listFiles((ignored, name) -> name.toLowerCase().endsWith(".wasm"))));
 
         if (files.isEmpty()) {
             throw new RuntimeException("Could not find files");
@@ -154,17 +152,15 @@ public class ParserTest {
 
         try (InputStream is = getClass().getResourceAsStream("/compiled/count_vowels.rs.wasm")) {
             parser.includeSection(SectionId.CUSTOM);
-            parser.parse(
-                    is,
-                    s -> {
-                        if (s.sectionId() == SectionId.CUSTOM) {
-                            var customSection = (CustomSection) s;
-                            var name = customSection.name();
-                            assertFalse(name.isEmpty());
-                        } else {
-                            fail("Should not have received section with id: " + s.sectionId());
-                        }
-                    });
+            parser.parse(is, s -> {
+                if (s.sectionId() == SectionId.CUSTOM) {
+                    var customSection = (CustomSection) s;
+                    var name = customSection.name();
+                    assertFalse(name.isEmpty());
+                } else {
+                    fail("Should not have received section with id: " + s.sectionId());
+                }
+            });
         }
     }
 


### PR DESCRIPTION
This is a proposal to use [Palantir Java Format](https://github.com/palantir/palantir-java-format). It's based on `google-java-format` but is more lambda friendly. See the examples in the README and compare the formatted code. This resolves my personal complaint about the excessive vertical formatting of `google-java-format`.

The only actual code change here is the configuration in `pom.xml`. The rest is the result of running the formater. The changes are easier to see if you view the diff with "hide whitespace".

This uses `<style>AOSP</style>` which maintains the 100 character limit. This change brings the option of using  `<style>PALANTIR</style>` which has a 120 character limit.