### PR TITLE
Add experimental annotation framework for functions

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -16,6 +16,11 @@
     <dependencies>
       <dependency>
         <groupId>com.dylibso.chicory</groupId>
+        <artifactId>function-annotations</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.dylibso.chicory</groupId>
         <artifactId>log</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/function-annotations/pom.xml
+++ b/function-annotations/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.dylibso.chicory</groupId>
+    <artifactId>chicory</artifactId>
+    <version>999-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>function-annotations</artifactId>
+  <packaging>jar</packaging>
+  <name>Chicory - Function annotations</name>
+  <description>Experimental annotations for host functions</description>
+
+</project>

--- a/function-annotations/src/main/java/com/dylibso/chicory/function/annotations/HostModule.java
+++ b/function-annotations/src/main/java/com/dylibso/chicory/function/annotations/HostModule.java
@@ -1,0 +1,12 @@
+package com.dylibso.chicory.function.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface HostModule {
+    String value();
+}

--- a/function-annotations/src/main/java/com/dylibso/chicory/function/annotations/WasmExport.java
+++ b/function-annotations/src/main/java/com/dylibso/chicory/function/annotations/WasmExport.java
@@ -1,0 +1,12 @@
+package com.dylibso.chicory.function.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface WasmExport {
+    String value() default "";
+}

--- a/function-processor/pom.xml
+++ b/function-processor/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.dylibso.chicory</groupId>
+    <artifactId>chicory</artifactId>
+    <version>999-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>function-processor</artifactId>
+  <packaging>jar</packaging>
+  <name>Chicory - Function annotation processor</name>
+  <description>Experimental annotation processor for host functions</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.dylibso.chicory</groupId>
+      <artifactId>function-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.javaparser</groupId>
+      <artifactId>javaparser-core</artifactId>
+      <version>${javaparser.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.dylibso.chicory</groupId>
+      <artifactId>runtime</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.dylibso.chicory</groupId>
+      <artifactId>wasm</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.testing.compile</groupId>
+      <artifactId>compile-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies combine.children="append">
+            <dependency>com.dylibso.chicory:runtime</dependency>
+            <dependency>com.dylibso.chicory:wasm</dependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/function-processor/src/main/java/com/dylibso/chicory/function/processor/FunctionProcessor.java
+++ b/function-processor/src/main/java/com/dylibso/chicory/function/processor/FunctionProcessor.java
@@ -1,0 +1,284 @@
+package com.dylibso.chicory.function.processor;
+
+import static com.github.javaparser.StaticJavaParser.parseType;
+import static com.github.javaparser.printer.configuration.DefaultPrinterConfiguration.ConfigOption.COLUMN_ALIGN_PARAMETERS;
+import static java.lang.String.format;
+import static javax.tools.Diagnostic.Kind.ERROR;
+import static javax.tools.Diagnostic.Kind.NOTE;
+
+import com.dylibso.chicory.function.annotations.HostModule;
+import com.dylibso.chicory.function.annotations.WasmExport;
+import com.github.javaparser.ast.ArrayCreationLevel;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.ArrayAccessExpr;
+import com.github.javaparser.ast.expr.ArrayCreationExpr;
+import com.github.javaparser.ast.expr.ArrayInitializerExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
+import com.github.javaparser.ast.expr.LambdaExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.NullLiteralExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.printer.DefaultPrettyPrinter;
+import com.github.javaparser.printer.configuration.DefaultConfigurationOption;
+import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration;
+import java.io.IOException;
+import java.io.Writer;
+import java.lang.annotation.Annotation;
+import java.util.Locale;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Generated;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+
+public final class FunctionProcessor extends AbstractProcessor {
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of(HostModule.class.getName());
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment round) {
+        for (Element element : round.getElementsAnnotatedWith(HostModule.class)) {
+            log(NOTE, "Generating module factory for " + element, null);
+            try {
+                processModule((TypeElement) element);
+            } catch (AbortProcessingException e) {
+                // skip type
+            }
+        }
+
+        return false;
+    }
+
+    private void processModule(TypeElement type) {
+        var moduleName = type.getAnnotation(HostModule.class).value();
+
+        var functions = new NodeList<Expression>();
+        for (Element member : elements().getAllMembers(type)) {
+            if (member instanceof ExecutableElement && annotatedWith(member, WasmExport.class)) {
+                functions.add(processMethod(member, (ExecutableElement) member, moduleName));
+            }
+        }
+
+        var cu = new CompilationUnit(type.getEnclosingElement().toString());
+        cu.addImport("com.dylibso.chicory.runtime.HostFunction");
+        cu.addImport("com.dylibso.chicory.runtime.Instance");
+        cu.addImport("com.dylibso.chicory.wasm.types.Value");
+        cu.addImport("com.dylibso.chicory.wasm.types.ValueType");
+        cu.addImport("java.util.List");
+
+        var typeName = type.getSimpleName().toString();
+        var processorName = new StringLiteralExpr(getClass().getName());
+        var classDef =
+                cu.addClass(typeName + "_ModuleFactory")
+                        .setPublic(true)
+                        .setFinal(true)
+                        .addSingleMemberAnnotation(Generated.class, processorName);
+
+        classDef.addConstructor().setPrivate(true);
+
+        var newHostFunctions =
+                new ArrayCreationExpr(
+                        parseType("HostFunction"),
+                        new NodeList<>(new ArrayCreationLevel()),
+                        new ArrayInitializerExpr(functions));
+
+        classDef.addMethod("toHostFunctions")
+                .setPublic(true)
+                .setStatic(true)
+                .addParameter(typeName, "functions")
+                .setType("HostFunction[]")
+                .setBody(new BlockStmt(new NodeList<>(new ReturnStmt(newHostFunctions))));
+
+        String qualifiedName = type.getQualifiedName() + "_ModuleFactory";
+        try (Writer writer = filer().createSourceFile(qualifiedName, type).openWriter()) {
+            writer.write(cu.printer(printer()).toString());
+        } catch (IOException e) {
+            log(ERROR, format("Failed to create %s file: %s", qualifiedName, e), null);
+        }
+    }
+
+    private Expression processMethod(
+            Element member, ExecutableElement executable, String moduleName) {
+        // compute function name
+        var name = executable.getAnnotation(WasmExport.class).value();
+        if (name.isEmpty()) {
+            name = camelCaseToSnakeCase(executable.getSimpleName().toString());
+        }
+
+        // compute parameter types and argument conversions
+        NodeList<Expression> paramTypes = new NodeList<>();
+        NodeList<Expression> arguments = new NodeList<>();
+        for (VariableElement parameter : executable.getParameters()) {
+            var argExpr =
+                    new ArrayAccessExpr(
+                            new NameExpr("args"),
+                            new IntegerLiteralExpr(String.valueOf(paramTypes.size())));
+            switch (parameter.asType().toString()) {
+                case "int":
+                    paramTypes.add(valueType("I32"));
+                    arguments.add(new MethodCallExpr(argExpr, "asInt"));
+                    break;
+                case "long":
+                    paramTypes.add(valueType("I64"));
+                    arguments.add(new MethodCallExpr(argExpr, "asLong"));
+                    break;
+                case "float":
+                    paramTypes.add(valueType("F32"));
+                    arguments.add(new MethodCallExpr(argExpr, "asFloat"));
+                    break;
+                case "double":
+                    paramTypes.add(valueType("F64"));
+                    arguments.add(new MethodCallExpr(argExpr, "asDouble"));
+                    break;
+                case "com.dylibso.chicory.runtime.Instance":
+                    arguments.add(new NameExpr("instance"));
+                    break;
+                case "com.dylibso.chicory.runtime.Memory":
+                    arguments.add(new MethodCallExpr(new NameExpr("instance"), "memory"));
+                    break;
+                default:
+                    log(ERROR, "Unsupported WASM type: " + parameter.asType(), parameter);
+                    throw new AbortProcessingException();
+            }
+        }
+
+        // compute return type and conversion
+        String returnName = executable.getReturnType().toString();
+        NodeList<Expression> returnType = new NodeList<>();
+        String returnExpr = null;
+        switch (returnName) {
+            case "void":
+                break;
+            case "int":
+                returnType.add(valueType("I32"));
+                returnExpr = "i32";
+                break;
+            case "long":
+                returnType.add(valueType("I64"));
+                returnExpr = "i64";
+                break;
+            case "float":
+                returnType.add(valueType("F32"));
+                returnExpr = "fromFloat";
+                break;
+            case "double":
+                returnType.add(valueType("F64"));
+                returnExpr = "fromDouble";
+                break;
+            default:
+                log(ERROR, "Unsupported WASM type: " + returnName, executable);
+                throw new AbortProcessingException();
+        }
+
+        // function invocation
+        Expression invocation =
+                new MethodCallExpr(
+                        new NameExpr("functions"), member.getSimpleName().toString(), arguments);
+
+        // convert return value
+        BlockStmt handleBody = new BlockStmt();
+        if (returnType.isEmpty()) {
+            handleBody.addStatement(invocation).addStatement(new ReturnStmt(new NullLiteralExpr()));
+        } else {
+            var result = new VariableDeclarator(parseType(returnName), "result", invocation);
+            var boxed =
+                    new MethodCallExpr(
+                            new NameExpr("Value"),
+                            returnExpr,
+                            new NodeList<>(new NameExpr("result")));
+            var wrapped =
+                    new ArrayCreationExpr(
+                            parseType("Value"),
+                            new NodeList<>(new ArrayCreationLevel()),
+                            new ArrayInitializerExpr(new NodeList<>(boxed)));
+            handleBody
+                    .addStatement(new ExpressionStmt(new VariableDeclarationExpr(result)))
+                    .addStatement(new ReturnStmt(wrapped));
+        }
+
+        // lambda for host function
+        var handle =
+                new LambdaExpr()
+                        .addParameter("Instance", "instance")
+                        .addParameter(new Parameter(parseType("Value"), "args").setVarArgs(true))
+                        .setEnclosingParameters(true)
+                        .setBody(handleBody);
+
+        // create host function
+        var function =
+                new ObjectCreationExpr()
+                        .setType("HostFunction")
+                        .addArgument(handle)
+                        .addArgument(new StringLiteralExpr(moduleName))
+                        .addArgument(new StringLiteralExpr(name))
+                        .addArgument(new MethodCallExpr(new NameExpr("List"), "of", paramTypes))
+                        .addArgument(new MethodCallExpr(new NameExpr("List"), "of", returnType));
+        // TODO: update javaparser and replace with multiline formatting
+        function.setLineComment("");
+        return function;
+    }
+
+    private Elements elements() {
+        return processingEnv.getElementUtils();
+    }
+
+    private Filer filer() {
+        return processingEnv.getFiler();
+    }
+
+    private void log(Diagnostic.Kind kind, String message, Element element) {
+        processingEnv.getMessager().printMessage(kind, message, element);
+    }
+
+    private static boolean annotatedWith(Element element, Class<? extends Annotation> annotation) {
+        var annotationName = annotation.getName();
+        return element.getAnnotationMirrors().stream()
+                .map(AnnotationMirror::getAnnotationType)
+                .map(TypeMirror::toString)
+                .anyMatch(annotationName::equals);
+    }
+
+    private static Expression valueType(String type) {
+        return new FieldAccessExpr(new NameExpr("ValueType"), type);
+    }
+
+    private static String camelCaseToSnakeCase(String name) {
+        return name.replaceAll("([a-z])([A-Z]+)", "$1_$2").toLowerCase(Locale.ROOT);
+    }
+
+    private static DefaultPrettyPrinter printer() {
+        return new DefaultPrettyPrinter(
+                new DefaultPrinterConfiguration()
+                        .addOption(new DefaultConfigurationOption(COLUMN_ALIGN_PARAMETERS, true)));
+    }
+
+    private static final class AbortProcessingException extends RuntimeException {}
+}

--- a/function-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/function-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+com.dylibso.chicory.function.processor.FunctionProcessor

