### PR TITLE
Skip macos Java 11 test because of memory leak

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         version: [11, 17]
+        exclude:
+          - os: macos-latest
+            version: 11
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Skip macos11 until we can fix memory leak in #451