### PR TITLE
GlobalInstance should expose MutabilityType instead of HostGlobal

### DIFF
--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1DataHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1DataHostFuncs.java
@@ -26,10 +26,9 @@ public final class SpecV1DataHostFuncs {
                     new HostGlobal(
                             "test",
                             "global-mut-i32",
-                            new GlobalInstance(Value.i32(0)),
-                            MutabilityType.Var),
+                            new GlobalInstance(Value.i32(0), MutabilityType.Var)),
                     new HostGlobal(
-                            "test", "g", new GlobalInstance(Value.i32(0)), MutabilityType.Var)
+                            "test", "g", new GlobalInstance(Value.i32(0), MutabilityType.Var))
                 },
                 new HostMemory[] {
                     new HostMemory("spectest", "memory", new Memory(new MemoryLimits(1, 1)))

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ElemHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ElemHostFuncs.java
@@ -29,10 +29,9 @@ public final class SpecV1ElemHostFuncs {
                         new HostGlobal(
                                 "test",
                                 "global-mut-i32",
-                                new GlobalInstance(Value.i32(0)),
-                                MutabilityType.Var),
+                                new GlobalInstance(Value.i32(0), MutabilityType.Var)),
                         new HostGlobal(
-                                "test", "g", new GlobalInstance(Value.i32(0)), MutabilityType.Var))
+                                "test", "g", new GlobalInstance(Value.i32(0), MutabilityType.Var)))
                 .addTable(
                         new HostTable(
                                 "spectest",

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
@@ -19,8 +19,7 @@ public final class SpecV1GlobalHostFuncs {
                     new HostGlobal(
                             "test",
                             "global-mut-i32",
-                            new GlobalInstance(Value.i32(0)),
-                            MutabilityType.Var),
+                            new GlobalInstance(Value.i32(0), MutabilityType.Var)),
                     new HostGlobal("", "", new GlobalInstance(Value.externRef(0))),
                 });
     }

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
@@ -268,8 +268,7 @@ public final class SpecV1ImportsHostFuncs {
                         new HostGlobal(
                                 "test",
                                 "global-mut-i64",
-                                new GlobalInstance(Value.i64(0)),
-                                MutabilityType.Var))
+                                new GlobalInstance(Value.i64(0), MutabilityType.Var)))
                 .addMemory(
                         new HostMemory("spectest", "memory", new Memory(new MemoryLimits(1))),
                         new HostMemory(

--- a/aot/src/test/java/com/dylibso/chicory/imports/SpecV1LinkingHostFuncs.java
+++ b/aot/src/test/java/com/dylibso/chicory/imports/SpecV1LinkingHostFuncs.java
@@ -105,7 +105,7 @@ public final class SpecV1LinkingHostFuncs {
                                 List.of()))
                 .addGlobal(
                         new HostGlobal("Mg", "glob", MgInstance.global(0)),
-                        new HostGlobal("Mg", "mut_glob", MgInstance.global(1), MutabilityType.Var))
+                        new HostGlobal("Mg", "mut_glob", MgInstance.global(1)))
                 .build();
     }
 
@@ -186,14 +186,12 @@ public final class SpecV1LinkingHostFuncs {
                         new HostGlobal(
                                 "Mref_ex",
                                 "g-var-func",
-                                new GlobalInstance(Value.funcRef(0)),
-                                MutabilityType.Var))
+                                new GlobalInstance(Value.funcRef(0), MutabilityType.Var)))
                 .addGlobal(
                         new HostGlobal(
                                 "Mref_ex",
                                 "g-var-extern",
-                                new GlobalInstance(Value.externRef(0)),
-                                MutabilityType.Var))
+                                new GlobalInstance(Value.externRef(0), MutabilityType.Var)))
                 .build();
     }
 