--- a/function-processor/src/test/java/com/dylibso/chicory/function/processor/FunctionProcessorTest.java
+++ b/function-processor/src/test/java/com/dylibso/chicory/function/processor/FunctionProcessorTest.java
@@ -1,0 +1,58 @@
+package com.dylibso.chicory.function.processor;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.jupiter.api.Test;
+
+class FunctionProcessorTest {
+
+    @Test
+    void generateModules() {
+        Compilation compilation =
+                javac().withProcessors(new FunctionProcessor())
+                        .compile(
+                                JavaFileObjects.forResource("BasicMath.java"),
+                                JavaFileObjects.forResource("Simple.java"));
+
+        assertThat(compilation).succeededWithoutWarnings();
+
+        assertThat(compilation)
+                .generatedSourceFile("chicory.testing.BasicMath_ModuleFactory")
+                .hasSourceEquivalentTo(JavaFileObjects.forResource("BasicMathGenerated.java"));
+
+        assertThat(compilation)
+                .generatedSourceFile("chicory.testing.Simple_ModuleFactory")
+                .hasSourceEquivalentTo(JavaFileObjects.forResource("SimpleGenerated.java"));
+    }
+
+    @Test
+    void invalidParameterType() {
+        Compilation compilation =
+                javac().withProcessors(new FunctionProcessor())
+                        .compile(JavaFileObjects.forResource("InvalidParameter.java"));
+
+        assertThat(compilation).failed();
+
+        assertThat(compilation)
+                .hadErrorContaining("Unsupported WASM type: java.lang.String")
+                .inFile(JavaFileObjects.forResource("InvalidParameter.java"))
+                .onLineContaining("public long concat(int a, String s) {");
+    }
+
+    @Test
+    void invalidReturnType() {
+        Compilation compilation =
+                javac().withProcessors(new FunctionProcessor())
+                        .compile(JavaFileObjects.forResource("InvalidReturn.java"));
+
+        assertThat(compilation).failed();
+
+        assertThat(compilation)
+                .hadErrorContaining("Unsupported WASM type: java.lang.String")
+                .inFile(JavaFileObjects.forResource("InvalidReturn.java"))
+                .onLineContaining("public String toString(int x) {");
+    }
+}

--- a/function-processor/src/test/resources/BasicMath.java
+++ b/function-processor/src/test/resources/BasicMath.java
@@ -1,0 +1,28 @@
+package chicory.testing;
+
+import com.dylibso.chicory.function.annotations.HostModule;
+import com.dylibso.chicory.function.annotations.WasmExport;
+import com.dylibso.chicory.runtime.HostFunction;
+
+@HostModule("math")
+public final class BasicMath {
+
+    @WasmExport
+    public long add(int a, int b) {
+        return a + b;
+    }
+
+    @WasmExport("square")
+    public double pow2(float x) {
+        return x * x;
+    }
+
+    @WasmExport
+    public int floorDiv(int x, int y) {
+        return Math.floorDiv(x, y);
+    }
+
+    public HostFunction[] toHostFunctions() {
+        return BasicMath_ModuleFactory.toHostFunctions(this);
+    }
+}

--- a/function-processor/src/test/resources/BasicMathGenerated.java
+++ b/function-processor/src/test/resources/BasicMathGenerated.java
@@ -1,0 +1,49 @@
+package chicory.testing;
+
+import com.dylibso.chicory.runtime.HostFunction;
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasm.types.Value;
+import com.dylibso.chicory.wasm.types.ValueType;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.dylibso.chicory.function.processor.FunctionProcessor")
+public final class BasicMath_ModuleFactory {
+
+    private BasicMath_ModuleFactory() {}
+
+    public static HostFunction[] toHostFunctions(BasicMath functions) {
+        return new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        long result = functions.add(args[0].asInt(), args[1].asInt());
+                        return new Value[] { Value.i64(result) };
+                    },
+                    "math",
+                    "add",
+                    List.of(ValueType.I32, ValueType.I32),
+                    List.of(ValueType.I64)
+            ),
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        double result = functions.pow2(args[0].asFloat());
+                        return new Value[] { Value.fromDouble(result) };
+                    },
+                    "math",
+                    "square",
+                    List.of(ValueType.F32),
+                    List.of(ValueType.F64)
+            ),
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        int result = functions.floorDiv(args[0].asInt(), args[1].asInt())
+                        return new Value[] { Value.i32(result) };
+                    },
+                    "math",
+                    "floor_div",
+                    List.of(ValueType.I32, ValueType.I32),
+                    List.of(ValueType.I32)
+            ),
+        };
+    }
+}

--- a/function-processor/src/test/resources/InvalidParameter.java
+++ b/function-processor/src/test/resources/InvalidParameter.java
@@ -1,0 +1,13 @@
+package chicory.testing;
+
+import com.dylibso.chicory.function.annotations.HostModule;
+import com.dylibso.chicory.function.annotations.WasmExport;
+
+@HostModule("bad_param")
+public final class InvalidParameter {
+
+    @WasmExport
+    public long concat(int a, String s) {
+        return (s + a).length();
+    }
+}

--- a/function-processor/src/test/resources/InvalidReturn.java
+++ b/function-processor/src/test/resources/InvalidReturn.java
@@ -1,0 +1,13 @@
+package chicory.testing;
+
+import com.dylibso.chicory.function.annotations.HostModule;
+import com.dylibso.chicory.function.annotations.WasmExport;
+
+@HostModule("bad_return")
+public final class InvalidReturn {
+
+    @WasmExport
+    public String toString(int x) {
+        return String.valueOf(x);
+    }
+}

--- a/function-processor/src/test/resources/Simple.java
+++ b/function-processor/src/test/resources/Simple.java
@@ -1,0 +1,25 @@
+package chicory.testing;
+
+import com.dylibso.chicory.function.annotations.HostModule;
+import com.dylibso.chicory.function.annotations.WasmExport;
+import com.dylibso.chicory.runtime.HostFunction;
+import com.dylibso.chicory.runtime.Memory;
+import com.dylibso.chicory.wasm.exceptions.ChicoryException;
+
+@HostModule("simple")
+public final class Simple {
+
+    @WasmExport
+    public void print(Memory memory, int ptr, int len) {
+        System.out.println(memory.readString(ptr, len));
+    }
+
+    @WasmExport
+    public void exit() {
+        throw new ChicoryException("exit");
+    }
+
+    public HostFunction[] toHostFunctions() {
+        return Simple_ModuleFactory.toHostFunctions(this);
+    }
+}

--- a/function-processor/src/test/resources/SimpleGenerated.java
+++ b/function-processor/src/test/resources/SimpleGenerated.java
@@ -1,0 +1,39 @@
+package chicory.testing;
+
+import com.dylibso.chicory.runtime.HostFunction;
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasm.types.Value;
+import com.dylibso.chicory.wasm.types.ValueType;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.dylibso.chicory.function.processor.FunctionProcessor")
+public final class Simple_ModuleFactory {
+
+    private Simple_ModuleFactory() {}
+
+    public static HostFunction[] toHostFunctions(Simple functions) {
+        return new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        functions.print(instance.memory(), args[0].asInt(), args[1].asInt());
+                        return null;
+                    },
+                    "simple",
+                    "print",
+                    List.of(ValueType.I32, ValueType.I32),
+                    List.of()
+            ),
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        functions.exit();
+                        return null;
+                    },
+                    "simple",
+                    "exit",
+                    List.of(),
+                    List.of()
+            ),
+        };
+    }
+}

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -15,8 +15,14 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/log/src/main/java/com/dylibso/chicory/log/Logger.java
+++ b/log/src/main/java/com/dylibso/chicory/log/Logger.java
@@ -1,5 +1,6 @@
 package com.dylibso.chicory.log;
 
+import com.google.errorprone.annotations.FormatMethod;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -74,6 +75,7 @@ public interface Logger {
         }
     }
 
+    @FormatMethod
     default void tracef(String format, Object... args) {
         Objects.requireNonNull(format);
 
@@ -115,6 +117,7 @@ public interface Logger {
         }
     }
 
+    @FormatMethod
     default void debugf(String format, Object... args) {
         Objects.requireNonNull(format);
 
@@ -156,6 +159,7 @@ public interface Logger {
         }
     }
 
+    @FormatMethod
     default void infof(String format, Object... args) {
         Objects.requireNonNull(format);
 
@@ -197,6 +201,7 @@ public interface Logger {
         }
     }
 
+    @FormatMethod
     default void warnf(String format, Object... args) {
         Objects.requireNonNull(format);
 
@@ -238,6 +243,7 @@ public interface Logger {
         }
     }
 
+    @FormatMethod
     default void errorf(String format, Object... args) {
         Objects.requireNonNull(format);
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
     <module>aot-tests</module>
     <module>bom</module>
     <module>cli</module>
+    <module>function-annotations</module>
+    <module>function-processor</module>
     <module>fuzz</module>
     <module>jmh</module>
     <module>log</module>
@@ -143,6 +145,16 @@
       </dependency>
       <dependency>
         <groupId>com.dylibso.chicory</groupId>
+        <artifactId>function-annotations</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.dylibso.chicory</groupId>
+        <artifactId>function-processor</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.dylibso.chicory</groupId>
         <artifactId>log</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -177,6 +189,13 @@
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>${error-prone.version}</version>
+      </dependency>
+
+      <!-- Use latest Guava -->
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>33.3.0-jre</version>
       </dependency>
 
       <!-- Used for WASI tests -->
@@ -224,6 +243,14 @@
         <groupId>com.approvaltests</groupId>
         <artifactId>approvaltests</artifactId>
         <version>${approvaltests.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- Used for annotation processor tests -->
+      <dependency>
+        <groupId>com.google.testing.compile</groupId>
+        <artifactId>compile-testing</artifactId>
+        <version>0.21.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,13 @@
         <version>${project.version}</version>
       </dependency>
 
+      <!-- Error Prone -->
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>${error-prone.version}</version>
+      </dependency>
+
       <!-- Used for WASI tests -->
       <dependency>
         <groupId>com.google.jimfs</groupId>

--- a/wasi/pom.xml
+++ b/wasi/pom.xml
@@ -16,6 +16,10 @@
   <dependencies>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>
+      <artifactId>function-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.dylibso.chicory</groupId>
       <artifactId>log</artifactId>
     </dependency>
     <dependency>
@@ -25,6 +29,12 @@
     <dependency>
       <groupId>com.dylibso.chicory</groupId>
       <artifactId>wasm</artifactId>
+    </dependency>
+    <!-- fake dependency for reactor build order -->
+    <dependency>
+      <groupId>com.dylibso.chicory</groupId>
+      <artifactId>function-processor</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>
@@ -111,6 +121,30 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>com.dylibso.chicory</groupId>
+              <artifactId>function-processor</artifactId>
+              <version>${project.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies combine.children="append">
+            <dependency>com.dylibso.chicory:function-processor</dependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
@@ -5,8 +5,6 @@ import static com.dylibso.chicory.wasi.Descriptors.DataWriter;
 import static com.dylibso.chicory.wasi.Descriptors.Descriptor;
 import static com.dylibso.chicory.wasi.Descriptors.OpenDirectory;
 import static com.dylibso.chicory.wasi.Descriptors.OpenFile;
-import static com.dylibso.chicory.wasm.types.ValueType.I32;
-import static com.dylibso.chicory.wasm.types.ValueType.I64;
 import static java.lang.Math.min;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -14,17 +12,17 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 
+import com.dylibso.chicory.function.annotations.HostModule;
+import com.dylibso.chicory.function.annotations.WasmExport;
 import com.dylibso.chicory.log.Logger;
 import com.dylibso.chicory.log.SystemLogger;
 import com.dylibso.chicory.runtime.HostFunction;
-import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.runtime.exceptions.WASMRuntimeException;
 import com.dylibso.chicory.wasi.Descriptors.Directory;
 import com.dylibso.chicory.wasi.Descriptors.InStream;
 import com.dylibso.chicory.wasi.Descriptors.OutStream;
 import com.dylibso.chicory.wasi.Descriptors.PreopenedDirectory;
-import com.dylibso.chicory.wasm.types.Value;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -55,6 +53,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Stream;
 
+@HostModule("wasi_snapshot_preview1")
 public final class WasiPreview1 implements Closeable {
     private final Logger logger;
     private final List<byte[]> arguments;
@@ -127,1490 +126,1030 @@ public final class WasiPreview1 implements Closeable {
         descriptors.closeAll();
     }
 
-    public HostFunction adapterCloseBadfd() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("adapter_close_badfd: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: adapter_close_badfd");
-                    // return new Value[] { Value.i32(0) };
-                },
-                "wasi_snapshot_preview1",
-                "adapter_close_badfd",
-                List.of(I32),
-                List.of(I32));
+    @WasmExport
+    public int adapterCloseBadfd(int fd) {
+        logger.infof("adapter_close_badfd: [%s]", fd);
+        throw new WASMRuntimeException("We don't yet support this WASI call: adapter_close_badfd");
     }
 
-    public HostFunction adapterOpenBadfd() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("adapter_open_badfd: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: adapter_open_badfd");
-                    // return new Value[] { Value.i32(0) };
-                },
-                "wasi_snapshot_preview1",
-                "adapter_open_badfd",
-                List.of(I32),
-                List.of(I32));
+    @WasmExport
+    public int adapterOpenBadfd(int fd) {
+        logger.infof("adapter_open_badfd: [%s]", fd);
+        throw new WASMRuntimeException("We don't yet support this WASI call: adapter_open_badfd");
     }
 
