### PR TITLE
Finalizing assert throws setup

### DIFF
--- a/aot/pom.xml
+++ b/aot/pom.xml
@@ -147,6 +147,7 @@
             <wast>utf8-invalid-encoding.wast</wast>
           </includedWasts>
           <excludedTests>
+            <test>SpecV1ElemTest.test29</test>
             <test>SpecV1LinkingTest.test83</test>
             <test>SpecV1LinkingTest.test86</test>
             <test>SpecV1LinkingTest.test94</test>
@@ -171,8 +172,6 @@
             <wast>conversions.wast</wast>
             <wast>data.wast</wast>
             <wast>elem.wast</wast>
-            <wast>endianness.wast</wast>
-            <wast>exports.wast</wast>
             <wast>f32.wast</wast>
             <wast>f32_bitwise.wast</wast>
             <wast>f32_cmp.wast</wast>
@@ -185,9 +184,7 @@
             <wast>i32.wast</wast>
             <wast>i64.wast</wast>
             <wast>if.wast</wast>
-            <wast>imports.wast</wast>
             <wast>labels.wast</wast>
-            <wast>linking.wast</wast>
             <wast>load.wast</wast>
             <wast>local_get.wast</wast>
             <wast>local_set.wast</wast>
@@ -206,10 +203,7 @@
             <wast>select.wast</wast>
             <wast>start.wast</wast>
             <wast>store.wast</wast>
-            <wast>switch.wast</wast>
             <wast>table-sub.wast</wast>
-            <wast>table.wast</wast>
-            <wast>table_copy.wast</wast>
             <wast>table_fill.wast</wast>
             <wast>table_get.wast</wast>
             <wast>table_grow.wast</wast>
@@ -218,6 +212,13 @@
             <wast>table_size.wast</wast>
             <wast>unreached-invalid.wast</wast>
           </excludedInvalidWasts>
+          <excludedUnlinkableWasts>
+            <wast>imports.wast</wast>
+            <wast>linking.wast</wast>
+          </excludedUnlinkableWasts>
+          <excludedUninstantiableWasts>
+            <wast>linking.wast</wast>
+          </excludedUninstantiableWasts>
           <excludedWasts>
             <wast>simd_address.wast</wast>
             <wast>simd_align.wast</wast>

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
@@ -348,6 +348,8 @@ public final class AotMachine implements Machine {
         } catch (ChicoryException e) {
             // propagate ChicoryExceptions
             throw e;
+        } catch (StackOverflowError e) {
+            throw new ChicoryException("call stack exhausted", e);
         } catch (IndexOutOfBoundsException e) {
             throw new WASMRuntimeException("undefined element " + e.getMessage(), e);
         } catch (Exception e) {

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
@@ -192,8 +192,8 @@ public class SpecV1ImportsHostFuncs {
                         },
                         "test",
                         "func",
-                        List.of(ValueType.I64),
-                        List.of(ValueType.I64));
+                        List.of(),
+                        List.of());
         var testFuncI64 =
                 new HostFunction(
                         (Instance instance, Value... args) -> {

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1StartHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1StartHostFuncs.java
@@ -25,7 +25,7 @@ public class SpecV1StartHostFuncs {
                             },
                             "spectest",
                             "print",
-                            List.of(ValueType.I32),
+                            List.of(),
                             List.of())
                 });
     }

--- a/runtime-tests/pom.xml
+++ b/runtime-tests/pom.xml
@@ -137,6 +137,8 @@
             <wast>utf8-invalid-encoding.wast</wast>
           </includedWasts>
           <excludedTests>
+            <!-- even wasm-decompile is not throwing on this one -->
+            <test>SpecV1ElemTest.test29</test>
             <test>SpecV1LinkingTest.test83</test>
             <test>SpecV1LinkingTest.test86</test>
             <test>SpecV1LinkingTest.test94</test>
@@ -154,6 +156,13 @@
           </excludedTests>
           <excludedMalformedWasts/>
           <excludedInvalidWasts/>
+          <excludedUnlinkableWasts>
+            <wast>imports.wast</wast>
+            <wast>linking.wast</wast>
+          </excludedUnlinkableWasts>
+          <excludedUninstantiableWasts>
+            <wast>linking.wast</wast>
+          </excludedUninstantiableWasts>
           <excludedWasts>
             <wast>simd_address.wast</wast>
             <wast>simd_align.wast</wast>

