### PR TITLE
Implement CALL for AOT

### DIFF
--- a/aot/pom.xml
+++ b/aot/pom.xml
@@ -77,10 +77,15 @@
             <wast>inline-module.wast</wast>
             <wast>int_exprs.wast</wast>
             <wast>int_literals.wast</wast>
+            <wast>memory_redundancy.wast</wast>
             <wast>memory_size.wast</wast>
+            <wast>memory_trap.wast</wast>
+            <wast>ref_is_null.wast</wast>
             <wast>ref_null.wast</wast>
             <wast>table.wast</wast>
             <wast>table_fill.wast</wast>
+            <wast>table_get.wast</wast>
+            <wast>table_set.wast</wast>
             <wast>table_size.wast</wast>
             <wast>token.wast</wast>
             <wast>traps.wast</wast>
@@ -192,12 +197,9 @@
             <wast>memory_fill.wast</wast>
             <wast>memory_grow.wast</wast>
             <wast>memory_init.wast</wast>
-            <wast>memory_redundancy.wast</wast>
-            <wast>memory_trap.wast</wast>
             <wast>names.wast</wast>
             <wast>nop.wast</wast>
             <wast>ref_func.wast</wast>
-            <wast>ref_is_null.wast</wast>
             <wast>return.wast</wast>
             <wast>select.wast</wast>
 
@@ -268,10 +270,8 @@
             <wast>switch.wast</wast>
             <wast>table-sub.wast</wast>
             <wast>table_copy.wast</wast>
-            <wast>table_get.wast</wast>
             <wast>table_grow.wast</wast>
             <wast>table_init.wast</wast>
-            <wast>table_set.wast</wast>
             <wast>tokens.wast</wast>
             <wast>unreachable.wast</wast>
             <wast>unreached-invalid.wast</wast>

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
@@ -151,7 +151,11 @@ public class AotEmitters {
 
     public static void LOCAL_TEE(AotContext ctx, Instruction ins, MethodVisitor asm) {
         StackSize stackSize = ctx.popStackSize();
-        emitPop(asm, stackSize);
+        if (stackSize == StackSize.ONE) {
+            asm.visitInsn(Opcodes.DUP);
+        } else {
+            asm.visitInsn(Opcodes.DUP2);
+        }
         ctx.pushStackSize(stackSize);
 
         LOCAL_SET(ctx, ins, asm);

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
@@ -7,6 +7,7 @@ import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.runtime.OpcodeImpl;
 import com.dylibso.chicory.runtime.TrapException;
 import com.dylibso.chicory.runtime.exceptions.WASMRuntimeException;
+import com.dylibso.chicory.wasm.exceptions.ChicoryException;
 import com.dylibso.chicory.wasm.types.Element;
 import com.dylibso.chicory.wasm.types.Value;
 import java.lang.reflect.Method;
@@ -14,6 +15,8 @@ import java.util.List;
 
 public final class AotMethods {
 
+    static final Method CHECK_INTERRUPTION;
+    static final Method INSTANCE_CALL_HOST_FUNCTION;
     static final Method INSTANCE_READ_GLOBAL;
     static final Method INSTANCE_WRITE_GLOBAL;
     static final Method INSTANCE_SET_ELEMENT;
@@ -49,6 +52,9 @@ public final class AotMethods {
 
     static {
         try {
+            CHECK_INTERRUPTION = AotMethods.class.getMethod("checkInterruption");
+            INSTANCE_CALL_HOST_FUNCTION =
+                    Instance.class.getMethod("callHostFunction", int.class, Value[].class);
             INSTANCE_READ_GLOBAL = Instance.class.getMethod("readGlobal", int.class);
             INSTANCE_WRITE_GLOBAL = Instance.class.getMethod("writeGlobal", int.class, Value.class);
             INSTANCE_SET_ELEMENT = Instance.class.getMethod("setElement", int.class, Element.class);
@@ -212,5 +218,12 @@ public final class AotMethods {
     @UsedByGeneratedCode
     public static RuntimeException throwTrapException() {
         throw new TrapException("Trapped on unreachable instruction", List.of());
+    }
+
+    @UsedByGeneratedCode
+    public static void checkInterruption() {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new ChicoryException("Thread interrupted");
+        }
     }
 }

--- a/aot/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/aot/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -75,7 +75,8 @@ public class TestModule {
                         // TODO: enable me!
                         .withTypeValidation(false)
                         .withHostImports(imports)
-                        .withMachineFactory(instance -> new AotMachine(module, instance))
+                        .withMachineFactory(
+                                instance -> new AotMachine(module.wasmModule(), instance))
                         .build();
         return this;
     }


### PR DESCRIPTION
This changes the compiler to generate a single, non-instantiable class for the entire WASM module, with a static method for each WASM method. The `Memory` and `Instance` parameters are last, which means their values are pushed onto the JVM stack last, thus methods can be called without any stack manipulation (or a much more complicated compiler).