-    public HostFunction argsGet() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("args_get: " + Arrays.toString(args));
-                    int argv = args[0].asInt();
-                    int argvBuf = args[1].asInt();
-
-                    Memory memory = instance.memory();
-                    for (byte[] argument : arguments) {
-                        memory.writeI32(argv, argvBuf);
-                        argv += 4;
-                        memory.write(argvBuf, argument);
-                        argvBuf += argument.length;
-                        memory.writeByte(argvBuf, (byte) 0);
-                        argvBuf++;
-                    }
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "args_get",
-                List.of(I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int argsGet(Memory memory, int argv, int argvBuf) {
+        logger.infof("args_get: [%s, %s]", argv, argvBuf);
+        for (byte[] argument : arguments) {
+            memory.writeI32(argv, argvBuf);
+            argv += 4;
+            memory.write(argvBuf, argument);
+            argvBuf += argument.length;
+            memory.writeByte(argvBuf, (byte) 0);
+            argvBuf++;
+        }
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction argsSizesGet() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("args_sizes_get: " + Arrays.toString(args));
-                    int argc = args[0].asInt();
-                    int argvBufSize = args[1].asInt();
-
-                    int bufSize = arguments.stream().mapToInt(x -> x.length + 1).sum();
-                    Memory memory = instance.memory();
-                    memory.writeI32(argc, arguments.size());
-                    memory.writeI32(argvBufSize, bufSize);
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "args_sizes_get",
-                List.of(I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int argsSizesGet(Memory memory, int argc, int argvBufSize) {
+        logger.infof("args_sizes_get: [%s, %s]", argc, argvBufSize);
+        int bufSize = arguments.stream().mapToInt(x -> x.length + 1).sum();
+        memory.writeI32(argc, arguments.size());
+        memory.writeI32(argvBufSize, bufSize);
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction clockResGet() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("clock_res_get: " + Arrays.toString(args));
-                    int clockId = args[0].asInt();
-                    int resultPtr = args[1].asInt();
-
-                    Memory memory = instance.memory();
-                    switch (clockId) {
-                        case WasiClockId.REALTIME:
-                        case WasiClockId.MONOTONIC:
-                            memory.writeLong(resultPtr, 1L);
-                            return wasiResult(WasiErrno.ESUCCESS);
-                        case WasiClockId.PROCESS_CPUTIME_ID:
-                            throw new WASMRuntimeException(
-                                    "We don't yet support clockid process_cputime_id");
-                        case WasiClockId.THREAD_CPUTIME_ID:
-                            throw new WASMRuntimeException(
-                                    "We don't yet support clockid thread_cputime_id");
-                        default:
-                            return wasiResult(WasiErrno.EINVAL);
-                    }
-                },
-                "wasi_snapshot_preview1",
-                "clock_res_get",
-                List.of(I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int clockResGet(Memory memory, int clockId, int resultPtr) {
+        logger.infof("clock_res_get: [%s, %s]", clockId, resultPtr);
+        switch (clockId) {
+            case WasiClockId.REALTIME:
+            case WasiClockId.MONOTONIC:
+                memory.writeLong(resultPtr, 1L);
+                return wasiResult(WasiErrno.ESUCCESS);
+            case WasiClockId.PROCESS_CPUTIME_ID:
+                throw new WASMRuntimeException("We don't yet support clockid process_cputime_id");
+            case WasiClockId.THREAD_CPUTIME_ID:
+                throw new WASMRuntimeException("We don't yet support clockid thread_cputime_id");
+            default:
+                return wasiResult(WasiErrno.EINVAL);
+        }
     }
 
-    public HostFunction clockTimeGet() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("clock_time_get: " + Arrays.toString(args));
-                    int clockId = args[0].asInt();
-                    // long precision = args[1].asLong();
-                    int resultPtr = args[2].asInt();
-
-                    Memory memory = instance.memory();
-                    switch (clockId) {
-                        case WasiClockId.REALTIME:
-                            Instant now = Instant.now();
-                            long epochNanos = SECONDS.toNanos(now.getEpochSecond()) + now.getNano();
-                            memory.writeLong(resultPtr, epochNanos);
-                            return wasiResult(WasiErrno.ESUCCESS);
-                        case WasiClockId.MONOTONIC:
-                            memory.writeLong(resultPtr, System.nanoTime());
-                            return wasiResult(WasiErrno.ESUCCESS);
-                        case WasiClockId.PROCESS_CPUTIME_ID:
-                            throw new WASMRuntimeException(
-                                    "We don't yet support clockid process_cputime_id");
-                        case WasiClockId.THREAD_CPUTIME_ID:
-                            throw new WASMRuntimeException(
-                                    "We don't yet support clockid thread_cputime_id");
-                        default:
-                            return wasiResult(WasiErrno.EINVAL);
-                    }
-                },
-                "wasi_snapshot_preview1",
-                "clock_time_get",
-                List.of(I32, I64, I32),
-                List.of(I32));
+    @WasmExport
+    public int clockTimeGet(Memory memory, int clockId, long precision, int resultPtr) {
+        logger.infof("clock_time_get: [%s, %s, %s]", clockId, precision, resultPtr);
+        switch (clockId) {
+            case WasiClockId.REALTIME:
+                Instant now = Instant.now();
+                long epochNanos = SECONDS.toNanos(now.getEpochSecond()) + now.getNano();
+                memory.writeLong(resultPtr, epochNanos);
+                return wasiResult(WasiErrno.ESUCCESS);
+            case WasiClockId.MONOTONIC:
+                memory.writeLong(resultPtr, System.nanoTime());
+                return wasiResult(WasiErrno.ESUCCESS);
+            case WasiClockId.PROCESS_CPUTIME_ID:
+                throw new WASMRuntimeException("We don't yet support clockid process_cputime_id");
+            case WasiClockId.THREAD_CPUTIME_ID:
+                throw new WASMRuntimeException("We don't yet support clockid thread_cputime_id");
+            default:
+                return wasiResult(WasiErrno.EINVAL);
+        }
     }
 
-    public HostFunction environGet() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("environ_get: " + Arrays.toString(args));
-                    int environ = args[0].asInt();
-                    int environBuf = args[1].asInt();
+    @WasmExport
+    public int environGet(Memory memory, int environ, int environBuf) {
+        logger.infof("environ_get: [%s, %s]", environ, environBuf);
+        for (Entry<byte[], byte[]> entry : environment) {
+            byte[] name = entry.getKey();
+            byte[] value = entry.getValue();
+            byte[] data = new byte[name.length + value.length + 2];
+            System.arraycopy(name, 0, data, 0, name.length);
+            data[name.length] = '=';
+            System.arraycopy(value, 0, data, name.length + 1, value.length);
+            data[data.length - 1] = '\0';
 
-                    Memory memory = instance.memory();
-                    for (var entry : environment) {
-                        byte[] name = entry.getKey();
-                        byte[] value = entry.getValue();
-                        byte[] data = new byte[name.length + value.length + 2];
-                        System.arraycopy(name, 0, data, 0, name.length);
-                        data[name.length] = '=';
-                        System.arraycopy(value, 0, data, name.length + 1, value.length);
-                        data[data.length - 1] = '\0';
-
-                        memory.writeI32(environ, environBuf);
-                        environ += 4;
-                        memory.write(environBuf, data);
-                        environBuf += data.length;
-                    }
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "environ_get",
-                List.of(I32, I32),
-                List.of(I32));
+            memory.writeI32(environ, environBuf);
+            environ += 4;
+            memory.write(environBuf, data);
+            environBuf += data.length;
+        }
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction environSizesGet() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("environ_sizes_get: " + Arrays.toString(args));
-                    int environCount = args[0].asInt();
-                    int environBufSize = args[1].asInt();
-
-                    int bufSize =
-                            environment.stream()
-                                    .mapToInt(x -> x.getKey().length + x.getValue().length + 2)
-                                    .sum();
-                    Memory memory = instance.memory();
-                    memory.writeI32(environCount, environment.size());
-                    memory.writeI32(environBufSize, bufSize);
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "environ_sizes_get",
-                List.of(I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int environSizesGet(Memory memory, int environCount, int environBufSize) {
+        logger.infof("environ_sizes_get: [%s, %s]", environCount, environBufSize);
+        int bufSize =
+                environment.stream()
+                        .mapToInt(x -> x.getKey().length + x.getValue().length + 2)
+                        .sum();
+        memory.writeI32(environCount, environment.size());
+        memory.writeI32(environBufSize, bufSize);
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction fdAdvise() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_advise: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: fd_advise");
-                    // return new Value[] { Value.i32(0) };
-                },
-                "wasi_snapshot_preview1",
-                "fd_advise",
-                List.of(I32, I64, I64, I32),
-                List.of(I32));
+    @WasmExport
+    public int fdAdvise(int fd, long offset, long len, int advice) {
+        logger.infof("fd_advise: [%s, %s, %s, %s]", fd, offset, len, advice);
+        throw new WASMRuntimeException("We don't yet support this WASI call: fd_advise");
     }
 
-    public HostFunction fdAllocate() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_allocate: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: fd_allocate");
-                    // return new Value[] { Value.i32(0) };
-                },
-                "wasi_snapshot_preview1",
-                "fd_allocate",
-                List.of(I32, I64, I64),
-                List.of(I32));
+    @WasmExport
+    public int fdAllocate(int fd, long offset, long len) {
+        logger.infof("fd_allocate: [%s, %s, %s]", fd, offset, len);
+        throw new WASMRuntimeException("We don't yet support this WASI call: fd_allocate");
     }
 
-    public HostFunction fdClose() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_close: " + Arrays.toString(args));
-                    int fd = args[0].asInt();
-
-                    Descriptor descriptor = descriptors.get(fd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
-
-                    descriptors.free(fd);
-
-                    try {
-                        if (descriptor instanceof Closeable) {
-                            ((Closeable) descriptor).close();
-                        }
-                    } catch (IOException e) {
-                        return wasiResult(WasiErrno.EIO);
-                    }
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "fd_close",
-                List.of(I32),
-                List.of(I32));
+    @WasmExport
+    public int fdClose(int fd) {
+        logger.infof("fd_close: [%s]", fd);
+        Descriptor descriptor = descriptors.get(fd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
+        descriptors.free(fd);
+        try {
+            if (descriptor instanceof Closeable) {
+                ((Closeable) descriptor).close();
+            }
+        } catch (IOException e) {
+            return wasiResult(WasiErrno.EIO);
+        }
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction fdDatasync() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_datasync: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: fd_datasync");
-                    // return new Value[] { Value.i32(0) };
-                },
-                "wasi_snapshot_preview1",
-                "fd_datasync",
-                List.of(I32),
-                List.of(I32));
+    @WasmExport
+    public int fdDatasync(int fd) {
+        logger.infof("fd_datasync: [%s]", fd);
+        throw new WASMRuntimeException("We don't yet support this WASI call: fd_datasync");
     }
 
