### PR TITLE
Disable the nightly fuzz

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,7 +2,9 @@ name: Nightly Fuzz
 
 on:
   schedule:
-    - cron: "0 0 * * *" # everyday
+# FIXME: Disabled waiting for: https://github.com/dylibso/chicory/pull/386
+    - cron: "0 12 1 1 *" # At 12:00 on day-of-month 1 in January.
+#    - cron: "0 0 * * *" # everyday
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Temporary disabling the nightly until I come back from vacation or someone take over the port to `wasm-interp`.