### PR TITLE
refactor: remove annoying obsolete log

### DIFF
--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -72,6 +72,10 @@ public final class Parser {
     private final BitSet includeSections;
     private final Logger logger;
 
+    public Parser() {
+        this(null, new BitSet());
+    }
+
     public Parser(Logger logger) {
         this(logger, new BitSet());
     }
@@ -84,7 +88,7 @@ public final class Parser {
             Logger logger,
             BitSet includeSections,
             Map<String, Function<byte[], CustomSection>> customParsers) {
-        this.logger = requireNonNull(logger, "logger");
+        this.logger = logger;
         this.includeSections = requireNonNull(includeSections, "includeSections");
         this.customParsers = Map.copyOf(customParsers);
     }
@@ -141,7 +145,9 @@ public final class Parser {
                 module.setDataCountSection((DataCountSection) s);
                 break;
             default:
-                logger.warnf("Ignoring section with id: %d", s.sectionId());
+                if (logger != null) {
+                    logger.warnf("Ignoring section with id: %d", s.sectionId());
+                }
                 break;
         }
     }
@@ -318,7 +324,9 @@ public final class Parser {
                         }
                 }
             } else {
-                System.out.println("Skipping Section with ID due to configuration: " + sectionId);
+                if (logger != null) {
+                    logger.info("Skipping Section with ID due to configuration: " + sectionId);
+                }
                 buffer.position((int) (buffer.position() + sectionSize));
                 continue;
             }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -84,7 +84,7 @@ public final class Parser {
             Logger logger,
             BitSet includeSections,
             Map<String, Function<byte[], CustomSection>> customParsers) {
-        this.logger =  requireNonNull(logger, "logger");;
+        this.logger = requireNonNull(logger, "logger");
         this.includeSections = requireNonNull(includeSections, "includeSections");
         this.customParsers = Map.copyOf(customParsers);
     }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -72,10 +72,6 @@ public final class Parser {
     private final BitSet includeSections;
     private final Logger logger;
 
-    public Parser() {
-        this(null, new BitSet());
-    }
-
     public Parser(Logger logger) {
         this(logger, new BitSet());
     }
@@ -88,7 +84,7 @@ public final class Parser {
             Logger logger,
             BitSet includeSections,
             Map<String, Function<byte[], CustomSection>> customParsers) {
-        this.logger = logger;
+        this.logger =  requireNonNull(logger, "logger");;
         this.includeSections = requireNonNull(includeSections, "includeSections");
         this.customParsers = Map.copyOf(customParsers);
     }
@@ -145,9 +141,7 @@ public final class Parser {
                 module.setDataCountSection((DataCountSection) s);
                 break;
             default:
-                if (logger != null) {
-                    logger.warnf("Ignoring section with id: %d", s.sectionId());
-                }
+                logger.warnf("Ignoring section with id: %d", s.sectionId());
                 break;
         }
     }
@@ -324,9 +318,7 @@ public final class Parser {
                         }
                 }
             } else {
-                if (logger != null) {
-                    logger.info("Skipping Section with ID due to configuration: " + sectionId);
-                }
+                logger.info("Skipping Section with ID due to configuration: " + sectionId);
                 buffer.position((int) (buffer.position() + sectionSize));
                 continue;
             }


### PR DESCRIPTION
System.out.println("Skipping Section with ID due to configuration: " + sectionId);
Is a public log that we cannot hide, so it would be optimal to use the provided logger to log it.

That set aside, I belive firmly that the provided logger should be optional and nullable. If you disagree with me, I can return the logger to be nonNull, but the sysout should be changed to logger.