--- a/runtime-tests/pom.xml
+++ b/runtime-tests/pom.xml
@@ -139,6 +139,31 @@
           <excludedTests>
             <!-- even wasm-decompile is not throwing on this one -->
             <test>SpecV1ElemTest.test29</test>
+            <!-- Missing checks on imports -->
+            <test>SpecV1ImportsTest.test101</test>
+            <test>SpecV1ImportsTest.test102</test>
+            <test>SpecV1ImportsTest.test103</test>
+            <test>SpecV1ImportsTest.test104</test>
+            <test>SpecV1ImportsTest.test105</test>
+            <test>SpecV1ImportsTest.test106</test>
+            <test>SpecV1ImportsTest.test107</test>
+            <test>SpecV1ImportsTest.test108</test>
+            <test>SpecV1ImportsTest.test111</test>
+            <test>SpecV1ImportsTest.test135</test>
+            <test>SpecV1ImportsTest.test136</test>
+            <test>SpecV1ImportsTest.test137</test>
+            <test>SpecV1ImportsTest.test138</test>
+            <test>SpecV1ImportsTest.test139</test>
+            <test>SpecV1ImportsTest.test140</test>
+            <test>SpecV1ImportsTest.test147</test>
+            <test>SpecV1ImportsTest.test148</test>
+            <test>SpecV1ImportsTest.test16</test>
+            <test>SpecV1ImportsTest.test17</test>
+            <test>SpecV1ImportsTest.test178</test>
+            <test>SpecV1ImportsTest.test36</test>
+            <test>SpecV1ImportsTest.test48</test>
+            <test>SpecV1ImportsTest.test49</test>
+            <test>SpecV1ImportsTest.test64</test>
             <test>SpecV1LinkingTest.test83</test>
             <test>SpecV1LinkingTest.test86</test>
             <test>SpecV1LinkingTest.test94</test>
@@ -157,7 +182,6 @@
           <excludedMalformedWasts/>
           <excludedInvalidWasts/>
           <excludedUnlinkableWasts>
-            <wast>imports.wast</wast>
             <wast>linking.wast</wast>
           </excludedUnlinkableWasts>
           <excludedUninstantiableWasts>

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1StartHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1StartHostFuncs.java
@@ -25,7 +25,7 @@ public class SpecV1StartHostFuncs {
                             },
                             "spectest",
                             "print",
