### PR TITLE
Disable the type validation in wabt tools

### DIFF
--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
@@ -90,7 +90,10 @@ public class Wast2Json {
                                 .withOpts(wasiOpts.build())
                                 .build()) {
                     HostImports imports = new HostImports(wasi.toHostFunctions());
-                    Instance.builder(MODULE).withHostImports(imports).build();
+                    Instance.builder(MODULE)
+                            .withTypeValidation(false)
+                            .withHostImports(imports)
+                            .build();
                 }
 
                 createDirectories(output.toPath().getParent());

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
@@ -75,7 +75,10 @@ public final class Wat2Wasm {
                 try (var wasi =
                         WasiPreview1.builder().withLogger(logger).withOpts(wasiOpts).build()) {
                     HostImports imports = new HostImports(wasi.toHostFunctions());
-                    Instance.builder(MODULE).withHostImports(imports).build();
+                    Instance.builder(MODULE)
+                            .withTypeValidation(false)
+                            .withHostImports(imports)
+                            .build();
                 }
 
                 return stdoutStream.toByteArray();


### PR DESCRIPTION
This potentially fixes/improves the situation for #451 but opens a question wrt our API.

Current situation:

You can do the parsing and cache the loaded module in memory with:
```java
private static final Module MODULE = Module.builder(...).build();
```
after that, you still need 2 steps:
 - `Instance` initialization
 - `start` function call
 the initialization will also map the `HostImports`, but, when using `wasi` we always need to re-initialize everything even when changing only the `arguments`, as we have a single `build` method:
 ```java
 Instance.builder(MODULE).withHostImports(imports).build();
 ```
 
 this is sub-optimal as there are use cases(i.e. multiple subsequent executions of a tool) that would benefit from caching the `Instance` and hot-swapping the wasi `HostImports`:
 
 Possible resolution:
 
 ```java
 private static final HostImports baseImports = ???;
 private static final Instance INSTANCE = Instance.builder(Module.builder(...).build()).withHostImports(baseImports).withStart(false).build();
 ```
 
 when using the `Instance` we should be able to fully skip the initialization(and have an effective memoization) by using, something like:
 
 ```java
 INSTANCE.updateImports(baseImports.withArgs(myNewArgs)).export("_start").apply();
 ```
 
 There are few possible alternatives to tackle the problem, I'm interested if this is something we want to fix now or something that can be postponed, I'm not sure how much this pattern is widely used. 
 Thoughts?