@@ -231,14 +229,12 @@ public final class SpecV1LinkingHostFuncs {
                                 new HostGlobal(
                                         "Mref_ex",
                                         "g-var-func",
-                                        new GlobalInstance(Value.funcRef(0)),
-                                        MutabilityType.Var))
+                                        new GlobalInstance(Value.funcRef(0), MutabilityType.Var)))
                         .addGlobal(
                                 new HostGlobal(
                                         "Mref_ex",
                                         "g-var-extern",
-                                        new GlobalInstance(Value.externRef(0)),
-                                        MutabilityType.Var))
+                                        new GlobalInstance(Value.externRef(0), MutabilityType.Var)))
                         .addTable(
                                 new HostTable(
                                         "Mtable_ex",
@@ -255,7 +251,7 @@ public final class SpecV1LinkingHostFuncs {
         if (MgInstance != null) {
             builder.addGlobal(
                     new HostGlobal("Mg", "glob", MgInstance.global(0)),
-                    new HostGlobal("Mg", "mut_glob", MgInstance.global(1), MutabilityType.Var));
+                    new HostGlobal("Mg", "mut_glob", MgInstance.global(1)));
         }
 
         if (MsInstance != null) {

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1DataHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1DataHostFuncs.java
@@ -26,10 +26,9 @@ public final class SpecV1DataHostFuncs {
                     new HostGlobal(
                             "test",
                             "global-mut-i32",
-                            new GlobalInstance(Value.i32(0)),
-                            MutabilityType.Var),
+                            new GlobalInstance(Value.i32(0), MutabilityType.Var)),
                     new HostGlobal(
-                            "test", "g", new GlobalInstance(Value.i32(0)), MutabilityType.Var)
+                            "test", "g", new GlobalInstance(Value.i32(0), MutabilityType.Var))
                 },
                 new HostMemory[] {
                     new HostMemory("spectest", "memory", new Memory(new MemoryLimits(1, 1)))

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ElemHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ElemHostFuncs.java
@@ -29,10 +29,9 @@ public final class SpecV1ElemHostFuncs {
                         new HostGlobal(
                                 "test",
                                 "global-mut-i32",
-                                new GlobalInstance(Value.i32(0)),
-                                MutabilityType.Var),
+                                new GlobalInstance(Value.i32(0), MutabilityType.Var)),
                         new HostGlobal(
-                                "test", "g", new GlobalInstance(Value.i32(0)), MutabilityType.Var))
+                                "test", "g", new GlobalInstance(Value.i32(0), MutabilityType.Var)))
                 .addTable(
                         new HostTable(
                                 "spectest",

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1GlobalHostFuncs.java
@@ -19,8 +19,7 @@ public final class SpecV1GlobalHostFuncs {
                     new HostGlobal(
                             "test",
                             "global-mut-i32",
-                            new GlobalInstance(Value.i32(0)),
-                            MutabilityType.Var),
+                            new GlobalInstance(Value.i32(0), MutabilityType.Var)),
                     new HostGlobal("", "", new GlobalInstance(Value.externRef(0))),
                 });
     }

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1ImportsHostFuncs.java
@@ -268,8 +268,7 @@ public final class SpecV1ImportsHostFuncs {
                         new HostGlobal(
                                 "test",
                                 "global-mut-i64",
-                                new GlobalInstance(Value.i64(0)),
-                                MutabilityType.Var))
+                                new GlobalInstance(Value.i64(0), MutabilityType.Var)))
                 .addMemory(
                         new HostMemory("spectest", "memory", new Memory(new MemoryLimits(1))),
                         new HostMemory(

--- a/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1LinkingHostFuncs.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/imports/SpecV1LinkingHostFuncs.java
@@ -105,7 +105,7 @@ public final class SpecV1LinkingHostFuncs {
                                 List.of()))
                 .addGlobal(
                         new HostGlobal("Mg", "glob", MgInstance.global(0)),
-                        new HostGlobal("Mg", "mut_glob", MgInstance.global(1), MutabilityType.Var))
+                        new HostGlobal("Mg", "mut_glob", MgInstance.global(1)))
                 .build();
     }
 
@@ -186,14 +186,12 @@ public final class SpecV1LinkingHostFuncs {
                         new HostGlobal(
                                 "Mref_ex",
                                 "g-var-func",
-                                new GlobalInstance(Value.funcRef(0)),
-                                MutabilityType.Var))
+                                new GlobalInstance(Value.funcRef(0), MutabilityType.Var)))
                 .addGlobal(
                         new HostGlobal(
                                 "Mref_ex",
                                 "g-var-extern",
-                                new GlobalInstance(Value.externRef(0)),
-                                MutabilityType.Var))
+                                new GlobalInstance(Value.externRef(0), MutabilityType.Var)))
                 .build();
     }
 
