### PR TITLE
Cleanup code and enforce with Checkstyle and Error Prone

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,11 +44,9 @@ jobs:
           java-version: '${{ matrix.version }}'
           cache: maven
       - name: Check Style
-        run:  mvn -B spotless:check -Pbenchmarks -Pfuzz
+        run:  mvn -B spotless:check
       - name: Test Java
         run: mvn -B clean install
-      - name: Verify that nightly fuzz compiles
-        run: mvn -B test -DskipTests -Pfuzz -pl fuzz
 
   readme-ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -49,7 +49,7 @@ jobs:
           # Build everything
           mvn -B install -DskipTests
           # Run only the fuzz tests
-          mvn -B clean verify -Pfuzz -pl fuzz -Dfuzz.test.numeric=10 -Dfuzz.test.table=10
+          mvn -B clean verify -pl fuzz -DskipTests=false -Dfuzz.test.numeric=10 -Dfuzz.test.table=10
 
       - name: Create Pull Request with the crash repro
         uses: peter-evans/create-pull-request@v6

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
@@ -174,15 +174,6 @@ final class AotEmitters {
         updateStackSize(ctx, functionType);
     }
 
-    private static void updateStackSize(AotContext ctx, FunctionType functionType) {
-        for (int i = 0; i < functionType.params().size(); i++) {
-            ctx.popStackSize();
-        }
-        for (ValueType type : functionType.returns()) {
-            ctx.pushStackSize(stackSize(jvmType(type)));
-        }
-    }
-
     public static void REF_FUNC(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
         asm.visitLdcInsn((int) ins.operands()[0]);
     }
@@ -646,6 +637,15 @@ final class AotEmitters {
                         + staticHelpers.getName()
                         + " does not provide an implementation of opcode "
                         + opcode.name());