-    public HostFunction fdFdstatGet() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_fdstat_get: " + Arrays.toString(args));
-                    int fd = args[0].asInt();
-                    int buf = args[1].asInt();
-                    int flags = 0;
-                    int rightsBase;
-                    int rightsInheriting = 0;
+    @WasmExport
+    public int fdFdstatGet(Memory memory, int fd, int buf) {
+        logger.infof("fd_fdstat_get: [%s, %s]", fd, buf);
+        int flags = 0;
+        int rightsBase;
+        int rightsInheriting = 0;
 
-                    var descriptor = descriptors.get(fd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        var descriptor = descriptors.get(fd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    WasiFileType fileType;
-                    if (descriptor instanceof InStream) {
-                        fileType = WasiFileType.CHARACTER_DEVICE;
-                        rightsBase = WasiRights.FD_READ;
-                    } else if (descriptor instanceof OutStream) {
-                        fileType = WasiFileType.CHARACTER_DEVICE;
-                        rightsBase = WasiRights.FD_WRITE;
-                    } else if (descriptor instanceof Directory) {
-                        fileType = WasiFileType.DIRECTORY;
-                        rightsBase = WasiRights.DIRECTORY_RIGHTS_BASE;
-                        rightsInheriting = rightsBase | WasiRights.FILE_RIGHTS_BASE;
-                    } else if (descriptor instanceof OpenFile) {
-                        fileType = WasiFileType.REGULAR_FILE;
-                        rightsBase = WasiRights.FILE_RIGHTS_BASE;
-                        flags = ((OpenFile) descriptor).fdFlags();
-                    } else {
-                        throw unhandledDescriptor(descriptor);
-                    }
+        WasiFileType fileType;
+        if (descriptor instanceof InStream) {
+            fileType = WasiFileType.CHARACTER_DEVICE;
+            rightsBase = WasiRights.FD_READ;
+        } else if (descriptor instanceof OutStream) {
+            fileType = WasiFileType.CHARACTER_DEVICE;
+            rightsBase = WasiRights.FD_WRITE;
+        } else if (descriptor instanceof Directory) {
+            fileType = WasiFileType.DIRECTORY;
+            rightsBase = WasiRights.DIRECTORY_RIGHTS_BASE;
+            rightsInheriting = rightsBase | WasiRights.FILE_RIGHTS_BASE;
+        } else if (descriptor instanceof OpenFile) {
+            fileType = WasiFileType.REGULAR_FILE;
+            rightsBase = WasiRights.FILE_RIGHTS_BASE;
+            flags = ((OpenFile) descriptor).fdFlags();
+        } else {
+            throw unhandledDescriptor(descriptor);
+        }
 
-                    Memory memory = instance.memory();
-                    memory.write(buf, new byte[8]);
-                    memory.writeByte(buf, (byte) fileType.value());
-                    memory.writeShort(buf + 2, (short) flags);
-                    memory.writeLong(buf + 8, rightsBase);
-                    memory.writeLong(buf + 16, rightsInheriting);
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "fd_fdstat_get",
-                List.of(I32, I32),
-                List.of(I32));
+        memory.write(buf, new byte[8]);
+        memory.writeByte(buf, (byte) fileType.value());
+        memory.writeShort(buf + 2, (short) flags);
+        memory.writeLong(buf + 8, rightsBase);
+        memory.writeLong(buf + 16, rightsInheriting);
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction fdFdstatSetFlags() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_fdstat_set_flags: " + Arrays.toString(args));
-                    int fd = args[0].asInt();
-                    int flags = args[1].asInt();
+    @WasmExport
+    public int fdFdstatSetFlags(int fd, int flags) {
+        logger.infof("fd_fdstat_set_flags: [%s, %s]", fd, flags);
 
-                    var descriptor = descriptors.get(fd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        var descriptor = descriptors.get(fd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    if ((descriptor instanceof InStream) || (descriptor instanceof OutStream)) {
-                        return wasiResult(WasiErrno.EINVAL);
-                    }
-                    if ((descriptor instanceof OpenDirectory)
-                            || (descriptor instanceof PreopenedDirectory)) {
-                        return wasiResult(WasiErrno.ESUCCESS);
-                    }
-                    if (!(descriptor instanceof OpenFile)) {
-                        throw unhandledDescriptor(descriptor);
-                    }
+        if ((descriptor instanceof InStream) || (descriptor instanceof OutStream)) {
+            return wasiResult(WasiErrno.EINVAL);
+        }
+        if ((descriptor instanceof OpenDirectory) || (descriptor instanceof PreopenedDirectory)) {
+            return wasiResult(WasiErrno.ESUCCESS);
+        }
+        if (!(descriptor instanceof OpenFile)) {
+            throw unhandledDescriptor(descriptor);
+        }
 
-                    // we don't support changing flags
-                    if (flags != ((OpenFile) descriptor).fdFlags()) {
-                        return wasiResult(WasiErrno.ENOTSUP);
-                    }
+        // we don't support changing flags
+        if (flags != ((OpenFile) descriptor).fdFlags()) {
+            return wasiResult(WasiErrno.ENOTSUP);
+        }
 
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "fd_fdstat_set_flags",
-                List.of(I32, I32),
-                List.of(I32));
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction fdFdstatSetRights() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_fdstat_set_rights: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: fd_fdstat_set_rightsn");
-                    // return new Value[] { Value.i32(0) };
-                },
-                "wasi_snapshot_preview1",
-                "fd_fdstat_set_rights",
-                List.of(I32, I64, I32),
-                List.of(I32));
+    @WasmExport
+    public int fdFdstatSetRights(int fd, long rightsBase, long rightsInheriting) {
+        logger.infof("fd_fdstat_set_rights: [%s, %s, %s]", fd, rightsBase, rightsInheriting);
+        throw new WASMRuntimeException("We don't yet support this WASI call: fd_fdstat_set_rights");
     }
 
-    public HostFunction fdFilestatGet() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_filestat_get: " + Arrays.toString(args));
-                    int fd = args[0].asInt();
-                    int buf = args[1].asInt();
+    @WasmExport
+    public int fdFilestatGet(Memory memory, int fd, int buf) {
+        logger.infof("fd_filestat_get: [%s, %s]", fd, buf);
 
-                    var descriptor = descriptors.get(fd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        var descriptor = descriptors.get(fd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    if ((descriptor instanceof InStream) || (descriptor instanceof OutStream)) {
-                        Map<String, Object> attributes =
-                                Map.of(
-                                        "dev", 0L,
-                                        "ino", 0L,
-                                        "nlink", 1L,
-                                        "size", 0L,
-                                        "lastAccessTime", FileTime.from(Instant.EPOCH),
-                                        "lastModifiedTime", FileTime.from(Instant.EPOCH),
-                                        "ctime", FileTime.from(Instant.EPOCH));
-                        writeFileStat(
-                                instance.memory(), buf, attributes, WasiFileType.CHARACTER_DEVICE);
-                        return wasiResult(WasiErrno.ESUCCESS);
-                    }
+        if ((descriptor instanceof InStream) || (descriptor instanceof OutStream)) {
+            Map<String, Object> attributes =
+                    Map.of(
+                            "dev", 0L,
+                            "ino", 0L,
+                            "nlink", 1L,
+                            "size", 0L,
+                            "lastAccessTime", FileTime.from(Instant.EPOCH),
+                            "lastModifiedTime", FileTime.from(Instant.EPOCH),
+                            "ctime", FileTime.from(Instant.EPOCH));
+            writeFileStat(memory, buf, attributes, WasiFileType.CHARACTER_DEVICE);
+            return wasiResult(WasiErrno.ESUCCESS);
+        }
 
-                    Path path;
-                    if (descriptor instanceof OpenFile) {
-                        path = ((OpenFile) descriptor).path();
-                    } else if (descriptor instanceof OpenDirectory) {
-                        path = ((OpenDirectory) descriptor).path();
-                    } else {
-                        throw unhandledDescriptor(descriptor);
-                    }
+        Path path;
+        if (descriptor instanceof OpenFile) {
+            path = ((OpenFile) descriptor).path();
+        } else if (descriptor instanceof OpenDirectory) {
+            path = ((OpenDirectory) descriptor).path();
+        } else {
+            throw unhandledDescriptor(descriptor);
+        }
 
-                    Map<String, Object> attributes;
-                    try {
-                        attributes = Files.readAttributes(path, "unix:*");
-                    } catch (UnsupportedOperationException e) {
-                        return wasiResult(WasiErrno.ENOTSUP);
-                    } catch (IOException e) {
-                        return wasiResult(WasiErrno.EIO);
-                    }
+        Map<String, Object> attributes;
+        try {
+            attributes = Files.readAttributes(path, "unix:*");
+        } catch (UnsupportedOperationException e) {
+            return wasiResult(WasiErrno.ENOTSUP);
+        } catch (IOException e) {
+            return wasiResult(WasiErrno.EIO);
+        }
 
-                    writeFileStat(instance.memory(), buf, attributes, getFileType(attributes));
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "fd_filestat_get",
-                List.of(I32, I32),
-                List.of(I32));
+        writeFileStat(memory, buf, attributes, getFileType(attributes));
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction fdFilestatSetSize() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_filestat_set_size: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: fd_filestat_set_size");
-                    // return new Value[] { Value.i32(0) };
-                },
-                "wasi_snapshot_preview1",
-                "fd_filestat_set_size",
-                List.of(I32, I64),
-                List.of(I32));
+    @WasmExport
+    public int fdFilestatSetSize(int fd, long size) {
+        logger.infof("fd_filestat_set_size: [%s, %s]", fd, size);
+        throw new WASMRuntimeException("We don't yet support this WASI call: fd_filestat_set_size");
     }
 
-    public HostFunction fdFilestatSetTimes() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_filestat_set_times: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: fd_filestat_set_times");
-                    // return new Value[] { Value.i32(0) };
-                },
-                "wasi_snapshot_preview1",
-                "fd_filestat_set_times",
-                List.of(I32, I64, I64, I32),
-                List.of(I32));
+    @WasmExport
+    public int fdFilestatSetTimes(int fd, long accessTime, long modifiedTime, int fstFlags) {
+        logger.infof(
+                "fd_filestat_set_times: [%s, %s, %s, %s]", fd, accessTime, modifiedTime, fstFlags);
+        throw new WASMRuntimeException(
+                "We don't yet support this WASI call: fd_filestat_set_times");
     }
 
-    public HostFunction fdPread() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_pread: " + Arrays.toString(args));
-                    throw new WASMRuntimeException("We don't yet support this WASI call: fd_pread");
-                    // return new Value[] { Value.i32(0) };
-                },
-                "wasi_snapshot_preview1",
-                "fd_pread",
-                List.of(I32, I32, I32, I64, I32),
-                List.of(I32));
+    @WasmExport
+    public int fdPread(int fd, int iovs, int iovsLen, long offset, int nreadPtr) {
+        logger.infof("fd_pread: [%s, %s, %s, %s, %s]", fd, iovs, iovsLen, offset, nreadPtr);
+        throw new WASMRuntimeException("We don't yet support this WASI call: fd_pread");
     }
 
