### PR TITLE
Add annotation support for string parameters

### DIFF
--- a/function-annotations/src/main/java/com/dylibso/chicory/function/annotations/Buffer.java
+++ b/function-annotations/src/main/java/com/dylibso/chicory/function/annotations/Buffer.java
@@ -1,0 +1,10 @@
+package com.dylibso.chicory.function.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface Buffer {}

--- a/function-annotations/src/main/java/com/dylibso/chicory/function/annotations/CString.java
+++ b/function-annotations/src/main/java/com/dylibso/chicory/function/annotations/CString.java
@@ -1,0 +1,10 @@
+package com.dylibso.chicory.function.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface CString {}

--- a/function-processor/src/main/java/com/dylibso/chicory/function/processor/FunctionProcessor.java
+++ b/function-processor/src/main/java/com/dylibso/chicory/function/processor/FunctionProcessor.java
@@ -6,6 +6,8 @@ import static java.lang.String.format;
 import static javax.tools.Diagnostic.Kind.ERROR;
 import static javax.tools.Diagnostic.Kind.NOTE;
 
+import com.dylibso.chicory.function.annotations.Buffer;
+import com.dylibso.chicory.function.annotations.CString;
 import com.dylibso.chicory.function.annotations.HostModule;
 import com.dylibso.chicory.function.annotations.WasmExport;
 import com.github.javaparser.ast.ArrayCreationLevel;
