### PR TITLE
Validate start function signature

### DIFF
--- a/runtime-tests/pom.xml
+++ b/runtime-tests/pom.xml
@@ -176,8 +176,6 @@
             <!-- SelectTest errors are suggesting that messages should be accumulated instead of directly throwing -->
             <test>SpecV1SelectTest.test120</test>
             <test>SpecV1SelectTest.test121</test>
-            <test>SpecV1StartTest.test1</test>
-            <test>SpecV1StartTest.test2</test>
           </excludedTests>
           <excludedMalformedWasts/>
           <excludedInvalidWasts/>


### PR DESCRIPTION
Start functions must have `() -> ()` types [according to the spec](https://webassembly.github.io/spec/core/valid/modules.html#start-function).

When validating functions, initializing a module now correctly checks the signature if a start function is defined and throws the correct exception.

With this check, two more skipped tests can be enabled.

Refs #335 