### PR TITLE
Builder helper class for HostImports

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostImports.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostImports.java
@@ -1,5 +1,9 @@
 package com.dylibso.chicory.runtime;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 public class HostImports {
     private static final HostFunction[] NO_HOST_FUNCTIONS = new HostFunction[0];
     private static final HostGlobal[] NO_HOST_GLOBALS = new HostGlobal[0];
@@ -127,5 +131,103 @@ public class HostImports {
 
     public void setIndex(FromHost[] index) {
         this.index = index;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private List<HostFunction> functions;
+        private List<HostGlobal> globals;
+        private List<HostMemory> memories;
+        private List<HostTable> tables;
+        private List<FromHost> index;
+
+        Builder() {}
+
+        public Builder withFunctions(List<HostFunction> functions) {
+            this.functions = functions;
+            return this;
+        }
+
+        public Builder addFunction(HostFunction... function) {
+            if (this.functions == null) {
+                this.functions = new ArrayList<>();
+            }
+            Collections.addAll(this.functions, function);
+            return this;
+        }
+
+        public Builder withGlobals(List<HostGlobal> globals) {
+            this.globals = globals;
+            return this;
+        }
+
+        public Builder addGlobal(HostGlobal... global) {
+            if (this.globals == null) {
+                this.globals = new ArrayList<>();
+            }
+            Collections.addAll(this.globals, global);
+            return this;
+        }
+
+        public Builder withMemories(List<HostMemory> memories) {
+            this.memories = memories;
+            return this;
+        }
+
+        public Builder addMemory(HostMemory... memory) {
+            if (this.memories == null) {
+                this.memories = new ArrayList<>();
+            }
+            Collections.addAll(this.memories, memory);
+            return this;
+        }
+
+        public Builder withTables(List<HostTable> tables) {
+            this.tables = tables;
+            return this;
+        }
+
+        public Builder addTable(HostTable... table) {
+            if (this.tables == null) {
+                this.tables = new ArrayList<>();
+            }
+            Collections.addAll(this.tables, table);
+            return this;
+        }
+
+        public Builder withIndex(List<FromHost> index) {
+            this.index = index;
+            return this;
+        }
+
+        public Builder addIndex(FromHost... i) {
+            if (this.index == null) {
+                this.index = new ArrayList<>();
+            }
+            Collections.addAll(this.index, i);
+            return this;
+        }
+
+        public HostImports build() {
+            final HostImports hostImports =
+                    new HostImports(
+                            functions == null
+                                    ? new HostFunction[0]
+                                    : functions.toArray(new HostFunction[0]),
+                            globals == null
+                                    ? new HostGlobal[0]
+                                    : globals.toArray(new HostGlobal[0]),
+                            memories == null
+                                    ? new HostMemory[0]
+                                    : memories.toArray(new HostMemory[0]),
+                            tables == null ? new HostTable[0] : tables.toArray(new HostTable[0]));
+            if (index != null) {
+                hostImports.setIndex(index.toArray(new FromHost[0]));
+            }
+            return hostImports;
+        }
     }
 }

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/HostImportsTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/HostImportsTest.java
@@ -1,0 +1,181 @@
+package com.dylibso.chicory.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.dylibso.chicory.wasm.types.Value;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class HostImportsTest {
+
+    @Nested
+    class Builder {
+        @Test
+        void empty() {
+            final HostImports result = HostImports.builder().build();
+            assertEquals(0, result.functionCount());
+            assertEquals(0, result.globalCount());
+            assertEquals(0, result.memoryCount());
+            assertEquals(0, result.tableCount());
+            assertNull(result.index());
+        }
+
+        @Nested
+        class Function {
+
+            @Test
+            void withFunctions() {
+                final HostImports result =
+                        HostImports.builder()
+                                .withFunctions(
+                                        Arrays.asList(
+                                                new HostFunction(null, "module_1", "", null, null),
+                                                new HostFunction(null, "module_2", "", null, null)))
+                                .build();
+                assertEquals(2, result.functionCount());
+            }
+
+            @Test
+            void addFunction() {
+                final HostImports result =
+                        HostImports.builder()
+                                .addFunction(new HostFunction(null, "module_1", "", null, null))
+                                .addFunction(new HostFunction(null, "module_2", "", null, null))
+                                .build();
+                assertEquals(2, result.functionCount());
+            }
+        }
+
+        @Nested
+        class Global {
+
+            @Test
+            void withGlobals() {
+                final HostImports result =
+                        HostImports.builder()
+                                .withGlobals(
+                                        Arrays.asList(
+                                                new HostGlobal(
+                                                        "spectest",
+                                                        "global_i32",
+                                                        new GlobalInstance(Value.i32(666))),
+                                                new HostGlobal(
+                                                        "spectest",
+                                                        "global_i64",
+                                                        new GlobalInstance(Value.i64(666)))))
+                                .build();
+                assertEquals(2, result.globalCount());
+            }
+
+            @Test
+            void addGlobal() {
+                final HostImports result =
+                        HostImports.builder()
+                                .addGlobal(
+                                        new HostGlobal(
+                                                "spectest",
+                                                "global_i32",
+                                                new GlobalInstance(Value.i32(666))))
+                                .addGlobal(
+                                        new HostGlobal(
+                                                "spectest",
+                                                "global_i64",
+                                                new GlobalInstance(Value.i64(666))))
+                                .build();
+                assertEquals(2, result.globalCount());
+            }
+        }
+
+        @Nested
+        class Memory {
+
+            @Test
+            void withMemories() {
+                final HostImports result =
+                        HostImports.builder()
+                                .withMemories(
+                                        Arrays.asList(
+                                                new HostMemory("spectest", "memory", null),
+                                                new HostMemory("spectest", "memory_2", null)))
+                                .build();
+                assertEquals(2, result.memoryCount());
+            }
+
+            @Test
+            void addMemory() {
+                final HostImports result =
+                        HostImports.builder()
+                                .addMemory(new HostMemory("spectest", "memory", null))
+                                .addMemory(new HostMemory("spectest", "memory_2", null))
+                                .build();
+                assertEquals(2, result.memoryCount());
+            }
+        }
+
+        @Nested
+        class Table {
+
+            @Test
+            void withTables() {
+                final HostImports result =
+                        HostImports.builder()
+                                .withTables(
+                                        Arrays.asList(
+                                                new HostTable(
+                                                        "spectest",
+                                                        "table",
+                                                        Collections.emptyMap()),
+                                                new HostTable(
+                                                        "spectest",
+                                                        "table_2",
+                                                        Collections.emptyMap())))
+                                .build();
+                assertEquals(2, result.tableCount());
+            }
+
+            @Test
+            void addMemory() {
+                final HostImports result =
+                        HostImports.builder()
+                                .addTable(
+                                        new HostTable("spectest", "table", Collections.emptyMap()))
+                                .addTable(
+                                        new HostTable(
+                                                "spectest", "table_2", Collections.emptyMap()))
+                                .build();
+                assertEquals(2, result.tableCount());
+            }
+        }
+
+        @Nested
+        class Index {
+
+            @Test
+            void withIndex() {
+                final HostImports result =
+                        HostImports.builder()
+                                .withIndex(
+                                        Arrays.asList(
+                                                new HostFunction(null, "", "", null, null),
+                                                new HostGlobal(
+                                                        "spectest",
+                                                        "global_i32",
+                                                        new GlobalInstance(Value.i32(666)))))
+                                .build();
+                assertEquals(2, result.index().length);
+            }
+
+            @Test
+            void addIndex() {
+                final HostImports result =
+                        HostImports.builder()
+                                .addIndex(new HostFunction(null, "", "", null, null))
+                                .build();
+                assertEquals(1, result.index().length);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

I'm getting familiar with this repository and wanted to start by contributing a very small improvement.

In this case, I'm tackling #357, since @andreaTP said it could be a good way to start.

Here I'm adding a `HostImportsBuilder` class that can help with the situation described in #357.

If this is OK and we merge it, further refinements can be done in the HostImports class to remove redundant constructors. Similar tactics could be used for other classes too.

(might fix #357)