@@ -231,14 +229,12 @@ public final class SpecV1LinkingHostFuncs {
                                 new HostGlobal(
                                         "Mref_ex",
                                         "g-var-func",
-                                        new GlobalInstance(Value.funcRef(0)),
-                                        MutabilityType.Var))
+                                        new GlobalInstance(Value.funcRef(0), MutabilityType.Var)))
                         .addGlobal(
                                 new HostGlobal(
                                         "Mref_ex",
                                         "g-var-extern",
-                                        new GlobalInstance(Value.externRef(0)),
-                                        MutabilityType.Var))
+                                        new GlobalInstance(Value.externRef(0), MutabilityType.Var)))
                         .addTable(
                                 new HostTable(
                                         "Mtable_ex",
@@ -255,7 +251,7 @@ public final class SpecV1LinkingHostFuncs {
         if (MgInstance != null) {
             builder.addGlobal(
                     new HostGlobal("Mg", "glob", MgInstance.global(0)),
-                    new HostGlobal("Mg", "mut_glob", MgInstance.global(1), MutabilityType.Var));
+                    new HostGlobal("Mg", "mut_glob", MgInstance.global(1)));
         }
 
         if (MsInstance != null) {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ConstantEvaluators.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ConstantEvaluators.java
@@ -65,7 +65,7 @@ public final class ConstantEvaluators {
                     {
                         var idx = (int) instruction.operands()[0];
                         if (idx < instance.imports().globalCount()) {
-                            if (instance.imports().global(idx).mutabilityType()
+                            if (instance.imports().global(idx).instance().getMutabilityType()
                                     != MutabilityType.Const) {
                                 throw new InvalidException(
                                         "constant expression required, initializer expression"

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/GlobalInstance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/GlobalInstance.java
@@ -1,13 +1,21 @@
 package com.dylibso.chicory.runtime;
 
+import com.dylibso.chicory.wasm.types.MutabilityType;
 import com.dylibso.chicory.wasm.types.Value;
 
 public class GlobalInstance {
     private Value value;
     private Instance instance;
+    private MutabilityType mutabilityType;
+
+    public GlobalInstance(Value value, MutabilityType mutabilityType) {
+        this.value = value;
+        this.mutabilityType = mutabilityType;
+    }
 
     public GlobalInstance(Value value) {
         this.value = value;
+        this.mutabilityType = MutabilityType.Const;
     }
 
     public Value getValue() {
@@ -24,5 +32,13 @@ public class GlobalInstance {
 
     public void setInstance(Instance instance) {
         this.instance = instance;
+    }
+
+    public MutabilityType getMutabilityType() {
+        return mutabilityType;
+    }
+
+    public void setMutabilityType(MutabilityType mutabilityType) {
+        this.mutabilityType = mutabilityType;
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostGlobal.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostGlobal.java
@@ -1,31 +1,18 @@
 package com.dylibso.chicory.runtime;
 
-import com.dylibso.chicory.wasm.types.MutabilityType;
-
 public class HostGlobal implements FromHost {
     private final GlobalInstance instance;
-    private final MutabilityType type;
     private final String moduleName;
     private final String fieldName;
 
     public HostGlobal(String moduleName, String fieldName, GlobalInstance instance) {
-        this(moduleName, fieldName, instance, MutabilityType.Const);
-    }
-
-    public HostGlobal(
-            String moduleName, String fieldName, GlobalInstance instance, MutabilityType type) {
         this.instance = instance;
-        this.type = type;
         this.moduleName = moduleName;
         this.fieldName = fieldName;
     }
 
     public GlobalInstance instance() {
         return instance;
-    }
-
-    public MutabilityType mutabilityType() {
-        return type;
     }
 
     @Override

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -184,7 +184,7 @@ public class Instance {
                 throw new InvalidException(
                         "type mismatch, expected: " + g.valueType() + ", got: " + value.type());
             }
-            globals[i] = new GlobalInstance(value);
+            globals[i] = new GlobalInstance(value, g.mutabilityType());
             globals[i].setInstance(this);
         }
 
@@ -431,7 +431,7 @@ public class Instance {
 
         private void validateHostGlobalType(GlobalImport i, HostGlobal g) {
             if (i.type() != g.instance().getValue().type()
-                    || i.mutabilityType() != g.mutabilityType()) {
+                    || i.mutabilityType() != g.instance().getMutabilityType()) {
                 throw new UnlinkableException("incompatible import type");
             }
         }


### PR DESCRIPTION
Move the MutabilityType field from HostGlobal to GlobalInstance. Notice that GlobalInstance has both getters and setters, we might want to revisit that.

Adjust tests accordingly.