### PR TITLE
Add `quick-build` profile to install skipping codegen and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Contributors and other advanced users may want to build the runtime from source.
 Basic steps:
 
 * `mvn clean install` to run all of the project's tests and install the library in your local repo
+* `mvn -Dquickly` to install the library skipping all tests
 * `mvn spotless:apply` to autoformat the code
 * `./scripts/compile-resources.sh` will recompile and regenerate the `resources/compiled` folders
 

--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,29 @@
 
   <profiles>
     <profile>
+      <!-- Performs the quick build: all plugins deactivated -->
+      <id>quick-build</id>
+      <activation>
+        <property>
+          <name>quickly</name>
+        </property>
+      </activation>
+      <properties>
+        <spotless.check.skip>true</spotless.check.skip>
+        <skipITs>true</skipITs>
+        <skipTests>true</skipTests>
+        <!-- Skip test codegen. -->
+        <wasm-test-gen.skip>true</wasm-test-gen.skip>
+        <!-- Prevent building broken tests (due to missing codegen). -->
+        <maven.test.skip>true</maven.test.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+      </properties>
+      <build>
+        <defaultGoal>clean install</defaultGoal>
+      </build>
+    </profile>
+
+    <profile>
       <id>fuzz</id>
       <modules>
         <module>fuzz</module>

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
@@ -106,6 +106,12 @@ public class TestGenMojo extends AbstractMojo {
     private List<String> excludedWasts;
 
     /**
+     * Skip execution of this Mojo.
+     */
+    @Parameter(property = "wasm-test-gen.skip", defaultValue = "false")
+    private boolean skip;
+
+    /**
      * The current Maven project.
      */
     @Parameter(property = "project", required = true, readonly = true)
@@ -113,6 +119,10 @@ public class TestGenMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if (skip) {
+            return;
+        }
+
         // Validate config
         validate(includedWasts, "includedWasts", true);
         validate(excludedTests, "excludedTests", false);


### PR DESCRIPTION
Add property `wasm-test-gen.skip` to the codegen plugin, and configure a `quick-build` profile to skip all tests and install the artifacts. The new profile defaults to `clean install` so to install the whole repo it should now be enough to just:

    $ mvn -Dquicky