+    }
+
+    private static void updateStackSize(AotContext ctx, FunctionType functionType) {
+        for (int i = 0; i < functionType.params().size(); i++) {
+            ctx.popStackSize();
+        }
+        for (ValueType type : functionType.returns()) {
+            ctx.pushStackSize(stackSize(jvmType(type)));
+        }
     }
 
     private static void updateStackSize(AotContext ctx, OpCode opCode) {

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
@@ -26,6 +26,7 @@ import static java.lang.invoke.MethodHandles.filterReturnValue;
 import static java.lang.invoke.MethodHandles.insertArguments;
 import static java.lang.invoke.MethodHandles.publicLookup;
 import static java.lang.invoke.MethodType.methodType;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
@@ -506,7 +507,7 @@ public final class AotMachine implements Machine {
             // run ASM verifier to help with debugging
             try {
                 ClassReader reader = new ClassReader(classBytes);
-                CheckClassAdapter.verify(reader, true, new PrintWriter(System.out));
+                CheckClassAdapter.verify(reader, true, new PrintWriter(System.out, false, UTF_8));
             } catch (NoClassDefFoundError ignored) {
                 // the ASM verifier is an optional dependency
             } catch (Throwable t) {

--- a/aot/src/main/java/com/dylibso/chicory/aot/HostFunctionInvoker.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/HostFunctionInvoker.java
@@ -17,7 +17,7 @@ final class HostFunctionInvoker {
                                     HostFunctionInvoker.class.getMethod(
                                             "invoke", Instance.class, int.class, Value[].class));
         } catch (NoSuchMethodException | IllegalAccessException e) {
-            throw new AssertionError(e);
+            throw new LinkageError(e.getMessage(), e);
         }
     }
 

--- a/aot/src/main/java/com/dylibso/chicory/aot/ValueWrapper.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/ValueWrapper.java
@@ -12,7 +12,7 @@ final class ValueWrapper {
         try {
             HANDLE = lookup().unreflect(ValueWrapper.class.getMethod("wrap", Value.class));
         } catch (NoSuchMethodException | IllegalAccessException e) {
-            throw new AssertionError(e);
+            throw new LinkageError(e.getMessage(), e);
         }
     }
 

--- a/aot/src/test/java/com/dylibso/chicory/approvals/ApprovalTest.java
+++ b/aot/src/test/java/com/dylibso/chicory/approvals/ApprovalTest.java
@@ -1,5 +1,7 @@
 package com.dylibso.chicory.approvals;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.dylibso.chicory.aot.AotMachine;
 import com.dylibso.chicory.runtime.HostFunction;
 import com.dylibso.chicory.runtime.HostImports;
@@ -94,7 +96,7 @@ public class ApprovalTest {
 
         ClassReader cr = new ClassReader(compiled);
         var out = new ByteArrayOutputStream();
-        cr.accept(new TraceClassVisitor(new PrintWriter(out)), 0);
+        cr.accept(new TraceClassVisitor(new PrintWriter(out, false, UTF_8)), 0);
 
         Approvals.verify(out);
     }

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1BinaryLeb128HostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1BinaryLeb128HostFuncs.java
@@ -7,7 +7,10 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1BinaryLeb128HostFuncs {
+public final class SpecV1BinaryLeb128HostFuncs {
+
+    private SpecV1BinaryLeb128HostFuncs() {}
+
     public static HostImports fallback() {
         return HostImports.builder()
                 .addFunction(

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1DataHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1DataHostFuncs.java
@@ -11,7 +11,10 @@ import com.dylibso.chicory.wasm.types.MemoryLimits;
 import com.dylibso.chicory.wasm.types.MutabilityType;
 import com.dylibso.chicory.wasm.types.Value;
 
-public class SpecV1DataHostFuncs {
+public final class SpecV1DataHostFuncs {
+
+    private SpecV1DataHostFuncs() {}
+
     public static HostImports fallback() {
 
         return new HostImports(

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ElemHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ElemHostFuncs.java
@@ -15,9 +15,11 @@ import com.dylibso.chicory.wasm.types.Table;
 import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 
-public class SpecV1ElemHostFuncs {
+public final class SpecV1ElemHostFuncs {
 
     private static GlobalInstance glob = new GlobalInstance(Value.i32(123));
+
+    private SpecV1ElemHostFuncs() {}
 
     public static HostImports fallback() {
         return HostImports.builder()

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ExportsHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ExportsHostFuncs.java
@@ -16,7 +16,10 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1ExportsHostFuncs {
+public final class SpecV1ExportsHostFuncs {
+
+    private SpecV1ExportsHostFuncs() {}
+
     public static HostImports fallback() {
         return HostImports.builder()
                 .addFunction(

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1FuncPtrsHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1FuncPtrsHostFuncs.java
@@ -7,7 +7,9 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1FuncPtrsHostFuncs {
+public final class SpecV1FuncPtrsHostFuncs {
+
+    private SpecV1FuncPtrsHostFuncs() {}
 
     public static HostImports fallback() {
         return new HostImports(

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
@@ -6,7 +6,9 @@ import com.dylibso.chicory.runtime.HostImports;
 import com.dylibso.chicory.wasm.types.MutabilityType;
 import com.dylibso.chicory.wasm.types.Value;
 
-public class SpecV1GlobalHostFuncs {
+public final class SpecV1GlobalHostFuncs {
+
+    private SpecV1GlobalHostFuncs() {}
 
     public static HostImports fallback() {
         return new HostImports(

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
@@ -17,7 +17,9 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1ImportsHostFuncs {
+public final class SpecV1ImportsHostFuncs {
+
+    private SpecV1ImportsHostFuncs() {}
 
     public static HostImports testModule11() {
         return HostImports.builder()

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1LinkingHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1LinkingHostFuncs.java
@@ -23,7 +23,7 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1LinkingHostFuncs {
+public final class SpecV1LinkingHostFuncs {
 
     private static HostFunction MfCall =
             new HostFunction(
@@ -32,6 +32,8 @@ public class SpecV1LinkingHostFuncs {
                     "call",
                     List.of(),
                     List.of(ValueType.I32));
+
+    private SpecV1LinkingHostFuncs() {}
 
     public static HostImports Mf() {
         return new HostImports(new HostFunction[] {MfCall});

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1NamesHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1NamesHostFuncs.java
@@ -7,7 +7,10 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1NamesHostFuncs {
+public final class SpecV1NamesHostFuncs {
+
+    private SpecV1NamesHostFuncs() {}
+
     public static HostImports fallback() {
         return new HostImports(
                 new HostFunction[] {

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1RefFuncHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1RefFuncHostFuncs.java
@@ -7,7 +7,9 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1RefFuncHostFuncs {
+public final class SpecV1RefFuncHostFuncs {
+
+    private SpecV1RefFuncHostFuncs() {}
 
     public static HostImports fallback() {
         return HostImports.builder()

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1StartHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1StartHostFuncs.java
@@ -7,7 +7,10 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1StartHostFuncs {
+public final class SpecV1StartHostFuncs {
+
+    private SpecV1StartHostFuncs() {}
+
     public static HostImports fallback() {
         return new HostImports(
                 new HostFunction[] {

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1TableCopyHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1TableCopyHostFuncs.java
@@ -7,7 +7,9 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1TableCopyHostFuncs {
+public final class SpecV1TableCopyHostFuncs {
+
+    private SpecV1TableCopyHostFuncs() {}
 
     public static HostImports fallback() {
         return new HostImports(

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1TableHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1TableHostFuncs.java
@@ -7,7 +7,10 @@ import com.dylibso.chicory.wasm.types.Limits;
 import com.dylibso.chicory.wasm.types.Table;
 import com.dylibso.chicory.wasm.types.ValueType;
 
-public class SpecV1TableHostFuncs {
+public final class SpecV1TableHostFuncs {
+
+    private SpecV1TableHostFuncs() {}
+
     public static HostImports fallback() {
         return HostImports.builder()
                 .addTable(

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1TableInitHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1TableInitHostFuncs.java
@@ -7,7 +7,9 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1TableInitHostFuncs {
+public final class SpecV1TableInitHostFuncs {
+
+    private SpecV1TableInitHostFuncs() {}
 
     public static HostImports fallback() {
         return new HostImports(

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1TokensHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1TokensHostFuncs.java
@@ -6,7 +6,10 @@ import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasm.types.Value;
 import java.util.List;
 
-public class SpecV1TokensHostFuncs {
+public final class SpecV1TokensHostFuncs {
+
+    private SpecV1TokensHostFuncs() {}
+
     public static HostImports fallback() {
         return HostImports.builder()
                 .addFunction(

--- a/aot/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/aot/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -50,7 +50,7 @@ public class TestModule {
             byte[] parsed;
             try {
                 parsed = Wat2Wasm.parse(file);
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 throw new MalformedException(
                         e.getMessage() + HACK_MATCH_ALL_MALFORMED_EXCEPTION_TEXT);
             }

--- a/aot/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/aot/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -16,10 +16,6 @@ public class TestModule {
 
     private HostImports imports;
 
-    public static TestModule of(Module module) {
-        return new TestModule(module);
-    }
-
     private static final String HACK_MATCH_ALL_MALFORMED_EXCEPTION_TEXT =
             "Matching keywords to get the WebAssembly testsuite to pass: "
                     + "malformed UTF-8 encoding "
@@ -57,6 +53,10 @@ public class TestModule {
             return of(Parser.parse(parsed));
         }
         return of(Parser.parse(file));
+    }
+
+    public static TestModule of(Module module) {
+        return new TestModule(module);
     }
 
     public TestModule(Module module) {

--- a/cli/src/main/java/com/dylibso/chicory/cli/Cli.java
+++ b/cli/src/main/java/com/dylibso/chicory/cli/Cli.java
@@ -30,18 +30,18 @@ public class Cli implements Runnable {
     int[] arguments;
 
     @CommandLine.Option(
-            names = {"--invoke"},
+            names = "--invoke",
             description = "The exported WASM function to be invoked")
     String functionName;
 
     @CommandLine.Option(
-            names = {"--wasi"},
+            names = "--wasi",
             description = "Enable the experimental WASI V1 support",
             defaultValue = "false")
     boolean wasi;
 
     @CommandLine.Option(
-            names = {"--log-level"},
+            names = "--log-level",
             description = "The log level to be used",
             defaultValue = "INFO")
     String logLevel; // this should be an enum

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -28,7 +28,3 @@ export CHICORY_FUZZ_TYPES=numeric,table
 
 mvn install -Pfuzz -pl fuzz -Dtest="com.dylibso.chicory.fuzz.SingleReproTest#singleReproducer"
 ```
-
-## Import in IntelliJ
-
-Right click on `/fuzz/pom.xml` -> "Add as a Maven Project"

--- a/fuzz/pom.xml
+++ b/fuzz/pom.xml
@@ -13,6 +13,13 @@
   <name>Chicory - Fuzz</name>
   <description>Fuzzying Chicory</description>
 
+  <properties>
+    <skipTests>true</skipTests>
+
+    <fuzz.test.numeric>10</fuzz.test.numeric>
+    <fuzz.test.table>10</fuzz.test.table>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>

--- a/fuzz/src/main/java/com/dylibso/chicory/fuzz/InstructionType.java
+++ b/fuzz/src/main/java/com/dylibso/chicory/fuzz/InstructionType.java
@@ -27,7 +27,9 @@ public enum InstructionType {
             new HashMap<>(InstructionType.values().length);
 
     static {
-        for (InstructionType i : InstructionType.values()) byValue.put(i.value(), i);
+        for (InstructionType i : InstructionType.values()) {
+            byValue.put(i.value(), i);
+        }
     }
 
     public String value() {

--- a/fuzz/src/main/java/com/dylibso/chicory/fuzz/InstructionTypes.java
+++ b/fuzz/src/main/java/com/dylibso/chicory/fuzz/InstructionTypes.java
@@ -1,6 +1,7 @@
 package com.dylibso.chicory.fuzz;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -28,7 +29,7 @@ public class InstructionTypes {
                 Arrays.stream(values.trim().split(","))
                         .map(
                                 v -> {
-                                    var res = InstructionType.byValue(v.toLowerCase());
+                                    var res = InstructionType.byValue(v.toLowerCase(Locale.ROOT));
                                     if (res == null) {
                                         throw new RuntimeException(
                                                 "Cannot find a matching type for " + v);

--- a/fuzz/src/main/java/com/dylibso/chicory/fuzz/RuntimeCli.java
+++ b/fuzz/src/main/java/com/dylibso/chicory/fuzz/RuntimeCli.java
@@ -24,7 +24,7 @@ public abstract class RuntimeCli {
         this.cmdName = cmdName;
     }
 
-    public String run(File file, String functionName, List<String> params) throws Exception {
+    public String run(File file, String functionName, List<String> params) throws IOException {
         var command = new ArrayList<String>();
         command.addAll(List.of(binaryName, file.getAbsolutePath(), "--invoke", functionName));
         command.addAll(params);
@@ -48,6 +48,7 @@ public abstract class RuntimeCli {
         } catch (IOException e) {
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
 

--- a/fuzz/src/main/java/com/dylibso/chicory/fuzz/RuntimeCli.java
+++ b/fuzz/src/main/java/com/dylibso/chicory/fuzz/RuntimeCli.java
@@ -62,7 +62,9 @@ public abstract class RuntimeCli {
         BufferedReader br = new BufferedReader(new InputStreamReader(ps.getInputStream()));
         StringBuilder sb = new StringBuilder();
         String line;
-        while ((line = br.readLine()) != null) sb.append(line + "\n");
+        while ((line = br.readLine()) != null) {
+            sb.append(line + "\n");
+        }
         String result = sb.toString();
         logger.info("Returned output is:\n" + result);
         return result;

--- a/fuzz/src/main/java/com/dylibso/chicory/fuzz/RuntimeCli.java
+++ b/fuzz/src/main/java/com/dylibso/chicory/fuzz/RuntimeCli.java
@@ -1,5 +1,7 @@
 package com.dylibso.chicory.fuzz;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.dylibso.chicory.log.Logger;
 import com.dylibso.chicory.log.SystemLogger;
 import java.io.BufferedReader;
@@ -7,7 +9,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -33,7 +34,7 @@ public abstract class RuntimeCli {
         // TODO: centralize the management of folders/files it's too scattered
         try (var outputStream =
                 new FileOutputStream(file.getParentFile() + "/" + cmdName + "-command.txt")) {
-            outputStream.write(String.join(" ", command).getBytes(StandardCharsets.UTF_8));
+            outputStream.write(String.join(" ", command).getBytes(UTF_8));
             outputStream.flush();
         }
 
@@ -55,12 +56,12 @@ public abstract class RuntimeCli {
         // check
         if (ps.exitValue() != 0) {
             System.err.println(cmdName + " exiting with:" + ps.exitValue());
-            System.err.println(new String(ps.getErrorStream().readAllBytes()));
+            System.err.println(new String(ps.getErrorStream().readAllBytes(), UTF_8));
             throw new RuntimeException("Failed to execute " + cmdName + " program.");
         }
 
         // get output
-        BufferedReader br = new BufferedReader(new InputStreamReader(ps.getInputStream()));
+        BufferedReader br = new BufferedReader(new InputStreamReader(ps.getInputStream(), UTF_8));
         StringBuilder sb = new StringBuilder();
         String line;
         while ((line = br.readLine()) != null) {

--- a/fuzz/src/main/java/com/dylibso/chicory/fuzz/TestModule.java
+++ b/fuzz/src/main/java/com/dylibso/chicory/fuzz/TestModule.java
@@ -7,6 +7,7 @@ import com.dylibso.chicory.wasm.Module;
 import com.dylibso.chicory.wasm.types.FunctionType;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +52,7 @@ public class TestModule {
                         String oracleResult = null;
                         try {
                             oracleResult = wasmtime.run(targetWasm, export.name(), params);
-                        } catch (Exception e) {
+                        } catch (IOException | RuntimeException e) {
                             // If the oracle failed we can skip ...
                             logger.error("Failed to run the oracle, skip the check on Chicory");
                             continue;
@@ -61,7 +62,7 @@ public class TestModule {
                         String chicoryResult = null;
                         try {
                             chicoryResult = chicoryCli.run(targetWasm, export.name(), params);
-                        } catch (Exception e) {
+                        } catch (IOException | RuntimeException e) {
                             logger.warn("Failed to run chicory, but wasmtime succeeded: " + e);
                         }
                         // To be used for files generation

--- a/fuzz/src/main/java/com/dylibso/chicory/fuzz/WasmSmithWrapper.java
+++ b/fuzz/src/main/java/com/dylibso/chicory/fuzz/WasmSmithWrapper.java
@@ -28,7 +28,7 @@ public class WasmSmithWrapper {
     WasmSmithWrapper() {}
 
     public File run(String subfolder, String fileName, InstructionTypes instructionTypes)
-            throws Exception {
+            throws IOException {
         return run(subfolder, fileName, instructionTypes, "/smith.default.properties");
     }
 
@@ -37,7 +37,7 @@ public class WasmSmithWrapper {
             String fileName,
             InstructionTypes instructionTypes,
             String smithProperties)
-            throws Exception {
+            throws IOException {
         var targetSubfolder = "target/fuzz/data/" + subfolder;
         var targetFolder = new File(targetSubfolder);
         targetFolder.mkdirs();
@@ -93,6 +93,7 @@ public class WasmSmithWrapper {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             } finally {
                 // Renew the seed

--- a/fuzz/src/main/java/com/dylibso/chicory/fuzz/WasmSmithWrapper.java
+++ b/fuzz/src/main/java/com/dylibso/chicory/fuzz/WasmSmithWrapper.java
@@ -1,11 +1,12 @@
 package com.dylibso.chicory.fuzz;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.dylibso.chicory.log.Logger;
 import com.dylibso.chicory.log.SystemLogger;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -32,6 +33,7 @@ public class WasmSmithWrapper {
         return run(subfolder, fileName, instructionTypes, "/smith.default.properties");
     }
 
+    @SuppressWarnings("StringSplitter")
     public File run(
             String subfolder,
             String fileName,
@@ -48,9 +50,7 @@ public class WasmSmithWrapper {
         // --ensure-termination true -> breaks the execution
         var defaultProperties = new ArrayList<String>();
         var propsFile =
-                new String(
-                        getClass().getResourceAsStream(smithProperties).readAllBytes(),
-                        StandardCharsets.UTF_8);
+                new String(getClass().getResourceAsStream(smithProperties).readAllBytes(), UTF_8);
         var props = propsFile.split("\n");
         for (var prop : props) {
             if (!prop.isEmpty()) {
@@ -81,7 +81,7 @@ public class WasmSmithWrapper {
 
             // write the seed file
             try (var outputStream = new FileOutputStream(seedFile)) {
-                outputStream.write((seed).getBytes(StandardCharsets.UTF_8));
+                outputStream.write((seed).getBytes(UTF_8));
                 outputStream.flush();
             }
 
@@ -103,7 +103,7 @@ public class WasmSmithWrapper {
 
             if (ps.exitValue() != 0) {
                 logger.error("wasm-smith exiting with:" + ps.exitValue());
-                logger.error(new String(ps.getErrorStream().readAllBytes()));
+                logger.error(new String(ps.getErrorStream().readAllBytes(), UTF_8));
                 retry--;
             } else {
                 break;

--- a/jmh/pom.xml
+++ b/jmh/pom.xml
@@ -38,7 +38,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <annotationProcessorPaths>
+          <annotationProcessorPaths combine.children="append">
             <path>
               <groupId>org.openjdk.jmh</groupId>
               <artifactId>jmh-generator-annprocess</artifactId>

--- a/jmh/pom.xml
+++ b/jmh/pom.xml
@@ -23,12 +23,12 @@
       <artifactId>runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.openjdk.jmh</groupId>
-      <artifactId>jmh-core</artifactId>
+      <groupId>com.dylibso.chicory</groupId>
+      <artifactId>wasm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
-      <artifactId>jmh-generator-annprocess</artifactId>
+      <artifactId>jmh-core</artifactId>
     </dependency>
   </dependencies>
 

--- a/log/src/main/java/com/dylibso/chicory/log/Logger.java
+++ b/log/src/main/java/com/dylibso/chicory/log/Logger.java
@@ -24,6 +24,7 @@ public interface Logger {
 
         /**
          * Returns the name of this level.
+         *
          * @return this level {@linkplain #name()}.
          */
         public final String getName() {
@@ -33,6 +34,7 @@ public interface Logger {
         /**
          * Returns the severity of this level.
          * A higher severity means a more severe condition.
+         *
          * @return this level severity.
          */
         public final int getSeverity() {

--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,7 @@
               </module>
               <module name="SuppressWarningsFilter"/>
               <module name="TreeWalker">
+                <module name="AnnotationUseStyle"/>
                 <module name="ArrayTypeStyle"/>
                 <module name="AtclauseOrder"/>
                 <module name="AvoidDoubleBraceInitialization"/>

--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,7 @@
                 </module>
                 <module name="EmptyCatchBlock"/>
                 <module name="FallThrough"/>
+                <module name="HideUtilityClassConstructor"/>
                 <module name="InnerAssignment"/>
                 <module name="InvalidJavadocPosition"/>
                 <module name="JavadocBlockTagLocation"/>

--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,9 @@
                 <module name="ExplicitInitialization"/>
                 <module name="FallThrough"/>
                 <module name="HideUtilityClassConstructor"/>
+                <module name="IllegalCatch">
+                  <property name="illegalClassNames" value="Exception"/>
+                </module>
                 <module name="InnerAssignment"/>
                 <module name="InvalidJavadocPosition"/>
                 <module name="JavadocBlockTagLocation"/>

--- a/pom.xml
+++ b/pom.xml
@@ -452,6 +452,7 @@
                 <module name="OneStatementPerLine"/>
                 <module name="OneTopLevelClass"/>
                 <module name="PackageDeclaration"/>
+                <module name="RequireEmptyLineBeforeBlockTagGroup"/>
                 <module name="SimplifyBooleanExpression"/>
                 <module name="SimplifyBooleanReturn"/>
                 <module name="SingleLineJavadoc"/>

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.release>11</maven.compiler.release>
-    <maven.compiler.parameters>true</maven.compiler.parameters>
 
     <approvaltests.version>24.4.0</approvaltests.version>
     <asm.version>9.7</asm.version>
@@ -402,9 +399,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>${maven.compiler.source}</source>
-          <target>${maven.compiler.target}</target>
-          <release>${maven.compiler.target}</release>
+          <release>${maven.compiler.release}</release>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
 
@@ -468,7 +464,7 @@
             </goals>
             <configuration>
               <doclint>all,-missing</doclint>
-              <release>${maven.compiler.target}</release>
+              <release>${maven.compiler.release}</release>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,7 @@
                 <module name="NonEmptyAtclauseDescription"/>
                 <module name="OneStatementPerLine"/>
                 <module name="OneTopLevelClass"/>
+                <module name="OverloadMethodsDeclarationOrder"/>
                 <module name="PackageDeclaration"/>
                 <module name="RequireEmptyLineBeforeBlockTagGroup"/>
                 <module name="SimplifyBooleanExpression"/>

--- a/pom.xml
+++ b/pom.xml
@@ -501,8 +501,13 @@
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
             <arg>-Xplugin:ErrorProne \
-              -XepDisableAllChecks \
+              -Xep:MissingCasesInEnumSwitch:OFF \
               -Xep:MissingOverride:ERROR \
+              -Xep:MissingSummary:OFF \
+              -Xep:NonOverridingEquals:OFF \
+              -Xep:OperatorPrecedence:OFF \
+              -Xep:ReferenceEquality:OFF \
+              -Xep:UnnecessaryParentheses:OFF \
               -XepExcludedPaths:.*/target/generated-(|test-)sources/.*</arg>
           </compilerArgs>
           <annotationProcessorPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -241,39 +241,9 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-source-plugin</artifactId>
-          <version>${maven-source-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>${maven-jar-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>${maven-install-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-plugin-plugin</artifactId>
-          <version>${maven-plugin-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>${maven-compiler-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>${maven-resources-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>${maven-surefire-plugin.version}</version>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${spotless-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -282,18 +252,18 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven-compiler-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>${maven-dependency-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>${maven-deploy-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>${maven-site-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>${maven-javadoc-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -302,23 +272,28 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <version>${maven-dependency-plugin.version}</version>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>${maven-install-plugin.version}</version>
         </plugin>
         <plugin>
-          <groupId>com.diffplug.spotless</groupId>
-          <artifactId>spotless-maven-plugin</artifactId>
-          <version>${spotless-maven-plugin.version}</version>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${maven-jar-plugin.version}</version>
         </plugin>
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>${nexus-staging-maven-plugin.version}</version>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${maven-javadoc-plugin.version}</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>templating-maven-plugin</artifactId>
-          <version>${templating-maven-plugin.version}</version>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>${maven-plugin-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>${maven-resources-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -326,109 +301,39 @@
           <version>${maven-shade-plugin.version}</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${maven-site-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>${maven-source-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
           <version>${flatten-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>templating-maven-plugin</artifactId>
+          <version>${templating-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>${nexus-staging-maven-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
 
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${maven.compiler.source}</source>
-          <target>${maven.compiler.target}</target>
-          <release>${maven.compiler.target}</release>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <jna.library.path>../target/release</jna.library.path>
-            <java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${maven-javadoc-plugin.version}</version>
-        <configuration>
-          <doclint>none</doclint>
-          <source>1.8</source>
-        </configuration>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <configuration>
-              <doclint>all,-missing</doclint>
-              <release>${maven.compiler.target}</release>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>${maven-source-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <configuration>
-          <fail>true</fail>
-          <failFast>false</failFast>
-          <rules>
-            <banDuplicatePomDependencyVersions/>
-            <requireUpperBoundDeps/>
-          </rules>
-        </configuration>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <phase>validate</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <failOnWarning>true</failOnWarning>
-          <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
-          <ignoredUnusedDeclaredDependencies>
-            <dependency>com.dylibso.chicory:wasm-corpus</dependency>
-            <dependency>org.junit.jupiter:junit-jupiter-engine</dependency>
-          </ignoredUnusedDeclaredDependencies>
-        </configuration>
-        <executions>
-          <execution>
-            <id>dependency-analyze</id>
-            <goals>
-              <goal>analyze-only</goal>
-            </goals>
-            <phase>process-test-classes</phase>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
@@ -478,6 +383,7 @@
               <sortModules>true</sortModules>
               <sortDependencies>scope,groupId,artifactId</sortDependencies>
               <sortDependencyExclusions>groupId,artifactId</sortDependencyExclusions>
+              <sortPlugins>groupId,artifactId</sortPlugins>
             </sortPom>
           </pom>
         </configuration>
@@ -490,6 +396,101 @@
             <phase>process-sources</phase>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+          <release>${maven.compiler.target}</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <failOnWarning>true</failOnWarning>
+          <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
+          <ignoredUnusedDeclaredDependencies>
+            <dependency>com.dylibso.chicory:wasm-corpus</dependency>
+            <dependency>org.junit.jupiter:junit-jupiter-engine</dependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+        <executions>
+          <execution>
+            <id>dependency-analyze</id>
+            <goals>
+              <goal>analyze-only</goal>
+            </goals>
+            <phase>process-test-classes</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <fail>true</fail>
+          <failFast>false</failFast>
+          <rules>
+            <banDuplicatePomDependencyVersions/>
+            <requireUpperBoundDeps/>
+          </rules>
+        </configuration>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>${maven-javadoc-plugin.version}</version>
+        <configuration>
+          <doclint>none</doclint>
+          <source>1.8</source>
+        </configuration>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <doclint>all,-missing</doclint>
+              <release>${maven.compiler.target}</release>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>${maven-source-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <jna.library.path>../target/release</jna.library.path>
+            <java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>
+          </systemPropertyVariables>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,7 @@
                   <property name="option" value="text"/>
                 </module>
                 <module name="EmptyCatchBlock"/>
+                <module name="ExplicitInitialization"/>
                 <module name="FallThrough"/>
                 <module name="HideUtilityClassConstructor"/>
                 <module name="InnerAssignment"/>

--- a/pom.xml
+++ b/pom.xml
@@ -502,6 +502,7 @@
             <arg>-XDcompilePolicy=simple</arg>
             <arg>-Xplugin:ErrorProne \
               -XepDisableAllChecks \
+              -Xep:MissingOverride:ERROR \
               -XepExcludedPaths:.*/target/generated-(|test-)sources/.*</arg>
           </compilerArgs>
           <annotationProcessorPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,7 @@
                 </module>
                 <module name="EmptyCatchBlock"/>
                 <module name="FallThrough"/>
+                <module name="InnerAssignment"/>
                 <module name="InvalidJavadocPosition"/>
                 <module name="JavadocBlockTagLocation"/>
                 <module name="JavadocContentLocation"/>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,9 @@
     <picocli.version>4.7.6</picocli.version>
 
     <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
+    <checkstyle.version>10.17.0</checkstyle.version>
     <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
+    <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.8.0</maven-dependency-plugin.version>
@@ -241,6 +243,18 @@
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${spotless-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>${maven-checkstyle-plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>${checkstyle.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -397,6 +411,72 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <failOnViolation>true</failOnViolation>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+          <excludeGeneratedSources>true</excludeGeneratedSources>
+          <checkstyleRules>
+            <module name="Checker">
+              <module name="FileTabCharacter">
+                <property name="fileExtensions" value="java,xml"/>
+              </module>
+              <module name="SuppressWarningsFilter"/>
+              <module name="TreeWalker">
+                <module name="ArrayTypeStyle"/>
+                <module name="AtclauseOrder"/>
+                <module name="AvoidDoubleBraceInitialization"/>
+                <module name="AvoidNoArgumentSuperConstructorCall"/>
+                <module name="ConstructorsDeclarationGrouping"/>
+                <module name="DefaultComesLast"/>
+                <module name="EmptyBlock">
+                  <property name="option" value="text"/>
+                </module>
+                <module name="EmptyCatchBlock"/>
+                <module name="FallThrough"/>
+                <module name="InvalidJavadocPosition"/>
+                <module name="JavadocBlockTagLocation"/>
+                <module name="JavadocContentLocation"/>
+                <module name="JavadocMissingLeadingAsterisk"/>
+                <module name="JavadocMissingWhitespaceAfterAsterisk"/>
+                <module name="ModifiedControlVariable"/>
+                <module name="ModifierOrder"/>
+                <module name="MultipleVariableDeclarations"/>
+                <module name="MutableException"/>
+                <module name="NoClone"/>
+                <module name="NoFinalizer"/>
+                <module name="NonEmptyAtclauseDescription"/>
+                <module name="OneStatementPerLine"/>
+                <module name="OneTopLevelClass"/>
+                <module name="PackageDeclaration"/>
+                <module name="SimplifyBooleanExpression"/>
+                <module name="SimplifyBooleanReturn"/>
+                <module name="SingleLineJavadoc"/>
+                <module name="StringLiteralEquality"/>
+                <module name="SuppressWarningsHolder"/>
+                <module name="TypeName"/>
+                <module name="UnnecessarySemicolonAfterOuterTypeDeclaration"/>
+                <module name="UnnecessarySemicolonAfterTypeMemberDeclaration"/>
+                <module name="UnnecessarySemicolonInEnumeration"/>
+                <module name="UnnecessarySemicolonInTryWithResources"/>
+                <module name="UpperEll"/>
+              </module>
+            </module>
+          </checkstyleRules>
+        </configuration>
+        <executions>
+          <execution>
+            <id>checkstyle</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <release>${maven.compiler.release}</release>
@@ -511,6 +591,7 @@
       </activation>
       <properties>
         <spotless.check.skip>true</spotless.check.skip>
+        <checkstyle.skip>true</checkstyle.skip>
         <skipITs>true</skipITs>
         <skipTests>true</skipTests>
         <!-- Skip test codegen. -->

--- a/pom.xml
+++ b/pom.xml
@@ -445,6 +445,7 @@
                 <module name="ModifierOrder"/>
                 <module name="MultipleVariableDeclarations"/>
                 <module name="MutableException"/>
+                <module name="NeedBraces"/>
                 <module name="NoClone"/>
                 <module name="NoFinalizer"/>
                 <module name="NonEmptyAtclauseDescription"/>

--- a/pom.xml
+++ b/pom.xml
@@ -469,6 +469,7 @@
                 <module name="UnnecessarySemicolonAfterTypeMemberDeclaration"/>
                 <module name="UnnecessarySemicolonInEnumeration"/>
                 <module name="UnnecessarySemicolonInTryWithResources"/>
+                <module name="UnusedLocalVariable"/>
                 <module name="UpperEll"/>
               </module>
             </module>

--- a/pom.xml
+++ b/pom.xml
@@ -401,6 +401,9 @@
         <configuration>
           <release>${maven.compiler.release}</release>
           <parameters>true</parameters>
+          <failOnWarning>true</failOnWarning>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
 
     <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
     <checkstyle.version>10.17.0</checkstyle.version>
+    <error-prone.version>2.30.0</error-prone.version>
     <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
@@ -497,6 +498,19 @@
           <failOnWarning>true</failOnWarning>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
+          <compilerArgs>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne \
+              -XepDisableAllChecks \
+              -XepExcludedPaths:.*/target/generated-(|test-)sources/.*</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error-prone.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
 
@@ -618,6 +632,16 @@
       </properties>
       <build>
         <defaultGoal>clean install</defaultGoal>
+        <plugins>
+          <!-- disable Error Prone -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgs combine.self="override"/>
+            </configuration>
+          </plugin>
+        </plugins>
       </build>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
     <module>aot</module>
     <module>bom</module>
     <module>cli</module>
+    <module>fuzz</module>
+    <module>jmh</module>
     <module>log</module>
     <module>runtime</module>
     <module>runtime-tests</module>
@@ -652,16 +654,6 @@
     </profile>
 
     <profile>
-      <id>fuzz</id>
-      <modules>
-        <module>fuzz</module>
-      </modules>
-      <properties>
-        <fuzz.test.numeric>10</fuzz.test.numeric>
-        <fuzz.test.table>10</fuzz.test.table>
-      </properties>
-    </profile>
-    <profile>
       <id>release</id>
       <distributionManagement>
         <snapshotRepository>
@@ -703,12 +695,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>benchmarks</id>
-      <modules>
-        <module>jmh</module>
-      </modules>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,7 @@
                 <module name="JavadocContentLocation"/>
                 <module name="JavadocMissingLeadingAsterisk"/>
                 <module name="JavadocMissingWhitespaceAfterAsterisk"/>
+                <module name="JavadocTagContinuationIndentation"/>
                 <module name="ModifiedControlVariable"/>
                 <module name="ModifierOrder"/>
                 <module name="MultipleVariableDeclarations"/>

--- a/pom.xml
+++ b/pom.xml
@@ -77,41 +77,40 @@
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.parameters>true</maven.compiler.parameters>
 
-    <junit.version>5.11.0</junit.version>
     <approvaltests.version>24.4.0</approvaltests.version>
-    <spotless.version>2.43.0</spotless.version>
-    <javaparser.version>3.26.1</javaparser.version>
-    <jackson.version>2.17.2</jackson.version>
     <asm.version>9.7</asm.version>
-    <jgit.version>6.10.0.202406032230-r</jgit.version>
-    <picocli.version>4.7.6</picocli.version>
-    <commons-lang.version>3.16.0</commons-lang.version>
     <commons-io.version>2.16.1</commons-io.version>
+    <commons-lang.version>3.16.0</commons-lang.version>
+    <jackson.version>2.17.2</jackson.version>
+    <javaparser.version>3.26.1</javaparser.version>
+    <jgit.version>6.10.0.202406032230-r</jgit.version>
     <jmh.version>1.37</jmh.version>
-
-    <maven-plugin-api.version>3.9.9</maven-plugin-api.version>
+    <junit.version>5.11.0</junit.version>
     <maven-plugin-annotations.version>3.14.0</maven-plugin-annotations.version>
+    <maven-plugin-api.version>3.9.9</maven-plugin-api.version>
+    <picocli.version>4.7.6</picocli.version>
 
-    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-    <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
-    <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
-    <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-    <maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>
-    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-    <maven-plugin-plugin.version>3.14.0</maven-plugin-plugin.version>
     <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
-    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-    <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
-    <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-    <maven-dependency-plugin.version>3.8.0</maven-dependency-plugin.version>
-    <maven-site-plugin.version>3.20.0</maven-site-plugin.version>
-    <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
-    <maven-gpg-plugin.version>3.2.5</maven-gpg-plugin.version>
-    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
-    <templating-maven-plugin.version>3.0.0</templating-maven-plugin.version>
-    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
+    <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+    <maven-dependency-plugin.version>3.8.0</maven-dependency-plugin.version>
+    <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
+    <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
+    <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
+    <maven-gpg-plugin.version>3.2.5</maven-gpg-plugin.version>
+    <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+    <maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>
+    <maven-plugin-plugin.version>3.14.0</maven-plugin-plugin.version>
+    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+    <maven-site-plugin.version>3.20.0</maven-site-plugin.version>
+    <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+    <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
+    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+    <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
+    <templating-maven-plugin.version>3.0.0</templating-maven-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -309,7 +308,7 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>${spotless.version}</version>
+          <version>${spotless-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.sonatype.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -397,6 +397,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -406,6 +407,7 @@
           <release>${maven.compiler.target}</release>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -427,6 +429,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -448,6 +451,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
@@ -469,6 +473,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
@@ -482,6 +487,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -436,6 +436,7 @@
                 <module name="EmptyCatchBlock"/>
                 <module name="ExplicitInitialization"/>
                 <module name="FallThrough"/>
+                <module name="FinalClass"/>
                 <module name="HideUtilityClassConstructor"/>
                 <module name="IllegalCatch">
                   <property name="illegalClassNames" value="Exception"/>

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1BinaryLeb128HostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1BinaryLeb128HostFuncs.java
@@ -7,7 +7,10 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1BinaryLeb128HostFuncs {
+public final class SpecV1BinaryLeb128HostFuncs {
+
+    private SpecV1BinaryLeb128HostFuncs() {}
+
     public static HostImports fallback() {
         return HostImports.builder()
                 .addFunction(

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1DataHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1DataHostFuncs.java
@@ -11,7 +11,10 @@ import com.dylibso.chicory.wasm.types.MemoryLimits;
 import com.dylibso.chicory.wasm.types.MutabilityType;
 import com.dylibso.chicory.wasm.types.Value;
 
-public class SpecV1DataHostFuncs {
+public final class SpecV1DataHostFuncs {
+
+    private SpecV1DataHostFuncs() {}
+
     public static HostImports fallback() {
 
         return new HostImports(

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ElemHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ElemHostFuncs.java
@@ -15,9 +15,11 @@ import com.dylibso.chicory.wasm.types.Table;
 import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 
-public class SpecV1ElemHostFuncs {
+public final class SpecV1ElemHostFuncs {
 
     private static GlobalInstance glob = new GlobalInstance(Value.i32(123));
+
+    private SpecV1ElemHostFuncs() {}
 
     public static HostImports fallback() {
         return HostImports.builder()

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ExportsHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ExportsHostFuncs.java
@@ -16,7 +16,10 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1ExportsHostFuncs {
+public final class SpecV1ExportsHostFuncs {
+
+    private SpecV1ExportsHostFuncs() {}
+
     public static HostImports fallback() {
         return HostImports.builder()
                 .addFunction(

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1FuncPtrsHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1FuncPtrsHostFuncs.java
@@ -7,7 +7,9 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1FuncPtrsHostFuncs {
+public final class SpecV1FuncPtrsHostFuncs {
+
+    private SpecV1FuncPtrsHostFuncs() {}
 
     public static HostImports fallback() {
         return new HostImports(

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
@@ -6,7 +6,9 @@ import com.dylibso.chicory.runtime.HostImports;
 import com.dylibso.chicory.wasm.types.MutabilityType;
 import com.dylibso.chicory.wasm.types.Value;
 
-public class SpecV1GlobalHostFuncs {
+public final class SpecV1GlobalHostFuncs {
+
+    private SpecV1GlobalHostFuncs() {}
 
     public static HostImports fallback() {
         return new HostImports(

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
@@ -17,7 +17,9 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1ImportsHostFuncs {
+public final class SpecV1ImportsHostFuncs {
+
+    private SpecV1ImportsHostFuncs() {}
 
     public static HostImports testModule11() {
         return HostImports.builder()

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1LinkingHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1LinkingHostFuncs.java
@@ -23,7 +23,7 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1LinkingHostFuncs {
+public final class SpecV1LinkingHostFuncs {
 
     private static HostFunction MfCall =
             new HostFunction(
@@ -32,6 +32,8 @@ public class SpecV1LinkingHostFuncs {
                     "call",
                     List.of(),
                     List.of(ValueType.I32));
+
+    private SpecV1LinkingHostFuncs() {}
 
     public static HostImports Mf() {
         return new HostImports(new HostFunction[] {MfCall});

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1NamesHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1NamesHostFuncs.java
@@ -7,7 +7,10 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1NamesHostFuncs {
+public final class SpecV1NamesHostFuncs {
+
+    private SpecV1NamesHostFuncs() {}
+
     public static HostImports fallback() {
         return new HostImports(
                 new HostFunction[] {

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1RefFuncHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1RefFuncHostFuncs.java
@@ -7,7 +7,9 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1RefFuncHostFuncs {
+public final class SpecV1RefFuncHostFuncs {
+
+    private SpecV1RefFuncHostFuncs() {}
 
     public static HostImports fallback() {
         return HostImports.builder()

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1StartHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1StartHostFuncs.java
@@ -7,7 +7,10 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1StartHostFuncs {
+public final class SpecV1StartHostFuncs {
+
+    private SpecV1StartHostFuncs() {}
+
     public static HostImports fallback() {
         return new HostImports(
                 new HostFunction[] {

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1TableCopyHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1TableCopyHostFuncs.java
@@ -7,7 +7,9 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1TableCopyHostFuncs {
+public final class SpecV1TableCopyHostFuncs {
+
+    private SpecV1TableCopyHostFuncs() {}
 
     public static HostImports fallback() {
         return new HostImports(

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1TableHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1TableHostFuncs.java
@@ -7,7 +7,10 @@ import com.dylibso.chicory.wasm.types.Limits;
 import com.dylibso.chicory.wasm.types.Table;
 import com.dylibso.chicory.wasm.types.ValueType;
 
-public class SpecV1TableHostFuncs {
+public final class SpecV1TableHostFuncs {
+
+    private SpecV1TableHostFuncs() {}
+
     public static HostImports fallback() {
         return HostImports.builder()
                 .addTable(

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1TableInitHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1TableInitHostFuncs.java
@@ -7,7 +7,9 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class SpecV1TableInitHostFuncs {
+public final class SpecV1TableInitHostFuncs {
+
+    private SpecV1TableInitHostFuncs() {}
 
     public static HostImports fallback() {
         return new HostImports(

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1TokensHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1TokensHostFuncs.java
@@ -6,7 +6,10 @@ import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasm.types.Value;
 import java.util.List;
 
-public class SpecV1TokensHostFuncs {
+public final class SpecV1TokensHostFuncs {
+
+    private SpecV1TokensHostFuncs() {}
+
     public static HostImports fallback() {
         return HostImports.builder()
                 .addFunction(

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -15,10 +15,6 @@ public class TestModule {
 
     private HostImports imports;
 
-    public static TestModule of(Module module) {
-        return new TestModule(module);
-    }
-
     private static final String HACK_MATCH_ALL_MALFORMED_EXCEPTION_TEXT =
             "Matching keywords to get the WebAssembly testsuite to pass: "
                     + "malformed UTF-8 encoding "
@@ -56,6 +52,10 @@ public class TestModule {
             return of(Parser.parse(parsed));
         }
         return of(Parser.parse(file));
+    }
+
+    public static TestModule of(Module module) {
+        return new TestModule(module);
     }
 
     public TestModule(Module module) {

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -49,7 +49,7 @@ public class TestModule {
             byte[] parsed;
             try {
                 parsed = Wat2Wasm.parse(file);
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 throw new MalformedException(
                         e.getMessage() + HACK_MATCH_ALL_MALFORMED_EXCEPTION_TEXT);
             }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/BitOps.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/BitOps.java
@@ -1,7 +1,9 @@
 package com.dylibso.chicory.runtime;
 
-public class BitOps {
+public final class BitOps {
 
     public static final int TRUE = 1;
     public static final int FALSE = 0;
+
+    private BitOps() {}
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ConstantEvaluators.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ConstantEvaluators.java
@@ -10,7 +10,9 @@ import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.Arrays;
 import java.util.List;
 
-public class ConstantEvaluators {
+public final class ConstantEvaluators {
+    private ConstantEvaluators() {}
+
     public static Value computeConstantValue(Instance instance, Instruction[] expr) {
         return computeConstantValue(instance, Arrays.asList(expr));
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
@@ -27,10 +27,12 @@ public class HostFunction implements FromHost {
         return handle;
     }
 
+    @Override
     public String moduleName() {
         return moduleName;
     }
 
+    @Override
     public String fieldName() {
         return fieldName;
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostGlobal.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostGlobal.java
@@ -28,10 +28,12 @@ public class HostGlobal implements FromHost {
         return type;
     }
 
+    @Override
     public String moduleName() {
         return moduleName;
     }
 
+    @Override
     public String fieldName() {
         return fieldName;
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostMemory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostMemory.java
@@ -11,10 +11,12 @@ public class HostMemory implements FromHost {
         this.memory = memory;
     }
 
+    @Override
     public String moduleName() {
         return moduleName;
     }
 
+    @Override
     public String fieldName() {
         return fieldName;
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostTable.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostTable.java
@@ -32,10 +32,12 @@ public class HostTable implements FromHost {
         this.table.reset();
     }
 
+    @Override
     public String moduleName() {
         return moduleName;
     }
 
+    @Override
     public String fieldName() {
         return fieldName;
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -359,9 +359,9 @@ public class Instance {
 
         private boolean initialize = true;
         private boolean start = true;
-        private ExecutionListener listener = null;
-        private HostImports hostImports = null;
-        private Function<Instance, Machine> machineFactory = null;
+        private ExecutionListener listener;
+        private HostImports hostImports;
+        private Function<Instance, Machine> machineFactory;
 
         private Builder(Module module) {
             this.module = Objects.requireNonNull(module);

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -220,7 +220,9 @@ public class Instance {
 
     public ExportFunction export(String name) {
         var export = this.exports.get(name);
-        if (export == null) throw new ChicoryException("Unknown export with name " + name);
+        if (export == null) {
+            throw new ChicoryException("Unknown export with name " + name);
+        }
 
         switch (export.exportType()) {
             case FUNCTION:

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -88,8 +88,12 @@ class InterpreterMachine implements Machine {
             return null;
         }
 
-        if (type.returns().isEmpty()) return null;
-        if (stack.size() == 0) return null;
+        if (type.returns().isEmpty()) {
+            return null;
+        }
+        if (stack.size() == 0) {
+            return null;
+        }
 
         var totalResults = type.returns().size();
         var results = new Value[totalResults];
@@ -106,7 +110,9 @@ class InterpreterMachine implements Machine {
 
         loop:
         while (!frame.terminated()) {
-            if (shouldReturn) return;
+            if (shouldReturn) {
+                return;
+            }
             var instruction = frame.loadCurrentInstruction();
             //                LOGGER.log(
             //                        System.Logger.Level.DEBUG,
@@ -1484,9 +1490,10 @@ class InterpreterMachine implements Machine {
     private static void MEMORY_COPY(MStack stack, Instance instance, long[] operands) {
         var memidxSrc = (int) operands[0];
         var memidxDst = (int) operands[1];
-        if (memidxDst != 0 && memidxSrc != 0)
+        if (memidxDst != 0 && memidxSrc != 0) {
             throw new WASMRuntimeException(
                     "We don't support non zero index for memory: " + memidxSrc + " " + memidxDst);
+        }
         var size = stack.pop().asInt();
         var offset = stack.pop().asInt();
         var destination = stack.pop().asInt();
@@ -1507,8 +1514,9 @@ class InterpreterMachine implements Machine {
     private static void MEMORY_INIT(MStack stack, Instance instance, long[] operands) {
         var segmentId = (int) operands[0];
         var memidx = (int) operands[1];
-        if (memidx != 0)
+        if (memidx != 0) {
             throw new WASMRuntimeException("We don't support non zero index for memory: " + memidx);
+        }
         var size = stack.pop().asInt();
         var offset = stack.pop().asInt();
         var destination = stack.pop().asInt();

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -10,6 +10,7 @@ import com.dylibso.chicory.wasm.types.OpCode;
 import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 
 /**
@@ -19,7 +20,7 @@ class InterpreterMachine implements Machine {
 
     private final MStack stack;
 
-    private final ArrayDeque<StackFrame> callStack;
+    private final Deque<StackFrame> callStack;
 
     private final Instance instance;
 
@@ -37,7 +38,7 @@ class InterpreterMachine implements Machine {
     public static Value[] call(
             MStack stack,
             Instance instance,
-            ArrayDeque<StackFrame> callStack,
+            Deque<StackFrame> callStack,
             int funcId,
             Value[] args,
             FunctionType callType,
@@ -98,7 +99,7 @@ class InterpreterMachine implements Machine {
         return results;
     }
 
-    static void eval(MStack stack, Instance instance, ArrayDeque<StackFrame> callStack)
+    static void eval(MStack stack, Instance instance, Deque<StackFrame> callStack)
             throws ChicoryException {
         var frame = callStack.peek();
         boolean shouldReturn = false;
@@ -1606,7 +1607,7 @@ class InterpreterMachine implements Machine {
     }
 
     private static void CALL(
-            MStack stack, Instance instance, ArrayDeque<StackFrame> callStack, long[] operands) {
+            MStack stack, Instance instance, Deque<StackFrame> callStack, long[] operands) {
         var funcId = (int) operands[0];
         var typeId = instance.functionType(funcId);
         var type = instance.type(typeId);
@@ -1822,7 +1823,7 @@ class InterpreterMachine implements Machine {
     }
 
     private static void CALL_INDIRECT(
-            MStack stack, Instance instance, ArrayDeque<StackFrame> callStack, long[] operands) {
+            MStack stack, Instance instance, Deque<StackFrame> callStack, long[] operands) {
         var tableIdx = (int) operands[1];
         var table = instance.table(tableIdx);
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -182,7 +182,7 @@ class InterpreterMachine implements Machine {
                     SELECT(stack);
                     break;
                 case SELECT_T:
-                    SELECT_T(stack, operands);
+                    SELECT_T(stack);
                     break;
                 case LOCAL_GET:
                     stack.push(frame.local((int) operands[0]));
@@ -1819,7 +1819,7 @@ class InterpreterMachine implements Machine {
         }
     }
 
-    private static void SELECT_T(MStack stack, long[] operands) {
+    private static void SELECT_T(MStack stack) {
         var pred = stack.pop().asInt();
         var b = stack.pop();
         var a = stack.pop();

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
@@ -43,6 +43,7 @@ public class MStack {
         return this.stack.size();
     }
 
+    @Override
     public String toString() {
         return this.stack.toString();
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
@@ -2,6 +2,7 @@ package com.dylibso.chicory.runtime;
 
 import com.dylibso.chicory.wasm.types.Value;
 import java.util.ArrayDeque;
+import java.util.Deque;
 
 /**
  * A temporary class that gives us a little more control over the interface.
@@ -9,7 +10,7 @@ import java.util.ArrayDeque;
  * We should replace with something more idiomatic and performant.
  */
 public class MStack {
-    private final ArrayDeque<Value> stack;
+    private final Deque<Value> stack;
 
     public MStack() {
         this.stack = new ArrayDeque<>();

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
@@ -17,19 +17,25 @@ public class MStack {
     }
 
     public void push(Value v) {
-        if (v == null) throw new RuntimeException("Can't push null value onto stack");
+        if (v == null) {
+            throw new RuntimeException("Can't push null value onto stack");
+        }
         this.stack.push(v);
     }
 
     public Value pop() {
         var r = this.stack.pollFirst();
-        if (r == null) throw new RuntimeException("Stack underflow exception");
+        if (r == null) {
+            throw new RuntimeException("Stack underflow exception");
+        }
         return r;
     }
 
     public Value peek() {
         var r = this.stack.peek();
-        if (r == null) throw new RuntimeException("Stack underflow exception");
+        if (r == null) {
+            throw new RuntimeException("Stack underflow exception");
+        }
         return r;
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
@@ -182,6 +182,10 @@ public final class Memory {
         return readCString(addr, StandardCharsets.UTF_8);
     }
 
+    public void write(int addr, Value data) {
+        write(addr, data.data());
+    }
+
     public void write(int addr, byte[] data) {
         write(addr, data, 0, data.length);
     }
@@ -214,10 +218,6 @@ public final class Memory {
                 | NegativeArraySizeException e) {
             throw new WASMRuntimeException("out of bounds memory access");
         }
-    }
-
-    public void write(int addr, Value data) {
-        write(addr, data.data());
     }
 
     public void writeI32(int addr, int data) {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
@@ -372,6 +372,7 @@ public final class Memory {
         fill(value, 0, buffer.capacity());
     }
 
+    @SuppressWarnings("ByteBufferBackingArray")
     public void fill(byte value, int fromIndex, int toIndex) {
         try {
             // see https://appsintheopen.com/posts/53-resetting-bytebuffers-to-zero-in-java

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
@@ -13,6 +13,8 @@ import com.dylibso.chicory.wasm.types.MemoryLimits;
 import com.dylibso.chicory.wasm.types.PassiveDataSegment;
 import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
@@ -188,7 +190,7 @@ public final class Memory {
         try {
             buffer.position(addr);
             buffer.put(data, offset, size);
-        } catch (Exception e) {
+        } catch (IllegalArgumentException | IndexOutOfBoundsException | BufferOverflowException e) {
             throw new UninstantiableException("out of bounds memory access");
         }
     }
@@ -207,7 +209,9 @@ public final class Memory {
             buffer.position(addr);
             buffer.get(bytes);
             return bytes;
-        } catch (Exception e) {
+        } catch (IllegalArgumentException
+                | BufferUnderflowException
+                | NegativeArraySizeException e) {
             throw new WASMRuntimeException("out of bounds memory access");
         }
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
@@ -24,7 +24,9 @@ import com.dylibso.chicory.wasm.types.ValueType;
  * are ordered such that the last value pushed is the last argument to the method, i.e.,
  * method(tos - 2, tos - 1, tos).
  */
-public class OpcodeImpl {
+public final class OpcodeImpl {
+
+    private OpcodeImpl() {}
 
     // ========= I32 =========
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/StackFrame.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/StackFrame.java
@@ -69,7 +69,9 @@ public class StackFrame {
         var id = "[" + funcId + "]";
         if (nameSec != null) {
             var funcName = nameSec.nameOfFunction(funcId);
-            if (funcName != null) id = funcName + id;
+            if (funcName != null) {
+                id = funcName + id;
+            }
         }
         return id + "\n\tpc=" + pc + " locals=" + Arrays.toString(locals);
     }
@@ -132,7 +134,9 @@ public class StackFrame {
         var endResults = ctrlFrame.startValues + ctrlFrame.endValues; // unwind stack
         Value[] returns = new Value[endResults];
         for (int i = 0; i < returns.length; i++) {
-            if (stack.size() > 0) returns[i] = stack.pop();
+            if (stack.size() > 0) {
+                returns[i] = stack.pop();
+            }
         }
 
         while (stack.size() > ctrlFrame.height) {

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
@@ -1,5 +1,6 @@
 package com.dylibso.chicory.runtime;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -173,7 +174,7 @@ public class ModuleTest {
         var countVowels = instance.export("count_vowels");
         var memory = instance.memory();
         var message = "Hello, World!";
-        var len = message.getBytes().length;
+        var len = message.getBytes(UTF_8).length;
         var ptr = alloc.apply(Value.i32(len))[0].asInt();
         memory.writeString(ptr, message);
         var result = countVowels.apply(Value.i32(ptr), Value.i32(len));

--- a/scripts/build-jmh-main.sh
+++ b/scripts/build-jmh-main.sh
@@ -7,5 +7,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
   cd "${SCRIPT_DIR}/.."
   rm -rf main
   git clone --depth 1 --branch main https://github.com/dylibso/chicory.git main
-  mvn -Dquickly -Pbenchmarks
+  mvn -Dquickly
 )

--- a/scripts/build-jmh.sh
+++ b/scripts/build-jmh.sh
@@ -5,5 +5,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 (
   cd "${SCRIPT_DIR}/.."
-  mvn -Dquickly -Pbenchmarks
+  mvn -Dquickly
 )

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaParserMavenUtils.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaParserMavenUtils.java
@@ -6,7 +6,9 @@ import org.apache.maven.plugin.logging.Log;
 /**
  * Things to make JavaParser and Maven interact better
  */
-public class JavaParserMavenUtils {
+public final class JavaParserMavenUtils {
+
+    private JavaParserMavenUtils() {}
 
     public static void makeJavaParserLogToMavenOutput(Log log) {
         com.github.javaparser.utils.Log.setAdapter(

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
@@ -34,13 +34,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.apache.maven.plugin.logging.Log;
 
 public class JavaTestGen {
 
     private static final String TEST_MODULE_NAME = "testModule";
-
-    private final Log log;
 
     private final File baseDir;
 
@@ -57,7 +54,6 @@ public class JavaTestGen {
     private final List<String> excludedUnlinkableWasts;
 
     public JavaTestGen(
-            Log log,
             File baseDir,
             File sourceTargetFolder,
             List<String> excludedTests,
@@ -65,7 +61,6 @@ public class JavaTestGen {
             List<String> excludedInvalidWasts,
             List<String> excludedUninstantiableWasts,
             List<String> excludedUnlinkableWasts) {
-        this.log = log;
         this.baseDir = baseDir;
         this.sourceTargetFolder = sourceTargetFolder;
         this.excludedTests = excludedTests;
@@ -171,7 +166,6 @@ public class JavaTestGen {
                                                 new AssignExpr(
                                                         new NameExpr(lastInstanceVarName),
                                                         generateModuleInstantiation(
-                                                                cmd,
                                                                 currentWasmFile,
                                                                 importsName,
                                                                 hostFuncs,
@@ -399,11 +393,7 @@ public class JavaTestGen {
     private static final String INDENT = TAB + TAB + TAB + TAB + TAB;
 
     private static NameExpr generateModuleInstantiation(
-            Command cmd,
-            String wasmFile,
-            String importsName,
-            String hostFuncs,
-            boolean excludeInvalid) {
+            String wasmFile, String importsName, String hostFuncs, boolean excludeInvalid) {
         return new NameExpr(
                 "TestModule.of(\n"
                         + INDENT
@@ -478,7 +468,7 @@ public class JavaTestGen {
                                 + exceptionType
                                 + ".class, () -> "
                                 + generateModuleInstantiation(
-                                        cmd, wasmFile, importsName, hostFuncs, false)
+                                        wasmFile, importsName, hostFuncs, false)
                                 + ")");
 
         method.getBody().get().addStatement(assertThrows);

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.utils.SourceRoot;
 import com.github.javaparser.utils.StringEscapeUtils;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -442,7 +443,7 @@ public class JavaTestGen {
                     hostFuncs = "fallback";
                 }
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
             // ignore
         }
         return hostFuncs;

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/StringUtils.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/StringUtils.java
@@ -8,7 +8,7 @@ public final class StringUtils {
         if (in.isEmpty()) {
             return in;
         }
-        return in.substring(0, 1).toUpperCase() + in.substring(1);
+        return Character.toUpperCase(in.charAt(0)) + in.substring(1);
     }
 
     public static String escapedCamelCase(String in) {

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/StringUtils.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/StringUtils.java
@@ -1,6 +1,8 @@
 package com.dylibso.chicory.maven;
 
-public class StringUtils {
+public final class StringUtils {
+
+    private StringUtils() {}
 
     public static String capitalize(String in) {
         if (in.isEmpty()) {

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
@@ -1,6 +1,7 @@
 package com.dylibso.chicory.maven;
 
 import static com.dylibso.chicory.maven.Constants.SPEC_JSON;
+import static org.apache.maven.plugins.annotations.LifecyclePhase.GENERATE_TEST_SOURCES;
 
 import com.dylibso.chicory.maven.wast.Wast;
 import com.dylibso.chicory.wabt.Wast2Json;
@@ -21,7 +22,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugin.logging.SystemStreamLog;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -29,7 +29,7 @@ import org.apache.maven.project.MavenProject;
 /**
  * This plugin should generate the testsuite out of wast files
  */
-@Mojo(name = "wasm-test-gen", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES)
+@Mojo(name = "wasm-test-gen", defaultPhase = GENERATE_TEST_SOURCES, threadSafe = true)
 public class TestGenMojo extends AbstractMojo {
 
     private final Log log = new SystemStreamLog();

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
@@ -199,8 +199,8 @@ public class TestGenMojo extends AbstractMojo {
             includedWasts.parallelStream().forEach(testGenerator::generateTests);
 
             dest.saveAll();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new MojoExecutionException(e);
         }
 
         // Add the generated tests to the source root

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
@@ -223,7 +223,7 @@ public class TestGenMojo extends AbstractMojo {
         }
     }
 
-    private class TestGenerator {
+    private final class TestGenerator {
 
         private final JavaTestGen testGen;
         private final SourceRoot importSourceRoot;

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
@@ -136,7 +136,6 @@ public class TestGenMojo extends AbstractMojo {
         var testSuiteDownloader = new TestSuiteDownloader(log);
         var testGen =
                 new JavaTestGen(
-                        log,
                         project.getBasedir(),
                         sourceDestinationFolder,
                         excludedTests,

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/ActionType.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/ActionType.java
@@ -15,7 +15,7 @@ public enum ActionType {
         this.value = value;
     }
 
-    @JsonValue()
+    @JsonValue
     public String value() {
         return value;
     }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/Command.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/Command.java
@@ -90,4 +90,8 @@ public class Command {
     public String moduleType() {
         return moduleType;
     }
+
+    public String as() {
+        return as;
+    }
 }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/CommandType.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/CommandType.java
@@ -31,7 +31,7 @@ public enum CommandType {
         this.value = value;
     }
 
-    @JsonValue()
+    @JsonValue
     public String value() {
         return value;
     }

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/WasmValueType.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/WasmValueType.java
@@ -23,7 +23,7 @@ public enum WasmValueType {
         this.value = value;
     }
 
-    @JsonValue()
+    @JsonValue
     public String value() {
         return value;
     }

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
@@ -24,7 +24,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Wast2Json {
+public final class Wast2Json {
     private static final Logger logger =
             new SystemLogger() {
                 @Override
@@ -129,7 +129,7 @@ public class Wast2Json {
     // minimal size
     //  --debug-names                            Write debug names to the generated binary file
     //  --no-check                               Don't check for invalid modules
-    public static class Builder {
+    public static final class Builder {
         private File input;
         private File output;
 

--- a/wabt/src/test/java/com/dylibso/chicory/wabt/Wat2WasmTest.java
+++ b/wabt/src/test/java/com/dylibso/chicory/wabt/Wat2WasmTest.java
@@ -1,5 +1,6 @@
 package com.dylibso.chicory.wabt;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,7 +19,7 @@ public class Wat2WasmTest {
         var result = Wat2Wasm.parse(new File("../wasm-corpus/src/main/resources/wat/iterfact.wat"));
 
         assertTrue(result.length > 0);
-        assertTrue(new String(result).contains("iterFact"));
+        assertTrue(new String(result, UTF_8).contains("iterFact"));
     }
 
     @Test

--- a/wasi-test-gen-plugin/src/main/java/com/dylibso/chicory/maven/StringUtils.java
+++ b/wasi-test-gen-plugin/src/main/java/com/dylibso/chicory/maven/StringUtils.java
@@ -8,7 +8,7 @@ public final class StringUtils {
         if (in.isEmpty()) {
             return in;
         }
-        return in.substring(0, 1).toUpperCase() + in.substring(1);
+        return Character.toUpperCase(in.charAt(0)) + in.substring(1);
     }
 
     public static String escapedCamelCase(String in) {

--- a/wasi-test-gen-plugin/src/main/java/com/dylibso/chicory/maven/StringUtils.java
+++ b/wasi-test-gen-plugin/src/main/java/com/dylibso/chicory/maven/StringUtils.java
@@ -1,6 +1,8 @@
 package com.dylibso.chicory.maven;
 
-public class StringUtils {
+public final class StringUtils {
+
+    private StringUtils() {}
 
     public static String capitalize(String in) {
         if (in.isEmpty()) {

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiErrno.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiErrno.java
@@ -77,5 +77,10 @@ enum WasiErrno {
     ETIMEDOUT,
     ETXTBSY,
     EXDEV,
-    ENOTCAPABLE,
+    ENOTCAPABLE;
+
+    @SuppressWarnings("EnumOrdinal")
+    public int value() {
+        return ordinal();
+    }
 }

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiFileType.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiFileType.java
@@ -8,5 +8,10 @@ enum WasiFileType {
     REGULAR_FILE,
     SOCKET_DGRAM,
     SOCKET_STREAM,
-    SYMBOLIC_LINK,
+    SYMBOLIC_LINK;
+
+    @SuppressWarnings("EnumOrdinal")
+    public int value() {
+        return ordinal();
+    }
 }

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiOptions.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiOptions.java
@@ -10,7 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public class WasiOptions {
+public final class WasiOptions {
     private final OutputStream stdout;
     private final OutputStream stderr;
     private final InputStream stdin;
@@ -22,7 +22,7 @@ public class WasiOptions {
         return new Builder();
     }
 
-    public WasiOptions(
+    private WasiOptions(
             OutputStream stdout,
             OutputStream stderr,
             InputStream stdin,
@@ -61,7 +61,7 @@ public class WasiOptions {
         return directories;
     }
 
-    public static class Builder {
+    public static final class Builder {
         private OutputStream stdout = OutputStream.nullOutputStream();
         private OutputStream stderr = OutputStream.nullOutputStream();
         private InputStream stdin = InputStream.nullInputStream();

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
@@ -419,7 +419,7 @@ public final class WasiPreview1 implements Closeable {
 
                     Memory memory = instance.memory();
                     memory.write(buf, new byte[8]);
-                    memory.writeByte(buf, (byte) fileType.ordinal());
+                    memory.writeByte(buf, (byte) fileType.value());
                     memory.writeShort(buf + 2, (short) flags);
                     memory.writeLong(buf + 8, rightsBase);
                     memory.writeLong(buf + 16, rightsInheriting);
@@ -758,7 +758,7 @@ public final class WasiPreview1 implements Closeable {
                             entry.putLong(0, cookie);
                             entry.putLong(8, ((Number) attributes.get("ino")).longValue());
                             entry.putInt(16, name.length);
-                            entry.put(20, (byte) getFileType(attributes).ordinal());
+                            entry.put(20, (byte) getFileType(attributes).value());
                             entry.position(24);
                             entry.put(name);
 
@@ -1610,7 +1610,7 @@ public final class WasiPreview1 implements Closeable {
         if (errno != WasiErrno.ESUCCESS) {
             logger.info("result = " + errno.name());
         }
-        return new Value[] {Value.i32(errno.ordinal())};
+        return new Value[] {Value.i32(errno.value())};
     }
 
     private static Path resolvePath(Path directory, String rawPathString) {
@@ -1638,7 +1638,7 @@ public final class WasiPreview1 implements Closeable {
         memory.writeLong(buf, (long) attributes.get("dev"));
         memory.writeLong(buf + 8, ((Number) attributes.get("ino")).longValue());
         memory.write(buf + 16, new byte[8]);
-        memory.writeByte(buf + 16, (byte) fileType.ordinal());
+        memory.writeByte(buf + 16, (byte) fileType.value());
         memory.writeLong(buf + 24, ((Number) attributes.get("nlink")).longValue());
         memory.writeLong(buf + 32, (long) attributes.get("size"));
         memory.writeLong(buf + 40, fileTimeToNanos(attributes, "lastAccessTime"));

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
@@ -55,7 +55,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Stream;
 
-public class WasiPreview1 implements Closeable {
+public final class WasiPreview1 implements Closeable {
     private final Logger logger;
     private final List<byte[]> arguments;
     private final List<Entry<byte[], byte[]>> environment;
@@ -95,7 +95,7 @@ public class WasiPreview1 implements Closeable {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private Logger logger;
         private WasiOptions opts;
 

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
@@ -232,7 +232,7 @@ public class WasiPreview1 implements Closeable {
                 (Instance instance, Value... args) -> {
                     logger.info("clock_time_get: " + Arrays.toString(args));
                     int clockId = args[0].asInt();
-                    long precision = args[1].asLong();
+                    // long precision = args[1].asLong();
                     int resultPtr = args[2].asInt();
 
                     Memory memory = instance.memory();
@@ -1088,8 +1088,8 @@ public class WasiPreview1 implements Closeable {
                     int pathPtr = args[2].asInt();
                     int pathLen = args[3].asInt();
                     int openFlags = args[4].asInt();
-                    long rightsBase = args[5].asLong();
-                    long rightsInheriting = args[6].asLong();
+                    // long rightsBase = args[5].asLong();
+                    // long rightsInheriting = args[6].asLong();
                     int fdFlags = args[7].asInt();
                     int fdPtr = args[8].asInt();
 
@@ -1182,15 +1182,15 @@ public class WasiPreview1 implements Closeable {
         return new HostFunction(
                 (Instance instance, Value... args) -> {
                     logger.info("path_readlink: " + Arrays.toString(args));
-                    int dirFd = args[0].asInt();
-                    int pathPtr = args[1].asInt();
-                    int pathLen = args[2].asInt();
-                    int buf = args[3].asInt();
-                    int bufLen = args[4].asInt();
-                    int bufUsed = args[5].asInt();
+                    // int dirFd = args[0].asInt();
+                    // int pathPtr = args[1].asInt();
+                    // int pathLen = args[2].asInt();
+                    // int buf = args[3].asInt();
+                    // int bufLen = args[4].asInt();
+                    // int bufUsed = args[5].asInt();
 
-                    Memory memory = instance.memory();
-                    String rawPath = memory.readString(pathPtr, pathLen);
+                    // Memory memory = instance.memory();
+                    // String rawPath = memory.readString(pathPtr, pathLen);
 
                     return wasiResult(WasiErrno.EINVAL);
                 },

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/MockPrintStream.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/MockPrintStream.java
@@ -1,5 +1,7 @@
 package com.dylibso.chicory.wasi;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
@@ -17,6 +19,6 @@ class MockPrintStream extends PrintStream {
     }
 
     public String output() {
-        return baos.toString();
+        return baos.toString(UTF_8);
     }
 }

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
@@ -1,5 +1,6 @@
 package com.dylibso.chicory.wasi;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -50,7 +51,7 @@ public class WasiPreview1Test {
     @Test
     public void shouldRunWasiGreetRustModule() {
         // check with: wasmtime src/test/resources/compiled/greet-wasi.rs.wasm
-        var fakeStdin = new ByteArrayInputStream("Benjamin".getBytes());
+        var fakeStdin = new ByteArrayInputStream("Benjamin".getBytes(UTF_8));
         var wasiOpts = WasiOptions.builder().withStdout(System.out).withStdin(fakeStdin).build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
         var imports = new HostImports(wasi.toHostFunctions());
@@ -63,7 +64,7 @@ public class WasiPreview1Test {
     public void shouldRunWasiDemoJavyModule() {
         // check with: echo "{ \"n\": 2, \"bar\": \"baz\"}" | wasmtime
         // wasi/src/test/resources/compiled/javy-demo.js.wasm
-        var fakeStdin = new ByteArrayInputStream("{ \"n\": 2, \"bar\": \"baz\" }".getBytes());
+        var fakeStdin = new ByteArrayInputStream("{ \"n\": 2, \"bar\": \"baz\" }".getBytes(UTF_8));
         var fakeStdout = new MockPrintStream();
         var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).withStdin(fakeStdin).build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);

--- a/wasm-support-plugin/src/main/java/com/dylibso/chicory/maven/OpCodeGenMojo.java
+++ b/wasm-support-plugin/src/main/java/com/dylibso/chicory/maven/OpCodeGenMojo.java
@@ -1,5 +1,7 @@
 package com.dylibso.chicory.maven;
 
+import static org.apache.maven.plugins.annotations.LifecyclePhase.GENERATE_SOURCES;
+
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
@@ -24,7 +26,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugin.logging.SystemStreamLog;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -32,7 +33,7 @@ import org.apache.maven.project.MavenProject;
 /**
  * This plugin should generate the OpCodes.java file from a tsv
  */
-@Mojo(name = "opcode-gen", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+@Mojo(name = "opcode-gen", defaultPhase = GENERATE_SOURCES, threadSafe = true)
 public class OpCodeGenMojo extends AbstractMojo {
 
     private final Log log = new SystemStreamLog();

--- a/wasm-support-plugin/src/main/java/com/dylibso/chicory/maven/OpCodeGenMojo.java
+++ b/wasm-support-plugin/src/main/java/com/dylibso/chicory/maven/OpCodeGenMojo.java
@@ -1,3 +1,5 @@
+package com.dylibso.chicory.maven;
+
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;

--- a/wasm-support-plugin/src/main/java/com/dylibso/chicory/maven/OpCodeGenMojo.java
+++ b/wasm-support-plugin/src/main/java/com/dylibso/chicory/maven/OpCodeGenMojo.java
@@ -22,10 +22,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -35,8 +34,6 @@ import org.apache.maven.project.MavenProject;
  */
 @Mojo(name = "opcode-gen", defaultPhase = GENERATE_SOURCES, threadSafe = true)
 public class OpCodeGenMojo extends AbstractMojo {
-
-    private final Log log = new SystemStreamLog();
 
     /**
      * The source file
@@ -58,15 +55,13 @@ public class OpCodeGenMojo extends AbstractMojo {
     @Parameter(property = "project", required = true, readonly = true)
     private MavenProject project;
 
+    @SuppressWarnings("StringSplitter")
     @Override
     public void execute() throws MojoExecutionException {
         sourceDestinationFolder.mkdirs();
-        List<String[]> lines = null;
-        try {
-            lines =
-                    Files.lines(instructionsFile.toPath())
-                            .map(line -> line.split("\t"))
-                            .collect(Collectors.toList());
+        List<String[]> lines;
+        try (Stream<String> stream = Files.lines(instructionsFile.toPath())) {
+            lines = stream.map(line -> line.split("\t")).collect(Collectors.toList());
         } catch (IOException e) {
             throw new MojoExecutionException(e);
         }

--- a/wasm-support-plugin/src/main/java/com/dylibso/chicory/maven/OpCodeGenMojo.java
+++ b/wasm-support-plugin/src/main/java/com/dylibso/chicory/maven/OpCodeGenMojo.java
@@ -95,7 +95,7 @@ public class OpCodeGenMojo extends AbstractMojo {
             var originalName = line[0].split(" ")[0];
             var enumName = originalName.toUpperCase(Locale.ROOT).replace('.', '_');
             var value = line[1].trim().split(" ")[0];
-            var hexValue = line[1].trim().split(" ")[0].replace("$", "0x");
+            var hexValue = value.replace("$", "0x");
 
             enumConstantDecl.setName(enumName);
             enumConstantDecl.setArguments(new NodeList<>(new IntegerLiteralExpr(hexValue)));
@@ -131,14 +131,13 @@ public class OpCodeGenMojo extends AbstractMojo {
                                         AssignExpr.Operator.ASSIGN)));
         opcodeField.createGetter().setName("opcode");
 
-        var byOpCodeMap =
-                enumDef.addFieldWithInitializer(
-                        "Map<Integer, OpCode>",
-                        "byOpCode",
-                        new NameExpr("new HashMap<>()"),
-                        Modifier.Keyword.PRIVATE,
-                        Modifier.Keyword.STATIC,
-                        Modifier.Keyword.FINAL);
+        enumDef.addFieldWithInitializer(
+                "Map<Integer, OpCode>",
+                "byOpCode",
+                new NameExpr("new HashMap<>()"),
+                Modifier.Keyword.PRIVATE,
+                Modifier.Keyword.STATIC,
+                Modifier.Keyword.FINAL);
 
         var byOpCode =
                 enumDef.addMethod("byOpCode", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
@@ -147,14 +146,13 @@ public class OpCodeGenMojo extends AbstractMojo {
         byOpCode.setBody(
                 new BlockStmt().addStatement(new ReturnStmt(new NameExpr("byOpCode.get(opcode)"))));
 
-        var signature =
-                enumDef.addFieldWithInitializer(
-                        "Map<OpCode, WasmEncoding[]>",
-                        "signature",
-                        new NameExpr("new HashMap<>()"),
-                        Modifier.Keyword.PRIVATE,
-                        Modifier.Keyword.STATIC,
-                        Modifier.Keyword.FINAL);
+        enumDef.addFieldWithInitializer(
+                "Map<OpCode, WasmEncoding[]>",
+                "signature",
+                new NameExpr("new HashMap<>()"),
+                Modifier.Keyword.PRIVATE,
+                Modifier.Keyword.STATIC,
+                Modifier.Keyword.FINAL);
 
         var getSignature =
                 enumDef.addMethod("getSignature", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Module.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Module.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class Module {
+public final class Module {
     private final Map<String, CustomSection> customSections;
 
     private final TypeSection typeSection;
@@ -39,7 +39,7 @@ public class Module {
     private final Optional<DataCountSection> dataCountSection;
     private final List<Integer> ignoredSections;
 
-    Module(
+    private Module(
             TypeSection typeSection,
             ImportSection importSection,
             FunctionSection functionSection,
@@ -138,7 +138,7 @@ public class Module {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private TypeSection typeSection = TypeSection.builder().build();
         private ImportSection importSection = ImportSection.builder().build();
         private FunctionSection functionSection = FunctionSection.builder().build();

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Module.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Module.java
@@ -52,7 +52,7 @@ public class Module {
             CodeSection codeSection,
             DataSection dataSection,
             Optional<DataCountSection> dataCountSection,
-            HashMap<String, CustomSection> customSections,
+            Map<String, CustomSection> customSections,
             List<Integer> ignoredSections) {
         this.typeSection = requireNonNull(typeSection);
         this.importSection = requireNonNull(importSection);
@@ -151,7 +151,7 @@ public class Module {
         private CodeSection codeSection = CodeSection.builder().build();
         private DataSection dataSection = DataSection.builder().build();
         private Optional<DataCountSection> dataCountSection = Optional.empty();
-        private final HashMap<String, CustomSection> customSections = new HashMap<>();
+        private final Map<String, CustomSection> customSections = new HashMap<>();
         private final List<Integer> ignoredSections = new ArrayList<>();
         private boolean validate = true;
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -157,10 +157,6 @@ public final class Parser {
         return new Parser().parse(() -> input);
     }
 
-    public static Module parse(ByteBuffer buffer) {
-        return parse(buffer.array());
-    }
-
     public static Module parse(byte[] buffer) {
         return new Parser().parse(() -> new ByteArrayInputStream(buffer));
     }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -439,7 +439,7 @@ public final class Parser {
             ExternalType descType;
             try {
                 descType = ExternalType.byId((int) readVarUInt32(buffer));
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 throw new MalformedException("malformed import kind", e);
             }
             switch (descType) {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -197,43 +197,6 @@ public final class Parser {
         return moduleBuilder.build();
     }
 
-    private static int readInt(ByteBuffer buffer) {
-        if (buffer.remaining() < 4) {
-            throw new MalformedException("length out of bounds");
-        }
-        return buffer.getInt();
-    }
-
-    private static byte readByte(ByteBuffer buffer) {
-        if (!buffer.hasRemaining()) {
-            throw new MalformedException("length out of bounds");
-        }
-        return buffer.get();
-    }
-
-    private static void readBytes(ByteBuffer buffer, byte[] dest) {
-        if (buffer.remaining() < dest.length) {
-            throw new MalformedException("length out of bounds");
-        }
-        buffer.get(dest);
-    }
-
-    // https://webassembly.github.io/spec/core/binary/modules.html#binary-module
-    private static class SectionsValidator {
-        private boolean hasStart;
-
-        SectionsValidator() {}
-
-        public void validateSectionType(byte sectionId) {
-            if (sectionId == SectionId.START) {
-                if (hasStart) {
-                    throw new MalformedException("unexpected content after last section");
-                }
-                hasStart = true;
-            }
-        }
-    }
-
     public void parse(InputStream in, ParserListener listener) {
 
         requireNonNull(listener, "listener");
@@ -354,6 +317,22 @@ public final class Parser {
                 }
             } else {
                 buffer.position((int) (buffer.position() + sectionSize));
+            }
+        }
+    }
+
+    // https://webassembly.github.io/spec/core/binary/modules.html#binary-module
+    private static class SectionsValidator {
+        private boolean hasStart;
+
+        SectionsValidator() {}
+
+        public void validateSectionType(byte sectionId) {
+            if (sectionId == SectionId.START) {
+                if (hasStart) {
+                    throw new MalformedException("unexpected content after last section");
+                }
+                hasStart = true;
             }
         }
     }
@@ -1033,6 +1012,27 @@ public final class Parser {
             expr.add(i);
         }
         return expr.toArray(new Instruction[0]);
+    }
+
+    private static int readInt(ByteBuffer buffer) {
+        if (buffer.remaining() < 4) {
+            throw new MalformedException("length out of bounds");
+        }
+        return buffer.getInt();
+    }
+
+    private static byte readByte(ByteBuffer buffer) {
+        if (!buffer.hasRemaining()) {
+            throw new MalformedException("length out of bounds");
+        }
+        return buffer.get();
+    }
+
+    private static void readBytes(ByteBuffer buffer, byte[] dest) {
+        if (buffer.remaining() < dest.length) {
+            throw new MalformedException("length out of bounds");
+        }
+        buffer.get(dest);
     }
 
     // https://webassembly.github.io/spec/core/syntax/values.html#integers

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Validator.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Validator.java
@@ -181,6 +181,10 @@ final class Validator {
         pushVals(in);
     }
 
+    private void pushCtrl(CtrlFrame frame) {
+        ctrlFrameStack.add(frame);
+    }
+
     private CtrlFrame popCtrl() {
         if (ctrlFrameStack.isEmpty()) {
             errors.add(new InvalidException("type mismatch, control frame stack empty"));
@@ -194,10 +198,6 @@ final class Validator {
         }
         ctrlFrameStack.remove(ctrlFrameStack.size() - 1);
         return frame;
-    }
-
-    private void pushCtrl(CtrlFrame frame) {
-        ctrlFrameStack.add(frame);
     }
 
     private CtrlFrame peekCtrl() {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/AnnotatedInstruction.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/AnnotatedInstruction.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-public class AnnotatedInstruction extends Instruction {
+public final class AnnotatedInstruction extends Instruction {
     public static final int UNDEFINED_LABEL = -1;
 
     // metadata fields
@@ -74,7 +74,7 @@ public class AnnotatedInstruction extends Instruction {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private Instruction base;
         private int depth;
         private Optional<Integer> labelTrue = Optional.empty();

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeSection.java
@@ -34,7 +34,7 @@ public final class CodeSection extends Section {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private final List<FunctionBody> functionBodies = new ArrayList<>();
         private boolean requiresDataCount;
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSection.java
@@ -28,7 +28,7 @@ public final class DataSection extends Section {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private final List<DataSegment> dataSegments = new ArrayList<>();
 
         private Builder() {}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Element.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Element.java
@@ -38,6 +38,7 @@ public abstract class Element {
 
     /**
      * This value is equal to the number of initializers present.
+     *
      * @return the number of elements defined by this section
      */
     public int elementCount() {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElementSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElementSection.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-public class ElementSection extends Section {
+public final class ElementSection extends Section {
     private final List<Element> elements;
 
     private ElementSection(List<Element> elements) {
@@ -33,7 +33,7 @@ public class ElementSection extends Section {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private final List<Element> elements = new ArrayList<>();
 
         /**

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ExportSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ExportSection.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class ExportSection extends Section {
+public final class ExportSection extends Section {
     private final List<Export> exports;
 
     private ExportSection(List<Export> exports) {
@@ -24,7 +24,7 @@ public class ExportSection extends Section {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private final List<Export> exports = new ArrayList<>();
 
         private Builder() {}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ExternalType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ExternalType.java
@@ -20,8 +20,10 @@ public enum ExternalType {
 
     private final int id;
 
+    @SuppressWarnings("EnumOrdinal")
     ExternalType(int id) {
         this.id = id;
+        assert ordinal() == id;
     }
 
     /**
@@ -32,11 +34,6 @@ public enum ExternalType {
     }
 
     private static final List<ExternalType> values = List.of(values());
-
-    static {
-        // integrity verification
-        assert values.stream().allMatch(e -> e.ordinal() == e.id());
-    }
 
     public static ExternalType byId(int id) {
         return values.get(id);

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionSection.java
@@ -15,12 +15,12 @@ public final class FunctionSection extends Section {
         return typeIndices.get(idx);
     }
 
-    public int functionCount() {
-        return typeIndices.size();
-    }
-
     public FunctionType getFunctionType(int idx, TypeSection typeSection) {
         return typeSection.getType(getFunctionType(idx));
+    }
+
+    public int functionCount() {
+        return typeIndices.size();
     }
 
     public static Builder builder() {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionSection.java
@@ -3,7 +3,7 @@ package com.dylibso.chicory.wasm.types;
 import java.util.ArrayList;
 import java.util.List;
 
-public class FunctionSection extends Section {
+public final class FunctionSection extends Section {
     private final List<Integer> typeIndices;
 
     private FunctionSection(List<Integer> typeIndices) {
@@ -27,7 +27,7 @@ public class FunctionSection extends Section {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private final List<Integer> typeIndices = new ArrayList<>();
 
         private Builder() {}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionType.java
@@ -79,6 +79,10 @@ public final class FunctionType {
         return accepting.get(valueType);
     }
 
+    public boolean typesMatch(FunctionType other) {
+        return paramsMatch(other) && returnsMatch(other);
+    }
+
     public static FunctionType of(List<ValueType> params, List<ValueType> returns) {
         if (params.isEmpty()) {
             if (returns.isEmpty()) {
@@ -93,10 +97,6 @@ public final class FunctionType {
             }
         }
         return new FunctionType(List.copyOf(params), List.copyOf(returns));
-    }
-
-    public boolean typesMatch(FunctionType other) {
-        return paramsMatch(other) && returnsMatch(other);
     }
 
     public static FunctionType of(ValueType[] params, ValueType[] returns) {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalSection.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class GlobalSection extends Section {
+public final class GlobalSection extends Section {
     private final List<Global> globals;
 
     private GlobalSection(List<Global> globals) {
@@ -28,7 +28,7 @@ public class GlobalSection extends Section {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private final List<Global> globals = new ArrayList<>();
 
         private Builder() {}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ImportSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ImportSection.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-public class ImportSection extends Section {
+public final class ImportSection extends Section {
     private final List<Import> imports;
 
     private ImportSection(List<Import> imports) {
@@ -33,7 +33,7 @@ public class ImportSection extends Section {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private final List<Import> imports = new ArrayList<>();
 
         private Builder() {}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/MemorySection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/MemorySection.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class MemorySection extends Section {
+public final class MemorySection extends Section {
     private final List<Memory> memories;
 
     private MemorySection(List<Memory> memories) {
@@ -24,7 +24,7 @@ public class MemorySection extends Section {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private final List<Memory> memories = new ArrayList<>();
 
         private Builder() {}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/MutabilityType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/MutabilityType.java
@@ -41,5 +41,7 @@ public enum MutabilityType {
     static final class ID {
         static final int Const = 0x00;
         static final int Var = 0x01;
+
+        private ID() {}
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameCustomSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameCustomSection.java
@@ -142,9 +142,9 @@ public class NameCustomSection extends CustomSection {
 
     /**
      * @return the number of function names in this section
-     * This value does not have any relationship to the function index of any particular entry;
-     * it merely reflects the number of function names in this section.
-     * Used for testing.
+     *         This value does not have any relationship to the function index of any particular entry;
+     *         it merely reflects the number of function names in this section.
+     *         Used for testing.
      */
     public int functionNameCount() {
         return funcNames.size();

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameCustomSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameCustomSection.java
@@ -276,7 +276,8 @@ public class NameCustomSection extends CustomSection {
         ListEntry<NameEntry> subList;
         if (fi < 0) {
             // insert
-            listList.add(-fi - 1, subList = new ListEntry<>(groupIdx));
+            subList = new ListEntry<>(groupIdx);
+            listList.add(-fi - 1, subList);
         } else {
             subList = listList.get(fi);
         }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameCustomSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/NameCustomSection.java
@@ -12,7 +12,7 @@ import java.util.function.ToIntFunction;
 /**
  * The "name" custom section.
  */
-public class NameCustomSection extends CustomSection {
+public final class NameCustomSection extends CustomSection {
 
     private final Optional<String> moduleName;
     private final List<NameEntry> funcNames;

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/StartSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/StartSection.java
@@ -16,7 +16,7 @@ public final class StartSection extends Section {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private long startIndex;
 
         private Builder() {}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableSection.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class TableSection extends Section {
+public final class TableSection extends Section {
     private final List<Table> tables;
 
     private TableSection(List<Table> tables) {
@@ -24,7 +24,7 @@ public class TableSection extends Section {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private final List<Table> tables = new ArrayList<>();
 
         private Builder() {}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TypeSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TypeSection.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class TypeSection extends Section {
+public final class TypeSection extends Section {
     private final List<FunctionType> types;
 
     private TypeSection(List<FunctionType> types) {
@@ -28,7 +28,7 @@ public class TypeSection extends Section {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private final List<FunctionType> types = new ArrayList<>();
 
         private Builder() {}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/UnknownCustomSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/UnknownCustomSection.java
@@ -27,7 +27,7 @@ public final class UnknownCustomSection extends CustomSection {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private String name;
         private byte[] bytes;
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -82,6 +82,7 @@ public class Value {
 
     /**
      * Create a zeroed value for the particular type.
+     *
      * @param valueType must be a valid zeroable type.
      * @return a zero.
      */

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -238,7 +238,7 @@ public class Value {
             return false;
         }
         Value other = (Value) v;
-        return Objects.equals(type.id(), other.type.id()) && data == other.data;
+        return type.id() == other.type.id() && data == other.data;
     }
 
     @Override

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.MethodOrderer;
@@ -126,7 +127,7 @@ public class ParserTest {
         try (Stream<Path> stream = Files.list(compiledDir.toPath())) {
             files =
                     stream.map(Path::toFile)
-                            .filter(f -> f.getName().toLowerCase().endsWith(".wasm"))
+                            .filter(f -> f.getName().toLowerCase(Locale.ROOT).endsWith(".wasm"))
                             .collect(Collectors.toList());
         }
 


### PR DESCRIPTION
Each commit is independent and is intended to be reviewed separately.

In the commit that adds the [Checkstyle](https://checkstyle.sourceforge.io/) configuration, I added a number of checks that seem useful and pass with the current code base. These could be removed later if they turn out to be a problem or annoying.  We don't need any of the formatting related checks, as those are already covered by the code formatter.

The subsequent commits fix individual issues and enable the corresponding checks. If anyone feels strongly about not fixing or adding the check, it's easy to drop the commit.

[ErrorProne](https://errorprone.info/) is different than a normal checker in that it is implemented as a plugin to the Java compiler. The default checks are enabled, all as errors that fail the build, with a few disabled for now. I think it's better to have disabled checks than to have warnings in the build log. We should address those later.

The last commit changes the module list to always include `fuzz` and `jmh`, since having those disabled by default makes it easy to miss them when doing a local build, so you end up with a failure in the CI after the local build passed.