@@ -137,10 +139,7 @@ public final class FunctionProcessor extends AbstractProcessor {
         NodeList<Expression> paramTypes = new NodeList<>();
         NodeList<Expression> arguments = new NodeList<>();
         for (VariableElement parameter : executable.getParameters()) {
-            var argExpr =
-                    new ArrayAccessExpr(
-                            new NameExpr("args"),
-                            new IntegerLiteralExpr(String.valueOf(paramTypes.size())));
+            var argExpr = argExpr(paramTypes.size());
             switch (parameter.asType().toString()) {
                 case "int":
                     paramTypes.add(valueType("I32"));
@@ -157,6 +156,31 @@ public final class FunctionProcessor extends AbstractProcessor {
                 case "double":
                     paramTypes.add(valueType("F64"));
                     arguments.add(new MethodCallExpr(argExpr, "asDouble"));
+                    break;
+                case "java.lang.String":
+                    if (annotatedWith(parameter, Buffer.class)) {
+                        var lenExpr = argExpr(paramTypes.size() + 1);
+                        paramTypes.add(valueType("I32"));
+                        paramTypes.add(valueType("I32"));
+                        arguments.add(
+                                new MethodCallExpr(
+                                        new MethodCallExpr(new NameExpr("instance"), "memory"),
+                                        "readString",
+                                        new NodeList<>(
+                                                new MethodCallExpr(argExpr, "asInt"),
+                                                new MethodCallExpr(lenExpr, "asInt"))));
+                    } else if (annotatedWith(parameter, CString.class)) {
+                        paramTypes.add(valueType("I32"));
+                        paramTypes.add(valueType("I32"));
+                        arguments.add(
+                                new MethodCallExpr(
+                                        new MethodCallExpr(new NameExpr("instance"), "memory"),
+                                        "readCString",
+                                        new NodeList<>(new MethodCallExpr(argExpr, "asInt"))));
+                    } else {
+                        log(ERROR, "Missing annotation for WASM type: java.lang.String", parameter);
+                        throw new AbortProcessingException();
+                    }
                     break;
                 case "com.dylibso.chicory.runtime.Instance":
                     arguments.add(new NameExpr("instance"));
@@ -264,6 +288,10 @@ public final class FunctionProcessor extends AbstractProcessor {
                 .map(AnnotationMirror::getAnnotationType)
                 .map(TypeMirror::toString)
                 .anyMatch(annotationName::equals);
+    }
+
+    private static Expression argExpr(int n) {
+        return new ArrayAccessExpr(new NameExpr("args"), new IntegerLiteralExpr(String.valueOf(n)));
     }
 
     private static Expression valueType(String type) {

--- a/function-processor/src/test/java/com/dylibso/chicory/function/processor/FunctionProcessorTest.java
+++ b/function-processor/src/test/java/com/dylibso/chicory/function/processor/FunctionProcessorTest.java
@@ -29,16 +29,30 @@ class FunctionProcessorTest {
     }
 
     @Test
-    void invalidParameterType() {
+    void invalidParameterTypeUnsupported() {
         Compilation compilation =
                 javac().withProcessors(new FunctionProcessor())
-                        .compile(JavaFileObjects.forResource("InvalidParameter.java"));
+                        .compile(JavaFileObjects.forResource("InvalidParameterUnsupported.java"));
 
         assertThat(compilation).failed();
 
         assertThat(compilation)
-                .hadErrorContaining("Unsupported WASM type: java.lang.String")
-                .inFile(JavaFileObjects.forResource("InvalidParameter.java"))
+                .hadErrorContaining("Unsupported WASM type: java.math.BigDecimal")
+                .inFile(JavaFileObjects.forResource("InvalidParameterUnsupported.java"))
+                .onLineContaining("public long square(BigDecimal x) {");
+    }
+
+    @Test
+    void invalidParameterTypeString() {
+        Compilation compilation =
+                javac().withProcessors(new FunctionProcessor())
+                        .compile(JavaFileObjects.forResource("InvalidParameterString.java"));
+
+        assertThat(compilation).failed();
+
+        assertThat(compilation)
+                .hadErrorContaining("Missing annotation for WASM type: java.lang.String")
+                .inFile(JavaFileObjects.forResource("InvalidParameterString.java"))
                 .onLineContaining("public long concat(int a, String s) {");
     }
 

--- a/function-processor/src/test/resources/InvalidParameterString.java
+++ b/function-processor/src/test/resources/InvalidParameterString.java
@@ -1,0 +1,13 @@
+package chicory.testing;
+
+import com.dylibso.chicory.function.annotations.HostModule;
+import com.dylibso.chicory.function.annotations.WasmExport;
+
+@HostModule("bad_param")
+public final class InvalidParameterString {
+
+    @WasmExport
+    public long concat(int a, String s) {
+        return (s + a).length();
+    }
+}

--- a/function-processor/src/test/resources/InvalidParameterUnsupported.java
+++ b/function-processor/src/test/resources/InvalidParameterUnsupported.java
@@ -2,12 +2,13 @@ package chicory.testing;
 
 import com.dylibso.chicory.function.annotations.HostModule;
 import com.dylibso.chicory.function.annotations.WasmExport;
+import java.math.BigDecimal;
 
 @HostModule("bad_param")
-public final class InvalidParameter {
+public final class InvalidParameterUnsupported {
 
     @WasmExport
-    public long concat(int a, String s) {
-        return (s + a).length();
+    public long square(BigDecimal x) {
+        return x.pow(2);
     }
 }

--- a/function-processor/src/test/resources/Simple.java
+++ b/function-processor/src/test/resources/Simple.java
@@ -1,17 +1,40 @@
 package chicory.testing;
 
+import static java.util.Objects.requireNonNull;
+
+import com.dylibso.chicory.function.annotations.Buffer;
+import com.dylibso.chicory.function.annotations.CString;
 import com.dylibso.chicory.function.annotations.HostModule;
 import com.dylibso.chicory.function.annotations.WasmExport;
 import com.dylibso.chicory.runtime.HostFunction;
 import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
+import java.util.Random;
 
 @HostModule("simple")
 public final class Simple {
 
+    private final Random random;
+
+    public Simple(Random random) {
+        this.random = requireNonNull(random);
+    }
+
     @WasmExport
-    public void print(Memory memory, int ptr, int len) {
-        System.out.println(memory.readString(ptr, len));
+    public void print(@Buffer String data) {
+        System.out.println(data);
+    }
+
+    @WasmExport
+    public void printx(@CString String data) {
+        System.out.println(data);
+    }
+
+    @WasmExport
+    public void randomGet(Memory memory, int ptr, int len) {
+        byte[] data = new byte[len];
+        random.nextBytes(data);
+        memory.write(ptr, data);
     }
 
     @WasmExport

--- a/function-processor/src/test/resources/SimpleGenerated.java
+++ b/function-processor/src/test/resources/SimpleGenerated.java
@@ -16,11 +16,32 @@ public final class Simple_ModuleFactory {
         return new HostFunction[] {
             new HostFunction(
                     (Instance instance, Value... args) -> {
-                        functions.print(instance.memory(), args[0].asInt(), args[1].asInt());
+                        functions.print(
+                                instance.memory().readString(args[0].asInt(), args[1].asInt()));
                         return null;
                     },
                     "simple",
                     "print",
+                    List.of(ValueType.I32, ValueType.I32),
+                    List.of()
+            ),
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        functions.printx(instance.memory().readCString(args[0].asInt()));
+                        return null;
+                    },
+                    "simple",
+                    "printx",
+                    List.of(ValueType.I32, ValueType.I32),
+                    List.of()
+            ),
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        functions.randomGet(instance.memory(), args[0].asInt(), args[1].asInt());
+                        return null;
+                    },
+                    "simple",
+                    "random_get",
                     List.of(ValueType.I32, ValueType.I32),
                     List.of()
             ),


### PR DESCRIPTION
The `@Buffer` annotation assumes a `POINTER_LENGTH` layout, which seems common. If needed, we can add an enum to support a `LENGTH_POINTER` layout, with the default being the former.

The `@Buffer` annotation could also be extended to support `byte[]`, additional character sets for strings, etc.

While there is lots more that we could do with layouts, this seems like a good step to handle a common case. It makes the logging for WASI significantly more useable, as we now have strings instead of pointers. This would allow us to add automatic logging/tracing support to the binding generator.