### PR TITLE
Fix nested classes and unnamed package names for FunctionProcessor

### DIFF
--- a/function-processor/src/test/java/com/dylibso/chicory/function/processor/FunctionProcessorTest.java
+++ b/function-processor/src/test/java/com/dylibso/chicory/function/processor/FunctionProcessorTest.java
@@ -15,6 +15,8 @@ class FunctionProcessorTest {
                 javac().withProcessors(new FunctionProcessor())
                         .compile(
                                 JavaFileObjects.forResource("BasicMath.java"),
+                                JavaFileObjects.forResource("Box.java"),
+                                JavaFileObjects.forResource("NoPackage.java"),
                                 JavaFileObjects.forResource("Simple.java"));
 
         assertThat(compilation).succeededWithoutWarnings();
@@ -26,6 +28,14 @@ class FunctionProcessorTest {
         assertThat(compilation)
                 .generatedSourceFile("chicory.testing.Simple_ModuleFactory")
                 .hasSourceEquivalentTo(JavaFileObjects.forResource("SimpleGenerated.java"));
+
+        assertThat(compilation)
+                .generatedSourceFile("chicory.testing.Nested_ModuleFactory")
+                .hasSourceEquivalentTo(JavaFileObjects.forResource("NestedGenerated.java"));
+
+        assertThat(compilation)
+                .generatedSourceFile("NoPackage_ModuleFactory")
+                .hasSourceEquivalentTo(JavaFileObjects.forResource("NoPackageGenerated.java"));
     }
 
     @Test

--- a/function-processor/src/test/resources/Box.java
+++ b/function-processor/src/test/resources/Box.java
@@ -1,0 +1,29 @@
+package chicory.testing;
+
+import com.dylibso.chicory.function.annotations.HostModule;
+import com.dylibso.chicory.function.annotations.WasmExport;
+import com.dylibso.chicory.runtime.HostFunction;
+import com.dylibso.chicory.runtime.Memory;
+import com.dylibso.chicory.wasm.exceptions.ChicoryException;
+
+public class Box {
+
+    @HostModule("nested")
+    public final class Nested {
+
+        @WasmExport
+        public void print(Memory memory, int ptr, int len) {
+            System.out.println(memory.readString(ptr, len));
+        }
+
+        @WasmExport
+        public void exit() {
+            throw new ChicoryException("exit");
+        }
+
+        public HostFunction[] toHostFunctions() {
+            return Nested_ModuleFactory.toHostFunctions(this);
+        }
+    }
+
+}

--- a/function-processor/src/test/resources/NestedGenerated.java
+++ b/function-processor/src/test/resources/NestedGenerated.java
@@ -1,0 +1,40 @@
+package chicory.testing;
+
+import chicory.testing.Box.Nested;
+import com.dylibso.chicory.runtime.HostFunction;
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasm.types.Value;
+import com.dylibso.chicory.wasm.types.ValueType;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.dylibso.chicory.function.processor.FunctionProcessor")
+public final class Nested_ModuleFactory {
+
+    private Nested_ModuleFactory() {}
+
+    public static HostFunction[] toHostFunctions(Nested functions) {
+        return new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        functions.print(instance.memory(), args[0].asInt(), args[1].asInt());
+                        return null;
+                    },
+                    "nested",
+                    "print",
+                    List.of(ValueType.I32, ValueType.I32),
+                    List.of()
+            ),
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        functions.exit();
+                        return null;
+                    },
+                    "nested",
+                    "exit",
+                    List.of(),
+                    List.of()
+            ),
+        };
+    }
+}

--- a/function-processor/src/test/resources/NoPackage.java
+++ b/function-processor/src/test/resources/NoPackage.java
@@ -1,0 +1,23 @@
+import com.dylibso.chicory.function.annotations.HostModule;
+import com.dylibso.chicory.function.annotations.WasmExport;
+import com.dylibso.chicory.runtime.HostFunction;
+import com.dylibso.chicory.runtime.Memory;
+import com.dylibso.chicory.wasm.exceptions.ChicoryException;
+
+@HostModule("nopackage")
+public final class NoPackage {
+
+    @WasmExport
+    public void print(Memory memory, int ptr, int len) {
+        System.out.println(memory.readString(ptr, len));
+    }
+
+    @WasmExport
+    public void exit() {
+        throw new ChicoryException("exit");
+    }
+
+    public HostFunction[] toHostFunctions() {
+        return NoPackage_ModuleFactory.toHostFunctions(this);
+    }
+}

--- a/function-processor/src/test/resources/NoPackageGenerated.java
+++ b/function-processor/src/test/resources/NoPackageGenerated.java
@@ -1,0 +1,37 @@
+import com.dylibso.chicory.runtime.HostFunction;
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasm.types.Value;
+import com.dylibso.chicory.wasm.types.ValueType;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.dylibso.chicory.function.processor.FunctionProcessor")
+public final class NoPackage_ModuleFactory {
+
+    private Nested_ModuleFactory() {}
+
+    public static HostFunction[] toHostFunctions(NoPackage functions) {
+        return new HostFunction[] {
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        functions.print(instance.memory(), args[0].asInt(), args[1].asInt());
+                        return null;
+                    },
+                    "nopackage",
+                    "print",
+                    List.of(ValueType.I32, ValueType.I32),
+                    List.of()
+            ),
+            new HostFunction(
+                    (Instance instance, Value... args) -> {
+                        functions.exit();
+                        return null;
+                    },
+                    "nopackage",
+                    "exit",
+                    List.of(),
+                    List.of()
+            ),
+        };
+    }
+}


### PR DESCRIPTION
Turns out that `getQualifiedName` is not the proper identifier for the package name to be used