### PR TITLE
Make type validation use Module instead of Instance

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -5,6 +5,7 @@ import static com.dylibso.chicory.runtime.ConstantEvaluators.computeConstantValu
 import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
 
 import com.dylibso.chicory.wasm.Module;
+import com.dylibso.chicory.wasm.TypeValidator;
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
 import com.dylibso.chicory.wasm.exceptions.InvalidException;
 import com.dylibso.chicory.wasm.exceptions.MalformedException;
@@ -273,7 +274,7 @@ public class Instance {
                                             + funcType);
                         }
                     }
-                    new TypeValidator().validate(i, this.function(i), this.types[funcType], this);
+                    new TypeValidator(module).validate(i, function(i), types[funcType]);
                 }
             }
         }
@@ -358,29 +359,11 @@ public class Instance {
         return globals[idx - importedGlobalsOffset].getValue();
     }
 
-    public Global globalInitializer(int idx) {
-        if (idx < importedGlobalsOffset) {
-            return null;
-        }
-        if ((idx - importedGlobalsOffset) >= globalInitializers.length) {
-            throw new InvalidException("unknown global " + idx);
-        }
-        return globalInitializers[idx - importedGlobalsOffset];
-    }
-
-    public int globalCount() {
-        return globals.length;
-    }
-
     public FunctionType type(int idx) {
         if (idx >= types.length) {
             throw new InvalidException("unknown type " + idx);
         }
         return types[idx];
-    }
-
-    public int typeCount() {
-        return types.length;
     }
 
     public int functionType(int idx) {
@@ -406,10 +389,6 @@ public class Instance {
             return imports.table(idx).table();
         }
         return tables[idx - importedTablesOffset];
-    }
-
-    public DataSegment[] dataSegments() {
-        return dataSegments;
     }
 
     public Element element(int idx) {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalSection.java
@@ -20,6 +20,10 @@ public class GlobalSection extends Section {
         return globals.size();
     }
 
+    public Global getGlobal(int idx) {
+        return globals.get(idx);
+    }
+
     public static Builder builder() {
         return new Builder();
     }


### PR DESCRIPTION
After #460 is merged, we can make this part of `Module.Builder`.