-                            List.of(ValueType.I32),
+                            List.of(),
                             List.of())
                 });
     }

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -15,7 +15,7 @@ public class TestModule {
     private Instance instance;
 
     private HostImports imports;
-    private boolean typeValidation;
+    private boolean typeValidation = true;
 
     public static TestModule of(File file) {
         return of(file, ModuleType.BINARY);

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -8,6 +8,7 @@ import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
 import com.dylibso.chicory.runtime.exceptions.WASMMachineException;
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
 import com.dylibso.chicory.wasm.exceptions.InvalidException;
+import com.dylibso.chicory.wasm.exceptions.UninstantiableException;
 import com.dylibso.chicory.wasm.types.ActiveDataSegment;
 import com.dylibso.chicory.wasm.types.ActiveElement;
 import com.dylibso.chicory.wasm.types.DataSegment;
@@ -264,6 +265,8 @@ public class Instance {
                             return machine.call(funcId, args);
                         } catch (InvalidException e) {
                             throw e;
+                        } catch (TrapException e) {
+                            throw new UninstantiableException("unreachable", e);
                         } catch (Exception e) {
                             throw new WASMMachineException(machine.getStackTrace(), e);
                         }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -735,6 +735,8 @@ class InterpreterMachine implements Machine {
         } catch (ChicoryException e) {
             // propagate ChicoryExceptions
             throw e;
+        } catch (StackOverflowError e) {
+            throw new ChicoryException("call stack exhausted", e);
         } catch (IndexOutOfBoundsException e) {
             throw new WASMRuntimeException("undefined element " + e.getMessage(), e);
         } catch (Exception e) {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
@@ -6,6 +6,7 @@ import static java.lang.Math.min;
 import com.dylibso.chicory.runtime.exceptions.WASMRuntimeException;
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
 import com.dylibso.chicory.wasm.exceptions.InvalidException;
+import com.dylibso.chicory.wasm.exceptions.UninstantiableException;
 import com.dylibso.chicory.wasm.types.ActiveDataSegment;
 import com.dylibso.chicory.wasm.types.DataSegment;
 import com.dylibso.chicory.wasm.types.MemoryLimits;
@@ -188,7 +189,7 @@ public final class Memory {
             buffer.position(addr);
             buffer.put(data, offset, size);
         } catch (Exception e) {
-            throw new WASMRuntimeException("out of bounds memory access");
+            throw new UninstantiableException("out of bounds memory access");
         }
     }
 
@@ -196,7 +197,7 @@ public final class Memory {
         try {
             return buffer.get(addr);
         } catch (IndexOutOfBoundsException e) {
-            throw new WASMRuntimeException("out of bounds memory access");
+            throw new UninstantiableException("out of bounds memory access");
         }
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Module.java
@@ -497,9 +497,7 @@ public class Module {
 
         private boolean initialize = true;
         private boolean start = true;
-        // TODO: turn the default to true
-        // Type validation needs to remain optional until it's finished
-        private boolean typeValidation = false;
+        private boolean typeValidation = true;
         private ExecutionListener listener = null;
         private HostImports hostImports = null;
         private Function<Instance, Machine> machineFactory = null;

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/TableInstance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/TableInstance.java
@@ -3,6 +3,7 @@ package com.dylibso.chicory.runtime;
 import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
 
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
+import com.dylibso.chicory.wasm.exceptions.UninstantiableException;
 import com.dylibso.chicory.wasm.types.Limits;
 import com.dylibso.chicory.wasm.types.Table;
 import com.dylibso.chicory.wasm.types.Value;
@@ -68,7 +69,7 @@ public class TableInstance {
             this.refs[index] = value;
             this.instances[index] = instance;
         } catch (IndexOutOfBoundsException e) {
-            throw new ChicoryException("out of bounds table access", e);
+            throw new UninstantiableException("out of bounds table access", e);
         }
     }
 
@@ -80,7 +81,7 @@ public class TableInstance {
         try {
             this.refs[index] = value;
         } catch (IndexOutOfBoundsException e) {
-            throw new ChicoryException("out of bounds table access", e);
+            throw new UninstantiableException("out of bounds table access", e);
         }
     }
 

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.dylibso.chicory.runtime.exceptions.WASMMachineException;
+import com.dylibso.chicory.wasm.exceptions.UninstantiableException;
 import com.dylibso.chicory.wasm.types.Instruction;
 import com.dylibso.chicory.wasm.types.MemoryLimits;
 import com.dylibso.chicory.wasm.types.Value;
@@ -155,7 +155,7 @@ public class ModuleTest {
     @Test
     public void shouldTrapOnUnreachable() {
         var module = Module.builder("compiled/trap.wat.wasm").build();
-        assertThrows(WASMMachineException.class, module::instantiate);
+        assertThrows(UninstantiableException.class, module::instantiate);
     }
 
     @Test

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
@@ -416,7 +416,7 @@ public class JavaTestGen {
                         + "\")"
                         + additionalParam
                         + ")\n"
-                        + ((excludeInvalid) ? "" : INDENT + ".withTypeValidation(true)\n")
+                        + ((excludeInvalid) ? INDENT + ".withTypeValidation(false)\n" : "")
                         + ((hostFuncs != null)
                                 ? INDENT
                                         + ".withHostImports("
@@ -465,17 +465,12 @@ public class JavaTestGen {
     }
 
     private String getWasmFile(Command cmd, File folder) {
-        try {
-            return folder.toPath()
-                    .resolve(cmd.filename())
-                    .toFile()
-                    .getAbsolutePath()
-                    .replace(baseDir.getAbsolutePath() + File.separator, "")
-                    .replace("\\", "\\\\"); // Win compat
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
-                    "DEBUG ME: " + cmd + " - " + folder.getAbsolutePath() + " - " + cmd.filename());
-        }
+        return folder.toPath()
+                .resolve(cmd.filename())
+                .toFile()
+                .getAbsolutePath()
+                .replace(baseDir.getAbsolutePath() + File.separator, "")
+                .replace("\\", "\\\\"); // Win compat
     }
 
     private void generateAssertThrows(

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
@@ -35,12 +35,6 @@ public class TestGenMojo extends AbstractMojo {
     private final Log log = new SystemStreamLog();
 
     /**
-     * OS name
-     */
-    @Parameter(defaultValue = "${os.name}")
-    private String osName;
-
-    /**
      * Repository of the testsuite.
      */
     @Parameter(required = true, defaultValue = "https://github.com/WebAssembly/testsuite")
@@ -99,6 +93,12 @@ public class TestGenMojo extends AbstractMojo {
     @Parameter(required = false, defaultValue = "[]")
     private List<String> excludedInvalidWasts;
 
+    @Parameter(required = false, defaultValue = "[]")
+    private List<String> excludedUninstantiableWasts;
+
+    @Parameter(required = false, defaultValue = "[]")
+    private List<String> excludedUnlinkableWasts;
+
     /**
      * Exclude list for wast files that are entirely skipped.
      */
@@ -126,9 +126,11 @@ public class TestGenMojo extends AbstractMojo {
         // Validate config
         validate(includedWasts, "includedWasts", true);
         validate(excludedTests, "excludedTests", false);
+        validate(excludedWasts, "excludedWasts", true);
         validate(excludedMalformedWasts, "excludedMalformedWasts", true);
         validate(excludedInvalidWasts, "excludedInvalidWasts", true);
-        validate(excludedWasts, "excludedWasts", true);
+        validate(excludedUninstantiableWasts, "excludedUninstantiableWasts", true);
+        validate(excludedUnlinkableWasts, "excludedUnlinkableWasts", true);
 
         // Instantiate the utilities
         var testSuiteDownloader = new TestSuiteDownloader(log);
@@ -139,7 +141,9 @@ public class TestGenMojo extends AbstractMojo {
                         sourceDestinationFolder,
                         excludedTests,
                         excludedMalformedWasts,
-                        excludedInvalidWasts);
+                        excludedInvalidWasts,
+                        excludedUninstantiableWasts,
+                        excludedUnlinkableWasts);
 
         JavaParserMavenUtils.makeJavaParserLogToMavenOutput(getLog());
 
@@ -168,6 +172,8 @@ public class TestGenMojo extends AbstractMojo {
             includedWasts.forEach(allWastFiles::remove);
             excludedMalformedWasts.forEach(allWastFiles::remove);
             excludedInvalidWasts.forEach(allWastFiles::remove);
+            excludedUninstantiableWasts.forEach(allWastFiles::remove);
+            excludedUnlinkableWasts.forEach(allWastFiles::remove);
             excludedWasts.forEach(allWastFiles::remove);
             if (!allWastFiles.isEmpty()) {
                 throw new MojoExecutionException(

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/exceptions/UninstantiableException.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/exceptions/UninstantiableException.java
@@ -1,0 +1,15 @@
+package com.dylibso.chicory.wasm.exceptions;
+
+public class UninstantiableException extends ChicoryException {
+    public UninstantiableException(String msg) {
+        super(msg);
+    }
+
+    public UninstantiableException(Throwable cause) {
+        super(cause);
+    }
+
+    public UninstantiableException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/exceptions/UnlinkableException.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/exceptions/UnlinkableException.java
@@ -1,0 +1,15 @@
+package com.dylibso.chicory.wasm.exceptions;
+
+public class UnlinkableException extends ChicoryException {
+    public UnlinkableException(String msg) {
+        super(msg);
+    }
+
+    public UnlinkableException(Throwable cause) {
+        super(cause);
+    }
+
+    public UnlinkableException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}


### PR DESCRIPTION
I'm about to go in vacation for a little while, I wanted to leave the project in a good state, few main goals here:

- complete the `assertThrows` setup of the `test-gen-plugin` so that it should be almost final (`linking.wast` might require a little more tweaks, but let see...)
- enable type validation by default
- get the skipped tests with the interpreter < 100 (currently 57 :tada: )

bonus:
- improved a bit the test coverage for AOT too