-    public HostFunction fdPrestatDirName() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_prestat_dir_name: " + Arrays.toString(args));
-                    int fd = args[0].asInt();
-                    int path = args[1].asInt();
-                    int pathLen = args[2].asInt();
+    @WasmExport
+    public int fdPrestatDirName(Memory memory, int fd, int path, int pathLen) {
+        logger.infof("fd_prestat_dir_name: [%s, %s, %s]", fd, path, pathLen);
+        var descriptor = descriptors.get(fd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    var descriptor = descriptors.get(fd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        if (!(descriptor instanceof PreopenedDirectory)) {
+            return wasiResult(WasiErrno.EBADF);
+        }
+        byte[] name = ((PreopenedDirectory) descriptor).name();
 
-                    if (!(descriptor instanceof PreopenedDirectory)) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
-                    byte[] name = ((PreopenedDirectory) descriptor).name();
+        if (pathLen < name.length) {
+            return wasiResult(WasiErrno.ENAMETOOLONG);
+        }
 
-                    if (pathLen < name.length) {
-                        return wasiResult(WasiErrno.ENAMETOOLONG);
-                    }
-
-                    instance.memory().write(path, name);
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "fd_prestat_dir_name",
-                List.of(I32, I32, I32),
-                List.of(I32));
+        memory.write(path, name);
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction fdPrestatGet() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_prestat_get: " + Arrays.toString(args));
-                    int fd = args[0].asInt();
-                    int buf = args[1].asInt();
+    @WasmExport
+    public int fdPrestatGet(Memory memory, int fd, int buf) {
+        logger.infof("fd_prestat_get: [%s, %s]", fd, buf);
+        var descriptor = descriptors.get(fd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    var descriptor = descriptors.get(fd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        if (!(descriptor instanceof PreopenedDirectory)) {
+            return wasiResult(WasiErrno.EBADF);
+        }
+        int length = ((PreopenedDirectory) descriptor).name().length;
 
-                    if (!(descriptor instanceof PreopenedDirectory)) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
-                    int length = ((PreopenedDirectory) descriptor).name().length;
-
-                    Memory memory = instance.memory();
-                    memory.writeI32(buf, 0); // preopentype::dir
-                    memory.writeI32(buf + 4, length);
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "fd_prestat_get",
-                List.of(I32, I32),
-                List.of(I32));
+        memory.writeI32(buf, 0); // preopentype::dir
+        memory.writeI32(buf + 4, length);
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction fdPwrite() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_pwrite: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: fd_pwrite");
-                    // return new Value[] { Value.i32(0) };
-                },
-                "wasi_snapshot_preview1",
-                "fd_pwrite",
-                List.of(I32, I32, I32, I64, I32),
-                List.of(I32));
+    @WasmExport
+    public int fdPwrite(int fd, int iovs, int iovsLen, long offset, int nwrittenPtr) {
+        logger.infof("fd_pwrite: [%s, %s, %s, %s, %s]", fd, iovs, iovsLen, offset, nwrittenPtr);
+        throw new WASMRuntimeException("We don't yet support this WASI call: fd_pwrite");
     }
 
-    public HostFunction fdRead() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_read: " + Arrays.toString(args));
-                    var fd = args[0].asInt();
-                    var iovs = args[1].asInt();
-                    var iovsLen = args[2].asInt();
-                    var nreadPtr = args[3].asInt();
+    @WasmExport
+    public int fdRead(Memory memory, int fd, int iovs, int iovsLen, int nreadPtr) {
+        logger.infof("fd_read: [%s, %s, %s, %s]", fd, iovs, iovsLen, nreadPtr);
+        var descriptor = descriptors.get(fd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    var descriptor = descriptors.get(fd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        if (descriptor instanceof OutStream) {
+            return wasiResult(WasiErrno.EBADF);
+        }
+        if (descriptor instanceof Directory) {
+            return wasiResult(WasiErrno.EISDIR);
+        }
+        if (!(descriptor instanceof DataReader)) {
+            throw unhandledDescriptor(descriptor);
+        }
+        DataReader reader = (DataReader) descriptor;
 
-                    if (descriptor instanceof OutStream) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
-                    if (descriptor instanceof Directory) {
-                        return wasiResult(WasiErrno.EISDIR);
-                    }
-                    if (!(descriptor instanceof DataReader)) {
-                        throw unhandledDescriptor(descriptor);
-                    }
-                    DataReader reader = (DataReader) descriptor;
+        int totalRead = 0;
+        for (var i = 0; i < iovsLen; i++) {
+            int base = iovs + (i * 8);
+            int iovBase = memory.readI32(base).asInt();
+            var iovLen = memory.readI32(base + 4).asInt();
+            try {
+                byte[] data = new byte[iovLen];
+                int read = reader.read(data);
+                if (read < 0) {
+                    break;
+                }
+                memory.write(iovBase, data, 0, read);
+                totalRead += read;
+                if (read < iovLen) {
+                    break;
+                }
+            } catch (IOException e) {
+                return wasiResult(WasiErrno.EIO);
+            }
+        }
 
-                    int totalRead = 0;
-                    Memory memory = instance.memory();
-                    for (var i = 0; i < iovsLen; i++) {
-                        int base = iovs + (i * 8);
-                        int iovBase = memory.readI32(base).asInt();
-                        var iovLen = memory.readI32(base + 4).asInt();
-                        try {
-                            byte[] data = new byte[iovLen];
-                            int read = reader.read(data);
-                            if (read < 0) {
-                                break;
-                            }
-                            memory.write(iovBase, data, 0, read);
-                            totalRead += read;
-                            if (read < iovLen) {
-                                break;
-                            }
-                        } catch (IOException e) {
-                            return wasiResult(WasiErrno.EIO);
-                        }
-                    }
-
-                    memory.writeI32(nreadPtr, totalRead);
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "fd_read",
-                List.of(I32, I32, I32, I32),
-                List.of(I32));
+        memory.writeI32(nreadPtr, totalRead);
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction fdReaddir() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_readdir: " + Arrays.toString(args));
-                    int dirFd = args[0].asInt();
-                    int buf = args[1].asInt();
-                    int bufLen = args[2].asInt();
-                    long cookie = args[3].asLong();
-                    int bufUsedPtr = args[4].asInt();
+    @WasmExport
+    public int fdReaddir(
+            Memory memory, int dirFd, int buf, int bufLen, long cookie, int bufUsedPtr) {
+        logger.infof("fd_readdir: [%s, %s, %s, %s, %s]", dirFd, buf, bufLen, cookie, bufUsedPtr);
+        if (cookie < 0) {
+            return wasiResult(WasiErrno.EINVAL);
+        }
 
-                    if (cookie < 0) {
-                        return wasiResult(WasiErrno.EINVAL);
-                    }
+        var descriptor = descriptors.get(dirFd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    var descriptor = descriptors.get(dirFd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        Path directoryPath;
+        if (descriptor instanceof Directory) {
+            directoryPath = ((Directory) descriptor).path();
+        } else {
+            return wasiResult(WasiErrno.ENOTDIR);
+        }
 
-                    Path directoryPath;
-                    if (descriptor instanceof Directory) {
-                        directoryPath = ((Directory) descriptor).path();
-                    } else {
-                        return wasiResult(WasiErrno.ENOTDIR);
-                    }
+        int used = 0;
+        try (Stream<Path> stream = Files.list(directoryPath)) {
+            Stream<Path> special =
+                    Stream.of(directoryPath.resolve("."), directoryPath.resolve(".."));
+            Iterator<Path> iterator = Stream.concat(special, stream).skip(cookie).iterator();
+            while (iterator.hasNext()) {
+                Path entryPath = iterator.next();
+                byte[] name = entryPath.getFileName().toString().getBytes(UTF_8);
+                cookie++;
 
-                    Memory memory = instance.memory();
-                    int used = 0;
-                    try (Stream<Path> stream = Files.list(directoryPath)) {
-                        Stream<Path> special =
-                                Stream.of(directoryPath.resolve("."), directoryPath.resolve(".."));
-                        Iterator<Path> iterator =
-                                Stream.concat(special, stream).skip(cookie).iterator();
-                        while (iterator.hasNext()) {
-                            Path entryPath = iterator.next();
-                            byte[] name = entryPath.getFileName().toString().getBytes(UTF_8);
-                            cookie++;
+                Map<String, Object> attributes;
+                try {
+                    attributes = Files.readAttributes(entryPath, "unix:*");
+                } catch (UnsupportedOperationException e) {
+                    return wasiResult(WasiErrno.ENOTSUP);
+                } catch (NoSuchFileException e) {
+                    continue;
+                }
 
-                            Map<String, Object> attributes;
-                            try {
-                                attributes = Files.readAttributes(entryPath, "unix:*");
-                            } catch (UnsupportedOperationException e) {
-                                return wasiResult(WasiErrno.ENOTSUP);
-                            } catch (NoSuchFileException e) {
-                                continue;
-                            }
+                ByteBuffer entry =
+                        ByteBuffer.allocate(24 + name.length).order(ByteOrder.LITTLE_ENDIAN);
+                entry.putLong(0, cookie);
+                entry.putLong(8, ((Number) attributes.get("ino")).longValue());
+                entry.putInt(16, name.length);
+                entry.put(20, (byte) getFileType(attributes).value());
+                entry.position(24);
+                entry.put(name);
 
-                            ByteBuffer entry =
-                                    ByteBuffer.allocate(24 + name.length)
-                                            .order(ByteOrder.LITTLE_ENDIAN);
-                            entry.putLong(0, cookie);
-                            entry.putLong(8, ((Number) attributes.get("ino")).longValue());
-                            entry.putInt(16, name.length);
-                            entry.put(20, (byte) getFileType(attributes).value());
-                            entry.position(24);
-                            entry.put(name);
+                int writeSize = min(entry.capacity(), bufLen - used);
+                memory.write(buf + used, entry.array(), 0, writeSize);
+                used += writeSize;
 
-                            int writeSize = min(entry.capacity(), bufLen - used);
-                            memory.write(buf + used, entry.array(), 0, writeSize);
-                            used += writeSize;
+                if (used == bufLen) {
+                    break;
+                }
+            }
+        } catch (NotDirectoryException e) {
+            return wasiResult(WasiErrno.ENOTDIR);
+        } catch (NoSuchFileException e) {
+            return wasiResult(WasiErrno.ENOENT);
+        } catch (IOException e) {
+            return wasiResult(WasiErrno.EIO);
+        }
 
-                            if (used == bufLen) {
-                                break;
-                            }
-                        }
-                    } catch (NotDirectoryException e) {
-                        return wasiResult(WasiErrno.ENOTDIR);
-                    } catch (NoSuchFileException e) {
-                        return wasiResult(WasiErrno.ENOENT);
-                    } catch (IOException e) {
-                        return wasiResult(WasiErrno.EIO);
-                    }
-
-                    memory.writeI32(bufUsedPtr, used);
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "fd_readdir",
-                List.of(I32, I32, I32, I64, I32),
-                List.of(I32));
+        memory.writeI32(bufUsedPtr, used);
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction fdRenumber() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_renumber: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: fd_renumber");
-                },
-                "wasi_snapshot_preview1",
-                "fd_renumber",
-                List.of(I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int fdRenumber(int from, int to) {
+        logger.infof("fd_renumber: [%s, %s]", from, to);
+        throw new WASMRuntimeException("We don't yet support this WASI call: fd_renumber");
     }
 
-    public HostFunction fdSeek() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_seek: " + Arrays.toString(args));
-                    int fd = args[0].asInt();
-                    long offset = args[1].asLong();
-                    int whence = args[2].asInt();
-                    int newOffsetPtr = args[3].asInt();
+    @WasmExport
+    public int fdSeek(Memory memory, int fd, long offset, int whence, int newOffsetPtr) {
+        logger.infof("fd_seek: [%s, %s, %s, %s]", fd, offset, whence, newOffsetPtr);
+        if (whence < 0 || whence > 2) {
+            return wasiResult(WasiErrno.EINVAL);
+        }
 
-                    if (whence < 0 || whence > 2) {
-                        return wasiResult(WasiErrno.EINVAL);
-                    }
+        var descriptor = descriptors.get(fd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    var descriptor = descriptors.get(fd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        if ((descriptor instanceof InStream) || (descriptor instanceof OutStream)) {
+            return wasiResult(WasiErrno.ESPIPE);
+        }
+        if (descriptor instanceof Directory) {
+            return wasiResult(WasiErrno.EISDIR);
+        }
+        if (!(descriptor instanceof OpenFile)) {
+            throw unhandledDescriptor(descriptor);
+        }
+        SeekableByteChannel channel = ((OpenFile) descriptor).channel();
 
-                    if ((descriptor instanceof InStream) || (descriptor instanceof OutStream)) {
-                        return wasiResult(WasiErrno.ESPIPE);
-                    }
-                    if (descriptor instanceof Directory) {
-                        return wasiResult(WasiErrno.EISDIR);
-                    }
-                    if (!(descriptor instanceof OpenFile)) {
-                        throw unhandledDescriptor(descriptor);
-                    }
-                    SeekableByteChannel channel = ((OpenFile) descriptor).channel();
+        long newOffset;
+        try {
+            switch (whence) {
+                case WasiWhence.SET:
+                    channel.position(offset);
+                    break;
+                case WasiWhence.CUR:
+                    channel.position(channel.position() + offset);
+                    break;
+                case WasiWhence.END:
+                    channel.position(channel.size() + offset);
+                    break;
+            }
+            newOffset = channel.position();
+        } catch (IllegalArgumentException e) {
+            return wasiResult(WasiErrno.EINVAL);
+        } catch (IOException e) {
+            return wasiResult(WasiErrno.EIO);
+        }
 
-                    long newOffset;
-                    try {
-                        switch (whence) {
-                            case WasiWhence.SET:
-                                channel.position(offset);
-                                break;
-                            case WasiWhence.CUR:
-                                channel.position(channel.position() + offset);
-                                break;
-                            case WasiWhence.END:
-                                channel.position(channel.size() + offset);
-                                break;
-                        }
-                        newOffset = channel.position();
-                    } catch (IllegalArgumentException e) {
-                        return wasiResult(WasiErrno.EINVAL);
-                    } catch (IOException e) {
-                        return wasiResult(WasiErrno.EIO);
-                    }
-
-                    instance.memory().writeLong(newOffsetPtr, newOffset);
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "fd_seek",
-                List.of(I32, I64, I32, I32),
-                List.of(I32));
+        memory.writeLong(newOffsetPtr, newOffset);
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction fdSync() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_sync: " + Arrays.toString(args));
-                    throw new WASMRuntimeException("We don't yet support this WASI call: fd_sync");
-                    // return new Value[] {Value.i32(0)};
-                },
-                "wasi_snapshot_preview1",
-                "fd_sync",
-                List.of(I32),
-                List.of(I32));
+    @WasmExport
+    public int fdSync(int fd) {
+        logger.infof("fd_sync: [%s]", fd);
+        throw new WASMRuntimeException("We don't yet support this WASI call: fd_sync");
     }
 
-    public HostFunction fdTell() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_tell: " + Arrays.toString(args));
-                    int fd = args[0].asInt();
-                    int offsetPtr = args[1].asInt();
+    @WasmExport
+    public int fdTell(Memory memory, int fd, int offsetPtr) {
+        logger.infof("fd_tell: [%s, %s]", fd, offsetPtr);
+        var descriptor = descriptors.get(fd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    var descriptor = descriptors.get(fd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        if ((descriptor instanceof InStream) || (descriptor instanceof OutStream)) {
+            return wasiResult(WasiErrno.ESPIPE);
+        }
+        if (descriptor instanceof Directory) {
+            return wasiResult(WasiErrno.EISDIR);
+        }
+        if (!(descriptor instanceof OpenFile)) {
+            throw unhandledDescriptor(descriptor);
+        }
+        SeekableByteChannel channel = ((OpenFile) descriptor).channel();
 
-                    if ((descriptor instanceof InStream) || (descriptor instanceof OutStream)) {
-                        return wasiResult(WasiErrno.ESPIPE);
-                    }
-                    if (descriptor instanceof Directory) {
-                        return wasiResult(WasiErrno.EISDIR);
-                    }
-                    if (!(descriptor instanceof OpenFile)) {
-                        throw unhandledDescriptor(descriptor);
-                    }
-                    SeekableByteChannel channel = ((OpenFile) descriptor).channel();
+        long offset;
+        try {
+            offset = channel.position();
+        } catch (IOException e) {
+            return wasiResult(WasiErrno.EIO);
+        }
 
-                    long offset;
-                    try {
-                        offset = channel.position();
-                    } catch (IOException e) {
-                        return wasiResult(WasiErrno.EIO);
-                    }
-
-                    instance.memory().writeLong(offsetPtr, offset);
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "fd_tell",
-                List.of(I32, I32),
-                List.of(I32));
+        memory.writeLong(offsetPtr, offset);
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction fdWrite() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("fd_write: " + Arrays.toString(args));
-                    var fd = args[0].asInt();
-                    var iovs = args[1].asInt();
-                    var iovsLen = args[2].asInt();
-                    var nwrittenPtr = args[3].asInt();
+    @WasmExport
+    public int fdWrite(Memory memory, int fd, int iovs, int iovsLen, int nwrittenPtr) {
+        logger.infof("fd_write: [%s, %s, %s, %s]", fd, iovs, iovsLen, nwrittenPtr);
+        var descriptor = descriptors.get(fd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    var descriptor = descriptors.get(fd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        if (descriptor instanceof InStream) {
+            return wasiResult(WasiErrno.EBADF);
+        }
+        if (descriptor instanceof Directory) {
+            return wasiResult(WasiErrno.EISDIR);
+        }
+        if (!(descriptor instanceof DataWriter)) {
+            throw unhandledDescriptor(descriptor);
+        }
+        DataWriter writer = (DataWriter) descriptor;
 
-                    if (descriptor instanceof InStream) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
-                    if (descriptor instanceof Directory) {
-                        return wasiResult(WasiErrno.EISDIR);
-                    }
-                    if (!(descriptor instanceof DataWriter)) {
-                        throw unhandledDescriptor(descriptor);
-                    }
-                    DataWriter writer = (DataWriter) descriptor;
+        var totalWritten = 0;
+        for (var i = 0; i < iovsLen; i++) {
+            var base = iovs + (i * 8);
+            var iovBase = memory.readI32(base).asInt();
+            var iovLen = memory.readI32(base + 4).asInt();
+            var data = memory.readBytes(iovBase, iovLen);
+            try {
+                int written = writer.write(data);
+                totalWritten += written;
+                if (written < iovLen) {
+                    break;
+                }
+            } catch (IOException e) {
+                return wasiResult(WasiErrno.EIO);
+            }
+        }
 
-                    var totalWritten = 0;
-                    Memory memory = instance.memory();
-                    for (var i = 0; i < iovsLen; i++) {
-                        var base = iovs + (i * 8);
-                        var iovBase = memory.readI32(base).asInt();
-                        var iovLen = memory.readI32(base + 4).asInt();
-                        var data = memory.readBytes(iovBase, iovLen);
-                        try {
-                            int written = writer.write(data);
-                            totalWritten += written;
-                            if (written < iovLen) {
-                                break;
-                            }
-                        } catch (IOException e) {
-                            return wasiResult(WasiErrno.EIO);
-                        }
-                    }
-
-                    memory.writeI32(nwrittenPtr, totalWritten);
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "fd_write",
-                List.of(I32, I32, I32, I32),
-                List.of(I32));
+        memory.writeI32(nwrittenPtr, totalWritten);
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction pathCreateDirectory() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("path_create_directory: " + Arrays.toString(args));
-                    int dirFd = args[0].asInt();
-                    int pathPtr = args[1].asInt();
-                    int pathLen = args[2].asInt();
+    @WasmExport
+    public int pathCreateDirectory(Memory memory, int dirFd, int pathPtr, int pathLen) {
+        logger.infof("path_create_directory: [%s, %s, %s]", dirFd, pathPtr, pathLen);
+        var descriptor = descriptors.get(dirFd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    var descriptor = descriptors.get(dirFd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        if (!(descriptor instanceof Directory)) {
+            return wasiResult(WasiErrno.ENOTDIR);
+        }
+        Path directory = ((Directory) descriptor).path();
 
-                    if (!(descriptor instanceof Directory)) {
-                        return wasiResult(WasiErrno.ENOTDIR);
-                    }
-                    Path directory = ((Directory) descriptor).path();
+        String rawPath = memory.readString(pathPtr, pathLen);
+        Path path = resolvePath(directory, rawPath);
+        if (path == null) {
+            return wasiResult(WasiErrno.EACCES);
+        }
 
-                    String rawPath = instance.memory().readString(pathPtr, pathLen);
-                    Path path = resolvePath(directory, rawPath);
-                    if (path == null) {
-                        return wasiResult(WasiErrno.EACCES);
-                    }
-
-                    try {
-                        Files.createDirectory(path);
-                    } catch (FileAlreadyExistsException e) {
-                        return wasiResult(WasiErrno.EEXIST);
-                    } catch (NoSuchFileException e) {
-                        return wasiResult(WasiErrno.ENOENT);
-                    } catch (IOException e) {
-                        return wasiResult(WasiErrno.EIO);
-                    }
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "path_create_directory",
-                List.of(I32, I32, I32),
-                List.of(I32));
+        try {
+            Files.createDirectory(path);
+        } catch (FileAlreadyExistsException e) {
+            return wasiResult(WasiErrno.EEXIST);
+        } catch (NoSuchFileException e) {
+            return wasiResult(WasiErrno.ENOENT);
+        } catch (IOException e) {
+            return wasiResult(WasiErrno.EIO);
+        }
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction pathFilestatGet() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("path_filestat_get: " + Arrays.toString(args));
-                    int dirFd = args[0].asInt();
-                    int lookupFlags = args[1].asInt();
-                    int pathPtr = args[2].asInt();
-                    int pathLen = args[3].asInt();
-                    int buf = args[4].asInt();
+    @WasmExport
+    public int pathFilestatGet(
+            Memory memory, int dirFd, int lookupFlags, int pathPtr, int pathLen, int buf) {
+        logger.infof(
+                "path_filestat_get: [%s, %s, %s, %s, %s]",
+                dirFd, lookupFlags, pathPtr, pathLen, buf);
+        var descriptor = descriptors.get(dirFd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    var descriptor = descriptors.get(dirFd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        if (!(descriptor instanceof Directory)) {
+            return wasiResult(WasiErrno.ENOTDIR);
+        }
+        Path directory = ((Directory) descriptor).path();
 
-                    if (!(descriptor instanceof Directory)) {
-                        return wasiResult(WasiErrno.ENOTDIR);
-                    }
-                    Path directory = ((Directory) descriptor).path();
+        String rawPath = memory.readString(pathPtr, pathLen);
+        Path path = resolvePath(directory, rawPath);
+        if (path == null) {
+            return wasiResult(WasiErrno.EACCES);
+        }
 
-                    Memory memory = instance.memory();
-                    String rawPath = memory.readString(pathPtr, pathLen);
-                    Path path = resolvePath(directory, rawPath);
-                    if (path == null) {
-                        return wasiResult(WasiErrno.EACCES);
-                    }
+        LinkOption[] linkOptions = toLinkOptions(lookupFlags);
 
-                    LinkOption[] linkOptions = toLinkOptions(lookupFlags);
+        Map<String, Object> attributes;
+        try {
+            attributes = Files.readAttributes(path, "unix:*", linkOptions);
+        } catch (UnsupportedOperationException e) {
+            return wasiResult(WasiErrno.ENOTSUP);
+        } catch (NoSuchFileException e) {
+            return wasiResult(WasiErrno.ENOENT);
+        } catch (IOException e) {
+            return wasiResult(WasiErrno.EIO);
+        }
 
-                    Map<String, Object> attributes;
-                    try {
-                        attributes = Files.readAttributes(path, "unix:*", linkOptions);
-                    } catch (UnsupportedOperationException e) {
-                        return wasiResult(WasiErrno.ENOTSUP);
-                    } catch (NoSuchFileException e) {
-                        return wasiResult(WasiErrno.ENOENT);
-                    } catch (IOException e) {
-                        return wasiResult(WasiErrno.EIO);
-                    }
+        writeFileStat(memory, buf, attributes, getFileType(attributes));
 
-                    writeFileStat(memory, buf, attributes, getFileType(attributes));
-
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "path_filestat_get",
-                List.of(I32, I32, I32, I32, I32),
-                List.of(I32));
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction pathFilestatSetTimes() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("path_filestat_set_times: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: path_filestat_set_times");
-                },
-                "wasi_snapshot_preview1",
-                "path_filestat_set_times",
-                List.of(I32, I32, I32, I32, I64, I64, I32),
-                List.of(I32));
+    @WasmExport
+    public int pathFilestatSetTimes(
+            int fd,
+            int lookupFlags,
+            int pathPtr,
+            int pathLen,
+            long accessTime,
+            long modifiedTime,
+            int fstFlags) {
+        logger.infof(
+                "path_filestat_set_times: [%s, %s, %s, %s, %s, %s, %s]",
+                fd, lookupFlags, pathPtr, pathLen, accessTime, modifiedTime, fstFlags);
+        throw new WASMRuntimeException(
+                "We don't yet support this WASI call: path_filestat_set_size");
     }
 
-    public HostFunction pathLink() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("path_link: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: path_link");
-                },
-                "wasi_snapshot_preview1",
-                "path_link",
-                List.of(I32, I32, I32, I32, I32, I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int pathLink(
+            int oldFd,
+            int oldFlags,
+            int oldPathPtr,
+            int oldPathLen,
+            int newFd,
+            int newPathPtr,
+            int newPathLen) {
+        logger.infof(
+                "path_link: [%s, %s, %s, %s, %s, %s, %s]",
+                oldFd, oldFlags, oldPathPtr, oldPathLen, newFd, newPathPtr, newPathLen);
+        throw new WASMRuntimeException("We don't yet support this WASI call: path_link");
     }
 
-    public HostFunction pathOpen() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("path_open: " + Arrays.toString(args));
-                    int dirFd = args[0].asInt();
-                    int lookupFlags = args[1].asInt();
-                    int pathPtr = args[2].asInt();
-                    int pathLen = args[3].asInt();
-                    int openFlags = args[4].asInt();
-                    // long rightsBase = args[5].asLong();
-                    // long rightsInheriting = args[6].asLong();
-                    int fdFlags = args[7].asInt();
-                    int fdPtr = args[8].asInt();
+    @WasmExport
+    public int pathOpen(
+            Memory memory,
+            int dirFd,
+            int lookupFlags,
+            int pathPtr,
+            int pathLen,
+            int openFlags,
+            long rightsBase,
+            long rightsInheriting,
+            int fdFlags,
+            int fdPtr) {
+        logger.infof(
+                "path_open: [%s, %s, %s, %s, %s, %s, %s, %s, %s]",
+                dirFd,
+                lookupFlags,
+                pathPtr,
+                pathLen,
+                openFlags,
+                rightsBase,
+                rightsInheriting,
+                fdFlags,
+                fdPtr);
+        var descriptor = descriptors.get(dirFd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    var descriptor = descriptors.get(dirFd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        if (!(descriptor instanceof Directory)) {
+            return wasiResult(WasiErrno.ENOTDIR);
+        }
+        Path directory = ((Directory) descriptor).path();
 
-                    if (!(descriptor instanceof Directory)) {
-                        return wasiResult(WasiErrno.ENOTDIR);
-                    }
-                    Path directory = ((Directory) descriptor).path();
+        String rawPath = memory.readString(pathPtr, pathLen);
+        Path path = resolvePath(directory, rawPath);
+        if (path == null) {
+            return wasiResult(WasiErrno.EACCES);
+        }
 
-                    Memory memory = instance.memory();
-                    String rawPath = memory.readString(pathPtr, pathLen);
-                    Path path = resolvePath(directory, rawPath);
-                    if (path == null) {
-                        return wasiResult(WasiErrno.EACCES);
-                    }
+        LinkOption[] linkOptions = toLinkOptions(lookupFlags);
 
-                    LinkOption[] linkOptions = toLinkOptions(lookupFlags);
+        if (Files.isDirectory(path, linkOptions)) {
+            int fd = descriptors.allocate(new OpenDirectory(path));
+            memory.writeI32(fdPtr, fd);
+            return wasiResult(WasiErrno.ESUCCESS);
+        }
 
-                    if (Files.isDirectory(path, linkOptions)) {
-                        int fd = descriptors.allocate(new OpenDirectory(path));
-                        memory.writeI32(fdPtr, fd);
-                        return wasiResult(WasiErrno.ESUCCESS);
-                    }
+        if (flagSet(openFlags, WasiOpenFlags.DIRECTORY) && Files.exists(path, linkOptions)) {
+            return wasiResult(WasiErrno.ENOTDIR);
+        }
 
-                    if (flagSet(openFlags, WasiOpenFlags.DIRECTORY)
-                            && Files.exists(path, linkOptions)) {
-                        return wasiResult(WasiErrno.ENOTDIR);
-                    }
+        Set<OpenOption> openOptions = new HashSet<>(Arrays.asList(linkOptions));
 
-                    Set<OpenOption> openOptions = new HashSet<>(Arrays.asList(linkOptions));
+        boolean append = flagSet(fdFlags, WasiFdFlags.APPEND);
+        boolean truncate = flagSet(openFlags, WasiOpenFlags.TRUNC);
 
-                    boolean append = flagSet(fdFlags, WasiFdFlags.APPEND);
-                    boolean truncate = flagSet(openFlags, WasiOpenFlags.TRUNC);
+        if (append && truncate) {
+            return wasiResult(WasiErrno.ENOTSUP);
+        }
+        if (!append) {
+            openOptions.add(StandardOpenOption.READ);
+        }
+        openOptions.add(StandardOpenOption.WRITE);
 
-                    if (append && truncate) {
-                        return wasiResult(WasiErrno.ENOTSUP);
-                    }
-                    if (!append) {
-                        openOptions.add(StandardOpenOption.READ);
-                    }
-                    openOptions.add(StandardOpenOption.WRITE);
+        if (flagSet(openFlags, WasiOpenFlags.CREAT)) {
+            if (flagSet(openFlags, WasiOpenFlags.EXCL)) {
+                openOptions.add(StandardOpenOption.CREATE_NEW);
+            } else {
+                openOptions.add(StandardOpenOption.CREATE);
+            }
+        }
+        if (truncate) {
+            openOptions.add(StandardOpenOption.TRUNCATE_EXISTING);
+        }
+        if (append) {
+            openOptions.add(StandardOpenOption.APPEND);
+        }
+        if (flagSet(fdFlags, WasiFdFlags.SYNC)) {
+            openOptions.add(StandardOpenOption.SYNC);
+        }
+        if (flagSet(fdFlags, WasiFdFlags.DSYNC)) {
+            openOptions.add(StandardOpenOption.DSYNC);
+        }
+        // ignore WasiFdFlags.RSYNC and WasiFdFlags.NONBLOCK
 
-                    if (flagSet(openFlags, WasiOpenFlags.CREAT)) {
-                        if (flagSet(openFlags, WasiOpenFlags.EXCL)) {
-                            openOptions.add(StandardOpenOption.CREATE_NEW);
-                        } else {
-                            openOptions.add(StandardOpenOption.CREATE);
-                        }
-                    }
-                    if (truncate) {
-                        openOptions.add(StandardOpenOption.TRUNCATE_EXISTING);
-                    }
-                    if (append) {
-                        openOptions.add(StandardOpenOption.APPEND);
-                    }
-                    if (flagSet(fdFlags, WasiFdFlags.SYNC)) {
-                        openOptions.add(StandardOpenOption.SYNC);
-                    }
-                    if (flagSet(fdFlags, WasiFdFlags.DSYNC)) {
-                        openOptions.add(StandardOpenOption.DSYNC);
-                    }
-                    // ignore WasiFdFlags.RSYNC and WasiFdFlags.NONBLOCK
+        int fd;
+        try {
+            SeekableByteChannel channel = Files.newByteChannel(path, openOptions);
+            fd = descriptors.allocate(new OpenFile(path, channel, fdFlags));
+        } catch (FileAlreadyExistsException e) {
+            return wasiResult(WasiErrno.EEXIST);
+        } catch (NoSuchFileException e) {
+            return wasiResult(WasiErrno.ENOENT);
+        } catch (IOException e) {
+            return wasiResult(WasiErrno.EIO);
+        }
 
-                    int fd;
-                    try {
-                        SeekableByteChannel channel = Files.newByteChannel(path, openOptions);
-                        fd = descriptors.allocate(new OpenFile(path, channel, fdFlags));
-                    } catch (FileAlreadyExistsException e) {
-                        return wasiResult(WasiErrno.EEXIST);
-                    } catch (NoSuchFileException e) {
-                        return wasiResult(WasiErrno.ENOENT);
-                    } catch (IOException e) {
-                        return wasiResult(WasiErrno.EIO);
-                    }
-
-                    memory.writeI32(fdPtr, fd);
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "path_open",
-                List.of(I32, I32, I32, I32, I32, I64, I64, I32, I32),
-                List.of(I32));
+        memory.writeI32(fdPtr, fd);
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction pathReadlink() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("path_readlink: " + Arrays.toString(args));
-                    // int dirFd = args[0].asInt();
-                    // int pathPtr = args[1].asInt();
-                    // int pathLen = args[2].asInt();
-                    // int buf = args[3].asInt();
-                    // int bufLen = args[4].asInt();
-                    // int bufUsed = args[5].asInt();
-
-                    // Memory memory = instance.memory();
-                    // String rawPath = memory.readString(pathPtr, pathLen);
-
-                    return wasiResult(WasiErrno.EINVAL);
-                },
-                "wasi_snapshot_preview1",
-                "path_readlink",
-                List.of(I32, I32, I32, I32, I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int pathReadlink(int dirFd, int pathPtr, int pathLen, int buf, int bufLen, int bufUsed) {
+        logger.infof(
+                "path_readlink: [%s, %s, %s, %s, %s, %s]",
+                dirFd, pathPtr, pathLen, buf, bufLen, bufUsed);
+        throw new WASMRuntimeException("We don't yet support this WASI call: path_readlink");
     }
 
-    public HostFunction pathRemoveDirectory() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("path_remove_directory: " + Arrays.toString(args));
-                    int dirFd = args[0].asInt();
-                    int pathPtr = args[1].asInt();
-                    int pathLen = args[2].asInt();
+    @WasmExport
+    public int pathRemoveDirectory(Memory memory, int dirFd, int pathPtr, int pathLen) {
+        logger.infof("path_remove_directory: [%s, %s, %s]", dirFd, pathPtr, pathLen);
+        var descriptor = descriptors.get(dirFd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    var descriptor = descriptors.get(dirFd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        if (!(descriptor instanceof Directory)) {
+            return wasiResult(WasiErrno.ENOTDIR);
+        }
+        Path directory = ((Directory) descriptor).path();
 
-                    if (!(descriptor instanceof Directory)) {
-                        return wasiResult(WasiErrno.ENOTDIR);
-                    }
-                    Path directory = ((Directory) descriptor).path();
+        String rawPath = memory.readString(pathPtr, pathLen);
+        Path path = resolvePath(directory, rawPath);
+        if (path == null) {
+            return wasiResult(WasiErrno.EACCES);
+        }
 
-                    String rawPath = instance.memory().readString(pathPtr, pathLen);
-                    Path path = resolvePath(directory, rawPath);
-                    if (path == null) {
-                        return wasiResult(WasiErrno.EACCES);
-                    }
-
-                    try {
-                        var attributes =
-                                Files.readAttributes(
-                                        path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-                        if (!attributes.isDirectory()) {
-                            return wasiResult(WasiErrno.ENOTDIR);
-                        }
-                        Files.delete(path);
-                    } catch (NoSuchFileException e) {
-                        return wasiResult(WasiErrno.ENOENT);
-                    } catch (DirectoryNotEmptyException e) {
-                        return wasiResult(WasiErrno.ENOTEMPTY);
-                    } catch (IOException e) {
-                        return wasiResult(WasiErrno.EIO);
-                    }
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "path_remove_directory",
-                List.of(I32, I32, I32),
-                List.of(I32));
+        try {
+            var attributes =
+                    Files.readAttributes(
+                            path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            if (!attributes.isDirectory()) {
+                return wasiResult(WasiErrno.ENOTDIR);
+            }
+            Files.delete(path);
+        } catch (NoSuchFileException e) {
+            return wasiResult(WasiErrno.ENOENT);
+        } catch (DirectoryNotEmptyException e) {
+            return wasiResult(WasiErrno.ENOTEMPTY);
+        } catch (IOException e) {
+            return wasiResult(WasiErrno.EIO);
+        }
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction pathRename() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("path_rename: " + Arrays.toString(args));
-                    int oldFd = args[0].asInt();
-                    int oldPathPtr = args[1].asInt();
-                    int oldPathLen = args[2].asInt();
-                    int newFd = args[3].asInt();
-                    int newPathPtr = args[4].asInt();
-                    int newPathLen = args[5].asInt();
+    @WasmExport
+    public int pathRename(
+            Memory memory,
+            int oldFd,
+            int oldPathPtr,
+            int oldPathLen,
+            int newFd,
+            int newPathPtr,
+            int newPathLen) {
+        logger.infof(
+                "path_rename: [%s, %s, %s, %s, %s, %s]",
+                oldFd, oldPathPtr, oldPathLen, newFd, newPathPtr, newPathLen);
+        var oldDescriptor = descriptors.get(oldFd);
+        if (oldDescriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
+        if (!(oldDescriptor instanceof Directory)) {
+            return wasiResult(WasiErrno.ENOTDIR);
+        }
+        Path oldDirectory = ((Directory) oldDescriptor).path();
 
-                    var oldDescriptor = descriptors.get(oldFd);
-                    if (oldDescriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
-                    if (!(oldDescriptor instanceof Directory)) {
-                        return wasiResult(WasiErrno.ENOTDIR);
-                    }
-                    Path oldDirectory = ((Directory) oldDescriptor).path();
+        var newDescriptor = descriptors.get(newFd);
+        if (newDescriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
+        if (!(newDescriptor instanceof Directory)) {
+            return wasiResult(WasiErrno.ENOTDIR);
+        }
+        Path newDirectory = ((Directory) newDescriptor).path();
 
-                    var newDescriptor = descriptors.get(newFd);
-                    if (newDescriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
-                    if (!(newDescriptor instanceof Directory)) {
-                        return wasiResult(WasiErrno.ENOTDIR);
-                    }
-                    Path newDirectory = ((Directory) newDescriptor).path();
+        String oldRawPath = memory.readString(oldPathPtr, oldPathLen);
+        Path oldPath = resolvePath(oldDirectory, oldRawPath);
+        if (oldPath == null) {
+            return wasiResult(WasiErrno.EACCES);
+        }
 
-                    String oldRawPath = instance.memory().readString(oldPathPtr, oldPathLen);
-                    Path oldPath = resolvePath(oldDirectory, oldRawPath);
-                    if (oldPath == null) {
-                        return wasiResult(WasiErrno.EACCES);
-                    }
+        String newRawPath = memory.readString(newPathPtr, newPathLen);
+        Path newPath = resolvePath(newDirectory, newRawPath);
+        if (newPath == null) {
+            return wasiResult(WasiErrno.EACCES);
+        }
 
-                    String newRawPath = instance.memory().readString(newPathPtr, newPathLen);
-                    Path newPath = resolvePath(newDirectory, newRawPath);
-                    if (newPath == null) {
-                        return wasiResult(WasiErrno.EACCES);
-                    }
+        if (Files.isDirectory(oldPath) && Files.isRegularFile(newPath, LinkOption.NOFOLLOW_LINKS)) {
+            return wasiResult(WasiErrno.ENOTDIR);
+        }
+        if (Files.isRegularFile(oldPath, LinkOption.NOFOLLOW_LINKS) && Files.isDirectory(newPath)) {
+            return wasiResult(WasiErrno.EISDIR);
+        }
 
-                    if (Files.isDirectory(oldPath)
-                            && Files.isRegularFile(newPath, LinkOption.NOFOLLOW_LINKS)) {
-                        return wasiResult(WasiErrno.ENOTDIR);
-                    }
-                    if (Files.isRegularFile(oldPath, LinkOption.NOFOLLOW_LINKS)
-                            && Files.isDirectory(newPath)) {
-                        return wasiResult(WasiErrno.EISDIR);
-                    }
-
-                    try {
-                        Files.move(
-                                oldPath,
-                                newPath,
-                                StandardCopyOption.REPLACE_EXISTING,
-                                StandardCopyOption.ATOMIC_MOVE,
-                                StandardCopyOption.COPY_ATTRIBUTES);
-                    } catch (UnsupportedOperationException | AtomicMoveNotSupportedException e) {
-                        return wasiResult(WasiErrno.ENOTSUP);
-                    } catch (NoSuchFileException e) {
-                        return wasiResult(WasiErrno.ENOENT);
-                    } catch (DirectoryNotEmptyException e) {
-                        return wasiResult(WasiErrno.ENOTEMPTY);
-                    } catch (IOException e) {
-                        return wasiResult(WasiErrno.EIO);
-                    }
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "path_rename",
-                List.of(I32, I32, I32, I32, I32, I32),
-                List.of(I32));
+        try {
+            Files.move(
+                    oldPath,
+                    newPath,
+                    StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.COPY_ATTRIBUTES);
+        } catch (UnsupportedOperationException | AtomicMoveNotSupportedException e) {
+            return wasiResult(WasiErrno.ENOTSUP);
+        } catch (NoSuchFileException e) {
+            return wasiResult(WasiErrno.ENOENT);
+        } catch (DirectoryNotEmptyException e) {
+            return wasiResult(WasiErrno.ENOTEMPTY);
+        } catch (IOException e) {
+            return wasiResult(WasiErrno.EIO);
+        }
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction pathSymlink() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("path_symlink: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: path_symlink");
-                },
-                "wasi_snapshot_preview1",
-                "path_symlink",
-                List.of(I32, I32, I32, I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int pathSymlink(
+            int oldPathPtr, int oldPathLen, int dirFd, int newPathPtr, int newPathLen) {
+        logger.infof(
+                "path_symlink: [%s, %s, %s, %s, %s]",
+                oldPathPtr, oldPathLen, dirFd, newPathPtr, newPathLen);
+        throw new WASMRuntimeException("We don't yet support this WASI call: path_symlink");
     }
 
-    public HostFunction pathUnlinkFile() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("path_unlink_file: " + Arrays.toString(args));
-                    int dirFd = args[0].asInt();
-                    int pathPtr = args[1].asInt();
-                    int pathLen = args[2].asInt();
+    @WasmExport
+    public int pathUnlinkFile(Memory memory, int dirFd, int pathPtr, int pathLen) {
+        logger.infof("path_unlink_file: [%s, %s, %s]", dirFd, pathPtr, pathLen);
+        var descriptor = descriptors.get(dirFd);
+        if (descriptor == null) {
+            return wasiResult(WasiErrno.EBADF);
+        }
 
-                    var descriptor = descriptors.get(dirFd);
-                    if (descriptor == null) {
-                        return wasiResult(WasiErrno.EBADF);
-                    }
+        if (!(descriptor instanceof Directory)) {
+            return wasiResult(WasiErrno.ENOTDIR);
+        }
+        Path directory = ((Directory) descriptor).path();
 
-                    if (!(descriptor instanceof Directory)) {
-                        return wasiResult(WasiErrno.ENOTDIR);
-                    }
-                    Path directory = ((Directory) descriptor).path();
+        String rawPath = memory.readString(pathPtr, pathLen);
+        Path path = resolvePath(directory, rawPath);
+        if (path == null) {
+            return wasiResult(WasiErrno.EACCES);
+        }
 
-                    String rawPath = instance.memory().readString(pathPtr, pathLen);
-                    Path path = resolvePath(directory, rawPath);
-                    if (path == null) {
-                        return wasiResult(WasiErrno.EACCES);
-                    }
-
-                    try {
-                        var attributes =
-                                Files.readAttributes(
-                                        path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-                        if (attributes.isDirectory()) {
-                            return wasiResult(WasiErrno.EISDIR);
-                        }
-                        if (rawPath.endsWith("/")) {
-                            return wasiResult(WasiErrno.ENOTDIR);
-                        }
-                        Files.delete(path);
-                    } catch (NoSuchFileException e) {
-                        return wasiResult(WasiErrno.ENOENT);
-                    } catch (IOException e) {
-                        return wasiResult(WasiErrno.EIO);
-                    }
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "path_unlink_file",
-                List.of(I32, I32, I32),
-                List.of(I32));
+        try {
+            var attributes =
+                    Files.readAttributes(
+                            path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            if (attributes.isDirectory()) {
+                return wasiResult(WasiErrno.EISDIR);
+            }
+            if (rawPath.endsWith("/")) {
+                return wasiResult(WasiErrno.ENOTDIR);
+            }
+            Files.delete(path);
+        } catch (NoSuchFileException e) {
+            return wasiResult(WasiErrno.ENOENT);
+        } catch (IOException e) {
+            return wasiResult(WasiErrno.EIO);
+        }
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction pollOneoff() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("poll_oneoff: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: poll_oneoff");
-                },
-                "wasi_snapshot_preview1",
-                "poll_oneoff",
-                List.of(I32, I32, I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int pollOneoff(int inPtr, int outPtr, int nsubscriptions, int neventsPtr) {
+        logger.infof("poll_oneoff: [%s, %s, %s, %s]", inPtr, outPtr, nsubscriptions, neventsPtr);
+        throw new WASMRuntimeException("We don't yet support this WASI call: poll_oneoff");
     }
 
-    public HostFunction procExit() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("proc_exit: " + Arrays.toString(args));
-                    int code = args[0].asInt();
-                    throw new WasiExitException(code);
-                },
-                "wasi_snapshot_preview1",
-                "proc_exit",
-                List.of(I32),
-                List.of());
+    @WasmExport
+    public void procExit(int code) {
+        logger.infof("proc_exit: [%s]", code);
+        throw new WasiExitException(code);
     }
 
-    public HostFunction procRaise() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("proc_raise: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: proc_raise");
-                },
-                "wasi_snapshot_preview1",
-                "proc_raise",
-                List.of(I32),
-                List.of(I32));
+    @WasmExport
+    public int procRaise(int sig) {
+        logger.infof("proc_raise: [%s]", sig);
+        throw new WASMRuntimeException("We don't yet support this WASI call: proc_raise");
     }
 
-    public HostFunction randomGet() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("random_get: " + Arrays.toString(args));
-                    int buf = args[0].asInt();
-                    int bufLen = args[1].asInt();
+    @WasmExport
+    public int randomGet(Memory memory, int buf, int bufLen) {
+        logger.infof("random_get: [%s, %s]", buf, bufLen);
+        if (bufLen < 0) {
+            return wasiResult(WasiErrno.EINVAL);
+        }
+        if (bufLen >= 100_000) {
+            throw new WASMRuntimeException("random_get: bufLen must be < 100_000");
+        }
 
-                    if (bufLen < 0) {
-                        return wasiResult(WasiErrno.EINVAL);
-                    }
-                    if (bufLen >= 100_000) {
-                        throw new WASMRuntimeException("random_get: bufLen must be < 100_000");
-                    }
-
-                    byte[] data = new byte[bufLen];
-                    new SecureRandom().nextBytes(data);
-                    instance.memory().write(buf, data);
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "random_get",
-                List.of(I32, I32),
-                List.of(I32));
+        byte[] data = new byte[bufLen];
+        new SecureRandom().nextBytes(data);
+        memory.write(buf, data);
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction resetAdapterState() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("reset_adapter_state: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: reset_adapter_state");
-                },
-                "wasi_snapshot_preview1",
-                "reset_adapter_state",
-                List.of(),
-                List.of());
+    @WasmExport
+    public void resetAdapterState() {
+        logger.info("reset_adapter_state");
+        throw new WASMRuntimeException("We don't yet support this WASI call: reset_adapter_state");
     }
 
-    public HostFunction schedYield() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("sched_yield: " + Arrays.toString(args));
-                    // do nothing here
-                    return wasiResult(WasiErrno.ESUCCESS);
-                },
-                "wasi_snapshot_preview1",
-                "sched_yield",
-                List.of(),
-                List.of(I32));
+    @WasmExport
+    public int schedYield() {
+        logger.info("sched_yield");
+        // do nothing here
+        return wasiResult(WasiErrno.ESUCCESS);
     }
 
-    public HostFunction setAllocationState() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("set_allocation_state: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: set_allocation_state");
-                },
-                "wasi_snapshot_preview1",
-                "set_allocation_state",
-                List.of(I32),
-                List.of());
+    @WasmExport
+    public void setAllocationState(int state) {
+        logger.infof("set_allocation_state: [%s]", state);
+        throw new WASMRuntimeException("We don't yet support this WASI call: set_allocation_state");
     }
 
-    public HostFunction setStatePtr() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("set_state_ptr: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: set_state_ptr");
-                },
-                "wasi_snapshot_preview1",
-                "set_state_ptr",
-                List.of(I32),
-                List.of());
+    @WasmExport
+    public void setStatePtr(int state) {
+        logger.infof("set_state_ptr: [%s]", state);
+        throw new WASMRuntimeException("We don't yet support this WASI call: set_state_ptr");
     }
 
-    public HostFunction sockAccept() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("sock_accept: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: sock_accept");
-                },
-                "wasi_snapshot_preview1",
-                "sock_accept",
-                List.of(I32, I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int sockAccept(int sock, int fdFlags, int roFdPtr) {
+        logger.infof("sock_accept: [%s, %s, %s]", sock, fdFlags, roFdPtr);
+        throw new WASMRuntimeException("We don't yet support this WASI call: sock_accept");
     }
 
-    public HostFunction sockRecv() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("sock_recv: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: sock_recv");
-                },
-                "wasi_snapshot_preview1",
-                "sock_recv",
-                List.of(I32, I32, I32, I32, I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int sockRecv(
+            int sock, int riDataPtr, int riDataLen, int riFlags, int roDataLenPtr, int roFlagsPtr) {
+        logger.infof(
+                "sock_recv: [%s, %s, %s, %s, %s, %s]",
+                sock, riDataPtr, riDataLen, riFlags, roDataLenPtr, roFlagsPtr);
+        throw new WASMRuntimeException("We don't yet support this WASI call: sock_recv");
     }
 
-    public HostFunction sockSend() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("sock_send: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: sock_send");
-                },
-                "wasi_snapshot_preview1",
-                "sock_send",
-                List.of(I32, I32, I32, I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int sockSend(int sock, int siDataPtr, int siDataLen, int siFlags, int retDataLenPtr) {
+        logger.infof(
+                "sock_send: [%s, %s, %s, %s, %s]",
+                sock, siDataPtr, siDataLen, siFlags, retDataLenPtr);
+        throw new WASMRuntimeException("We don't yet support this WASI call: sock_send");
     }
 
-    public HostFunction sockShutdown() {
-        return new HostFunction(
-                (Instance instance, Value... args) -> {
-                    logger.info("sock_shutdown: " + Arrays.toString(args));
-                    throw new WASMRuntimeException(
-                            "We don't yet support this WASI call: sock_shutdown");
-                },
-                "wasi_snapshot_preview1",
-                "sock_shutdown",
-                List.of(I32, I32),
-                List.of(I32));
+    @WasmExport
+    public int sockShutdown(int sock, int how) {
+        logger.infof("sock_shutdown: [%s, %s]", sock, how);
+        throw new WASMRuntimeException("We don't yet support this WASI call: sock_shutdown");
     }
 
     public HostFunction[] toHostFunctions() {
-        return new HostFunction[] {
-            adapterCloseBadfd(),
-            adapterOpenBadfd(),
-            argsGet(),
-            argsSizesGet(),
-            clockResGet(),
-            clockTimeGet(),
-            environGet(),
-            environSizesGet(),
-            fdAdvise(),
-            fdAllocate(),
-            fdClose(),
-            fdDatasync(),
-            fdFdstatGet(),
-            fdFdstatSetFlags(),
-            fdFdstatSetRights(),
-            fdFilestatGet(),
-            fdFilestatSetSize(),
-            fdFilestatSetTimes(),
-            fdPread(),
-            fdPrestatDirName(),
-            fdPrestatGet(),
-            fdPwrite(),
-            fdRead(),
-            fdReaddir(),
-            fdRenumber(),
-            fdSeek(),
-            fdSync(),
-            fdTell(),
-            fdWrite(),
-            pathCreateDirectory(),
-            pathFilestatGet(),
-            pathFilestatSetTimes(),
-            pathLink(),
-            pathOpen(),
-            pathReadlink(),
-            pathRemoveDirectory(),
-            pathRename(),
-            pathSymlink(),
-            pathUnlinkFile(),
-            pollOneoff(),
-            procExit(),
-            procRaise(),
-            randomGet(),
-            resetAdapterState(),
-            schedYield(),
-            setAllocationState(),
-            setStatePtr(),
-            sockAccept(),
-            sockRecv(),
-            sockSend(),
-            sockShutdown()
-        };
+        return WasiPreview1_ModuleFactory.toHostFunctions(this);
     }
 
-    private Value[] wasiResult(WasiErrno errno) {
+    private int wasiResult(WasiErrno errno) {
         if (errno != WasiErrno.ESUCCESS) {
             logger.info("result = " + errno.name());
         }
-        return new Value[] {Value.i32(errno.value())};
+        return errno.value();
     }
 
     private static Path resolvePath(Path directory, String rawPathString) {


### PR DESCRIPTION
This implements a basic annotation framework, similar to the example shown in #482. It works and could be merged now, with the expectation that we'll try it out with more projects such as SQLite, and eventually extract it as a public interface in its own module.

Ideas for future improvements:

* More argument type conversions. For example, accepting `byte[]` or `String` from `(ptr i32, len i32)` arguments. This gets complicated quickly, but some basic support might cover most use cases.
* Automatic tracing of calls and results, for example, similar to `strace` on Linux. This really needs argument type conversion to be useful, so that the traces can show strings rather than useless pointers.
* Support multiple return values.

I suspect that @andreaTP will dislike the usage of `MethodHandle`. I'm thinking we can convert this to be an annotation processor that generates the `HostFunction[]` adapter, though I'm not sure what the API would look like.

The current implementation doesn't change the API of `WasiPreview1`: users create it and call `toHostFunctions()`. An annotation processor would generate a new class, and I don't think it's possible for `WasiPreview1` to statically reference that class (as it won't exist when `WasiPreview1` is compiled). I see a couple of options:

* `WasiPreview1#toHostFunctions` would call some utility method like `getHostFunctions(WasiPreview1.class)` which would reflectively find the generated class.
* Change callers to use directly reference the generated class:
  ```java
  WasiPreview1 instance = new WasiPreview1(logger, opts);
  HostFunctions[] functions = WasiPreview1.HostFunctions.get(instance);
  ```

Neither one seems ideal, so I'm hoping someone has better suggestions, if we want to go down the annotation processor route. I'm personally fine with the `MethodHandle` approach, as this is quite common in these sorts of frameworks, but there are advantages to generating code at compile time.