### PR TITLE
Implement CALL_INDIRECT for AOT

### DIFF
--- a/aot/pom.xml
+++ b/aot/pom.xml
@@ -57,6 +57,7 @@
           <includedWasts>
             <wast>address.wast</wast>
             <wast>binary-leb128.wast</wast>
+            <wast>bulk.wast</wast>
             <wast>comments.wast</wast>
             <wast>const.wast</wast>
             <wast>conversions.wast</wast>
@@ -72,16 +73,20 @@
             <wast>float_literals.wast</wast>
             <wast>float_memory.wast</wast>
             <wast>float_misc.wast</wast>
+            <wast>func_ptrs.wast</wast>
             <wast>i32.wast</wast>
             <wast>i64.wast</wast>
+            <wast>imports.wast</wast>
             <wast>inline-module.wast</wast>
             <wast>int_exprs.wast</wast>
             <wast>int_literals.wast</wast>
             <wast>memory_redundancy.wast</wast>
             <wast>memory_size.wast</wast>
             <wast>memory_trap.wast</wast>
+            <wast>names.wast</wast>
             <wast>ref_is_null.wast</wast>
             <wast>ref_null.wast</wast>
+            <wast>start.wast</wast>
             <wast>table.wast</wast>
             <wast>table_fill.wast</wast>
             <wast>table_get.wast</wast>
@@ -172,7 +177,6 @@
             <wast>br.wast</wast>
             <wast>br_if.wast</wast>
             <wast>br_table.wast</wast>
-            <wast>bulk.wast</wast>
             <wast>call.wast</wast>
             <wast>call_indirect.wast</wast>
             <wast>elem.wast</wast>
@@ -180,10 +184,8 @@
             <wast>float_exprs.wast</wast>
             <wast>forward.wast</wast>
             <wast>func.wast</wast>
-            <wast>func_ptrs.wast</wast>
             <wast>global.wast</wast>
             <wast>if.wast</wast>
-            <wast>imports.wast</wast>
             <wast>labels.wast</wast>
             <wast>left-to-right.wast</wast>
             <wast>linking.wast</wast>
@@ -197,7 +199,6 @@
             <wast>memory_fill.wast</wast>
             <wast>memory_grow.wast</wast>
             <wast>memory_init.wast</wast>
-            <wast>names.wast</wast>
             <wast>nop.wast</wast>
             <wast>ref_func.wast</wast>
             <wast>return.wast</wast>
@@ -265,7 +266,6 @@
             <!-- Include below to match compliance with interpreter -->
             <wast>skip-stack-guard-page.wast</wast>
             <wast>stack.wast</wast>
-            <wast>start.wast</wast>
             <wast>store.wast</wast>
             <wast>switch.wast</wast>
             <wast>table-sub.wast</wast>

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotContext.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotContext.java
@@ -19,6 +19,7 @@ final class AotContext {
     private final String internalClassName;
     private final List<ValueType> globalTypes;
     private final List<FunctionType> functionTypes;
+    private final FunctionType[] types;
     private final int funcId;
     private final FunctionType type;
     private final FunctionBody body;
@@ -31,12 +32,14 @@ final class AotContext {
             String internalClassName,
             List<ValueType> globalTypes,
             List<FunctionType> functionTypes,
+            FunctionType[] types,
             int funcId,
             FunctionType type,
             FunctionBody body) {
         this.internalClassName = internalClassName;
         this.globalTypes = globalTypes;
         this.functionTypes = functionTypes;
+        this.types = types;
         this.funcId = funcId;
         this.type = type;
         this.body = body;
@@ -76,6 +79,10 @@ final class AotContext {
 
     public List<FunctionType> functionTypes() {
         return functionTypes;
+    }
+
+    public FunctionType[] types() {
+        return types;
     }
 
     public int getId() {

--- a/aot/src/main/java/com/dylibso/chicory/aot/HostFunctionInvoker.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/HostFunctionInvoker.java
@@ -5,9 +5,10 @@ import static java.lang.invoke.MethodHandles.lookup;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasm.types.Value;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 final class HostFunctionInvoker {
-    public static final MethodHandle HANDLE;
+    private static final MethodHandle HANDLE;
 
     static {
         try {
@@ -21,6 +22,10 @@ final class HostFunctionInvoker {
     }
 
     private HostFunctionInvoker() {}
+
+    public static MethodHandle handleFor(Instance instance, int funcId) {
+        return MethodHandles.insertArguments(HANDLE, 0, instance, funcId);
+    }
 
     public static Value[] invoke(Instance instance, int funcId, Value[] args) {
         return instance.callHostFunction(funcId, args);


### PR DESCRIPTION
This is ugly and expensive, as it uses boxing for everything, even functions inside the current module. We can replace this with `invokedynamic` later.