### PR TITLE
Make Instruction class immutable

### DIFF
--- a/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
@@ -102,7 +102,7 @@ final class AotEmitters {
     }
 
     public static void ELEM_DROP(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        int index = (int) ins.operands()[0];
+        int index = (int) ins.operand(0);
         asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
         asm.visitLdcInsn(index);
         asm.visitInsn(Opcodes.ACONST_NULL);
@@ -126,7 +126,7 @@ final class AotEmitters {
     }
 
     public static void CALL(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        int funcId = (int) ins.operands()[0];
+        int funcId = (int) ins.operand(0);
         FunctionType functionType = ctx.functionTypes().get(funcId);
         MethodType methodType = methodTypeFor(functionType);
 
@@ -149,8 +149,8 @@ final class AotEmitters {
     }
 
     public static void CALL_INDIRECT(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        int typeId = (int) ins.operands()[0];
-        int tableIdx = (int) ins.operands()[1];
+        int typeId = (int) ins.operand(0);
+        int tableIdx = (int) ins.operand(1);
         FunctionType functionType = ctx.types()[typeId];
 
         MethodType methodType = callIndirectMethodType(functionType);
@@ -175,7 +175,7 @@ final class AotEmitters {
     }
 
     public static void REF_FUNC(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        asm.visitLdcInsn((int) ins.operands()[0]);
+        asm.visitLdcInsn((int) ins.operand(0));
     }
 
     public static void REF_NULL(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
@@ -187,14 +187,14 @@ final class AotEmitters {
     }
 
     public static void LOCAL_GET(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        var loadIndex = (int) ins.operands()[0];
+        var loadIndex = (int) ins.operand(0);
         var localType = localType(ctx.getType(), ctx.getBody(), loadIndex);
         asm.visitVarInsn(loadTypeOpcode(localType), ctx.localSlotIndex(loadIndex));
         ctx.pushStackSize(stackSize(jvmType(localType)));
     }
 
     public static void LOCAL_SET(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        int index = (int) ins.operands()[0];
+        int index = (int) ins.operand(0);
         var localType = localType(ctx.getType(), ctx.getBody(), index);
         asm.visitVarInsn(storeTypeOpcode(localType), ctx.localSlotIndex(index));
     }
@@ -212,7 +212,7 @@ final class AotEmitters {
     }
 
     public static void GLOBAL_GET(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        int globalIndex = (int) ins.operands()[0];
+        int globalIndex = (int) ins.operand(0);
 
         asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
         asm.visitLdcInsn(globalIndex);
@@ -225,7 +225,7 @@ final class AotEmitters {
     }
 
     public static void GLOBAL_SET(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        int globalIndex = (int) ins.operands()[0];
+        int globalIndex = (int) ins.operand(0);
 
         emitInvokeStatic(asm, boxer(ctx.globalTypes().get(globalIndex)));
         asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
@@ -236,51 +236,51 @@ final class AotEmitters {
     }
 
     public static void TABLE_GET(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        asm.visitLdcInsn((int) ins.operands()[0]);
+        asm.visitLdcInsn((int) ins.operand(0));
         asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
         emitInvokeStatic(asm, TABLE_GET);
     }
 
     public static void TABLE_SET(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        asm.visitLdcInsn((int) ins.operands()[0]);
+        asm.visitLdcInsn((int) ins.operand(0));
         asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
         emitInvokeStatic(asm, TABLE_SET);
     }
 
     public static void TABLE_SIZE(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        asm.visitLdcInsn((int) ins.operands()[0]);
+        asm.visitLdcInsn((int) ins.operand(0));
         asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
         emitInvokeStatic(asm, TABLE_SIZE);
     }
 
     public static void TABLE_GROW(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        asm.visitLdcInsn((int) ins.operands()[0]);
+        asm.visitLdcInsn((int) ins.operand(0));
         asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
         emitInvokeStatic(asm, TABLE_GROW);
     }
 
     public static void TABLE_FILL(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        asm.visitLdcInsn((int) ins.operands()[0]);
+        asm.visitLdcInsn((int) ins.operand(0));
         asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
         emitInvokeStatic(asm, TABLE_FILL);
     }
 
     public static void TABLE_COPY(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        asm.visitLdcInsn((int) ins.operands()[0]);
-        asm.visitLdcInsn((int) ins.operands()[1]);
+        asm.visitLdcInsn((int) ins.operand(0));
+        asm.visitLdcInsn((int) ins.operand(1));
         asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
         emitInvokeStatic(asm, TABLE_COPY);
     }
 
     public static void TABLE_INIT(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        asm.visitLdcInsn((int) ins.operands()[0]);
-        asm.visitLdcInsn((int) ins.operands()[1]);
+        asm.visitLdcInsn((int) ins.operand(0));
+        asm.visitLdcInsn((int) ins.operand(1));
         asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
         emitInvokeStatic(asm, TABLE_INIT);
     }
 
     public static void MEMORY_INIT(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        int segmentId = (int) ins.operands()[0];
+        int segmentId = (int) ins.operand(0);
         asm.visitLdcInsn(segmentId);
         asm.visitVarInsn(Opcodes.ALOAD, ctx.memorySlot());
         emitInvokeStatic(asm, MEMORY_INIT);
@@ -308,7 +308,7 @@ final class AotEmitters {
     }
 
     public static void DATA_DROP(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        int segmentId = (int) ins.operands()[0];
+        int segmentId = (int) ins.operand(0);
         asm.visitVarInsn(Opcodes.ALOAD, ctx.memorySlot());
         asm.visitLdcInsn(segmentId);
         emitInvokeVirtual(asm, MEMORY_DROP);
@@ -323,7 +323,7 @@ final class AotEmitters {
     }
 
     public static void I32_CONST(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        asm.visitLdcInsn((int) ins.operands()[0]);
+        asm.visitLdcInsn((int) ins.operand(0));
     }
 
     public static void I32_MUL(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
@@ -367,7 +367,7 @@ final class AotEmitters {
     }
 
     public static void I64_CONST(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        asm.visitLdcInsn(ins.operands()[0]);
+        asm.visitLdcInsn(ins.operand(0));
     }
 
     public static void I64_EXTEND_I32_S(
@@ -411,7 +411,7 @@ final class AotEmitters {
     }
 
     public static void F32_CONST(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        asm.visitLdcInsn(Float.intBitsToFloat((int) ins.operands()[0]));
+        asm.visitLdcInsn(Float.intBitsToFloat((int) ins.operand(0)));
     }
 
     public static void F32_DEMOTE_F64(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
@@ -439,7 +439,7 @@ final class AotEmitters {
     }
 
     public static void F64_CONST(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
-        asm.visitLdcInsn(Double.longBitsToDouble(ins.operands()[0]));
+        asm.visitLdcInsn(Double.longBitsToDouble(ins.operand(0)));
     }
 
     public static void F64_DIV(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
@@ -574,7 +574,7 @@ final class AotEmitters {
 
     private static void emitLoadOrStore(
             AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm, Method method) {
-        long offset = ins.operands()[1];
+        long offset = ins.operand(1);
 
         if (offset < 0 || offset >= Integer.MAX_VALUE) {
             emitInvokeStatic(asm, THROW_OUT_OF_BOUNDS_MEMORY_ACCESS);

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
@@ -21,6 +21,7 @@ import static com.dylibso.chicory.aot.AotUtil.slotCount;
 import static com.dylibso.chicory.aot.AotUtil.storeTypeOpcode;
 import static com.dylibso.chicory.aot.AotUtil.unboxer;
 import static com.dylibso.chicory.aot.AotUtil.unboxerHandle;
+import static com.dylibso.chicory.wasm.types.Instruction.EMPTY_OPERANDS;
 import static java.lang.invoke.MethodHandles.filterArguments;
 import static java.lang.invoke.MethodHandles.filterReturnValue;
 import static java.lang.invoke.MethodHandles.insertArguments;
@@ -81,7 +82,9 @@ import org.objectweb.asm.util.CheckClassAdapter;
 public final class AotMachine implements Machine {
 
     public static final String DEFAULT_CLASS_NAME = "com.dylibso.chicory.$gen.CompiledModule";
-    private static final Instruction FUNCTION_SCOPE = new Instruction(-1, OpCode.NOP, new long[0]);
+
+    private static final Instruction FUNCTION_SCOPE =
+            new Instruction(-1, OpCode.NOP, EMPTY_OPERANDS);
 
     private final Module module;
     private final Instance instance;
@@ -865,7 +868,7 @@ public final class AotMachine implements Machine {
     }
 
     private FunctionType blockType(Instruction ins) {
-        var typeId = (int) ins.operands()[0];
+        var typeId = (int) ins.operand(0);
         if (typeId == 0x40) {
             return FunctionType.empty();
         }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ConstantEvaluators.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ConstantEvaluators.java
@@ -23,27 +23,27 @@ public final class ConstantEvaluators {
             switch (instruction.opcode()) {
                 case F32_CONST:
                     {
-                        tos = Value.f32(instruction.operands()[0]);
+                        tos = Value.f32(instruction.operand(0));
                         break;
                     }
                 case F64_CONST:
                     {
-                        tos = Value.f64(instruction.operands()[0]);
+                        tos = Value.f64(instruction.operand(0));
                         break;
                     }
                 case I32_CONST:
                     {
-                        tos = Value.i32(instruction.operands()[0]);
+                        tos = Value.i32(instruction.operand(0));
                         break;
                     }
                 case I64_CONST:
                     {
-                        tos = Value.i64(instruction.operands()[0]);
+                        tos = Value.i64(instruction.operand(0));
                         break;
                     }
                 case REF_NULL:
                     {
-                        ValueType vt = ValueType.refTypeForId((int) instruction.operands()[0]);
+                        ValueType vt = ValueType.refTypeForId((int) instruction.operand(0));
                         if (vt == ValueType.ExternRef) {
                             tos = Value.EXTREF_NULL;
                         } else if (vt == ValueType.FuncRef) {
@@ -56,14 +56,14 @@ public final class ConstantEvaluators {
                     }
                 case REF_FUNC:
                     {
-                        var idx = (int) instruction.operands()[0];
+                        var idx = (int) instruction.operand(0);
                         instance.function(idx);
                         tos = Value.funcRef(idx);
                         break;
                     }
                 case GLOBAL_GET:
                     {
-                        var idx = (int) instruction.operands()[0];
+                        var idx = (int) instruction.operand(0);
                         if (idx < instance.imports().globalCount()) {
                             if (instance.imports().global(idx).instance().getMutabilityType()
                                     != MutabilityType.Const) {
@@ -102,7 +102,7 @@ public final class ConstantEvaluators {
     public static Instance computeConstantInstance(Instance instance, List<Instruction> expr) {
         for (Instruction instruction : expr) {
             if (instruction.opcode() == GLOBAL_GET) {
-                return instance.global((int) instruction.operands()[0]).getInstance();
+                return instance.global((int) instruction.operand(0)).getInstance();
             }
         }
         return instance;

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExecutionListener.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExecutionListener.java
@@ -1,6 +1,6 @@
 package com.dylibso.chicory.runtime;
 
-import com.dylibso.chicory.wasm.types.AnnotatedInstruction;
+import com.dylibso.chicory.wasm.types.Instruction;
 
 @FunctionalInterface
 public interface ExecutionListener {
@@ -13,5 +13,5 @@ public interface ExecutionListener {
      *
      * If you have a specific use case for this functionality, please, open an Issue at: https://github.com/dylibso/chicory/issues
      */
-    void onExecution(AnnotatedInstruction instruction, long[] operands, MStack stack);
+    void onExecution(Instruction instruction, MStack stack);
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -12,7 +12,6 @@ import com.dylibso.chicory.wasm.exceptions.UninstantiableException;
 import com.dylibso.chicory.wasm.exceptions.UnlinkableException;
 import com.dylibso.chicory.wasm.types.ActiveDataSegment;
 import com.dylibso.chicory.wasm.types.ActiveElement;
-import com.dylibso.chicory.wasm.types.AnnotatedInstruction;
 import com.dylibso.chicory.wasm.types.DataSegment;
 import com.dylibso.chicory.wasm.types.DeclarativeElement;
 import com.dylibso.chicory.wasm.types.Element;
@@ -344,9 +343,9 @@ public class Instance {
         return imprt.handle().apply(this, args);
     }
 
-    public void onExecution(AnnotatedInstruction instruction, long[] operands, MStack stack) {
+    public void onExecution(Instruction instruction, MStack stack) {
         if (listener != null) {
-            listener.onExecution(instruction, operands, stack);
+            listener.onExecution(instruction, stack);
         }
     }
 

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.dylibso.chicory.wasm.Module;
 import com.dylibso.chicory.wasm.Parser;
 import com.dylibso.chicory.wasm.exceptions.UninstantiableException;
-import com.dylibso.chicory.wasm.types.AnnotatedInstruction;
 import com.dylibso.chicory.wasm.types.MemoryLimits;
 import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
@@ -328,8 +327,7 @@ public class ModuleTest {
         var instance =
                 Instance.builder(loadModule("compiled/iterfact.wat.wasm"))
                         .withUnsafeExecutionListener(
-                                (AnnotatedInstruction instruction, long[] operands, MStack stack) ->
-                                        count.getAndIncrement())
+                                (instruction, stack) -> count.getAndIncrement())
                         .build();
         var iterFact = instance.export("iterFact");
 
@@ -346,11 +344,7 @@ public class ModuleTest {
         var instance =
                 Instance.builder(loadModule("compiled/fac.wat.wasm"))
                         .withUnsafeExecutionListener(
-                                (AnnotatedInstruction instruction,
-                                        long[] operands,
-                                        MStack stack) -> {
-                                    finalStackSize.set(stack.size());
-                                })
+                                (instruction, stack) -> finalStackSize.set(stack.size()))
                         .build();
         var facSsa = instance.export("fac-ssa");
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -5,6 +5,7 @@ import static com.dylibso.chicory.wasm.Encoding.readSigned32Leb128;
 import static com.dylibso.chicory.wasm.Encoding.readSigned64Leb128;
 import static com.dylibso.chicory.wasm.Encoding.readUnsignedLeb128;
 import static com.dylibso.chicory.wasm.WasmLimits.MAX_FUNCTION_LOCALS;
+import static com.dylibso.chicory.wasm.types.Instruction.EMPTY_OPERANDS;
 import static java.util.Objects.requireNonNull;
 
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
@@ -659,7 +660,7 @@ public final class Parser {
                         List.of(
                                 new Instruction(
                                         -1, OpCode.REF_FUNC, new long[] {readVarUInt32(buffer)}),
-                                new Instruction(-1, OpCode.END, new long[0])));
+                                new Instruction(-1, OpCode.END, EMPTY_OPERANDS)));
             }
         }
         if (declarative) {
@@ -791,7 +792,7 @@ public final class Parser {
                         // fallthrough
                     case BR:
                         {
-                            var offset = (int) baseInstruction.operands()[0];
+                            var offset = (int) baseInstruction.operand(0);
                             ControlTree reference = currentControlFlow;
                             while (offset > 0) {
                                 if (reference == null) {
@@ -805,11 +806,11 @@ public final class Parser {
                         }
                     case BR_TABLE:
                         {
-                            var length = baseInstruction.operands().length;
+                            var length = baseInstruction.operandCount();
                             var labelTable = new ArrayList<Integer>();
                             for (var idx = 0; idx < length; idx++) {
                                 labelTable.add(null);
-                                var offset = (int) baseInstruction.operands()[idx];
+                                var offset = (int) baseInstruction.operand(idx);
                                 ControlTree reference = currentControlFlow;
                                 while (offset > 0) {
                                     if (reference == null) {
@@ -921,6 +922,11 @@ public final class Parser {
             default:
                 break;
         }
+
+        if (signature.isEmpty()) {
+            return new Instruction(address, op, EMPTY_OPERANDS);
+        }
+
         var operands = new ArrayList<Long>();
         for (var sig : signature) {
             switch (sig) {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Instruction.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Instruction.java
@@ -3,6 +3,8 @@ package com.dylibso.chicory.wasm.types;
 import java.util.Arrays;
 
 public class Instruction {
+    public static final long[] EMPTY_OPERANDS = new long[0];
+
     private final int address;
     private final OpCode opcode;
     private final long[] operands;
@@ -10,7 +12,7 @@ public class Instruction {
     public Instruction(int address, OpCode opcode, long[] operands) {
         this.address = address;
         this.opcode = opcode;
-        this.operands = operands;
+        this.operands = operands.length == 0 ? EMPTY_OPERANDS : operands.clone();
     }
 
     public int address() {
@@ -22,7 +24,15 @@ public class Instruction {
     }
 
     public long[] operands() {
-        return operands;
+        return operands.clone();
+    }
+
+    public int operandCount() {
+        return operands.length;
+    }
+
+    public long operand(int index) {
+        return operands[index];
     }
 
     @Override

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
@@ -85,9 +85,9 @@ public class ParserTest {
 
             assertTrue(instructions.get(0).toString().contains("0x00000032: I32_CONST [42]"));
             assertEquals(OpCode.I32_CONST, instructions.get(0).opcode());
-            assertEquals(42L, instructions.get(0).operands()[0]);
+            assertEquals(42L, instructions.get(0).operand(0));
             assertEquals(OpCode.CALL, instructions.get(1).opcode());
-            assertEquals(0L, instructions.get(1).operands()[0]);
+            assertEquals(0L, instructions.get(1).operand(0));
             assertEquals(OpCode.END, instructions.get(2).opcode());
         }
     }
@@ -170,9 +170,9 @@ public class ParserTest {
             var module = Parser.parse(is);
             var codeSection = module.codeSection();
             var fbody = codeSection.getFunctionBody(0);
-            var f32 = Float.intBitsToFloat((int) fbody.instructions().get(0).operands()[0]);
+            var f32 = Float.intBitsToFloat((int) fbody.instructions().get(0).operand(0));
             assertEquals(0.12345678f, f32, 0.0);
-            var f64 = Double.longBitsToDouble(fbody.instructions().get(1).operands()[0]);
+            var f64 = Double.longBitsToDouble(fbody.instructions().get(1).operand(0));
             assertEquals(0.123456789012345d, f64, 0.0);
         }
     }
@@ -183,20 +183,20 @@ public class ParserTest {
             var module = Parser.parse(is);
             var codeSection = module.codeSection();
             var fbody = codeSection.getFunctionBody(0);
-            assertEquals(-2147483648L, fbody.instructions().get(0).operands()[0]);
-            assertEquals(0L, fbody.instructions().get(2).operands()[0]);
-            assertEquals(2147483647L, fbody.instructions().get(4).operands()[0]);
-            assertEquals(-9223372036854775808L, fbody.instructions().get(6).operands()[0]);
-            assertEquals(0L, fbody.instructions().get(8).operands()[0]);
-            assertEquals(9223372036854775807L, fbody.instructions().get(10).operands()[0]);
-            assertEquals(-2147483647L, fbody.instructions().get(12).operands()[0]);
-            assertEquals(2147483646L, fbody.instructions().get(14).operands()[0]);
-            assertEquals(-9223372036854775807L, fbody.instructions().get(16).operands()[0]);
-            assertEquals(9223372036854775806L, fbody.instructions().get(18).operands()[0]);
-            assertEquals(-1L, fbody.instructions().get(20).operands()[0]);
-            assertEquals(1L, fbody.instructions().get(22).operands()[0]);
-            assertEquals(-1L, fbody.instructions().get(24).operands()[0]);
-            assertEquals(1L, fbody.instructions().get(26).operands()[0]);
+            assertEquals(-2147483648L, fbody.instructions().get(0).operand(0));
+            assertEquals(0L, fbody.instructions().get(2).operand(0));
+            assertEquals(2147483647L, fbody.instructions().get(4).operand(0));
+            assertEquals(-9223372036854775808L, fbody.instructions().get(6).operand(0));
+            assertEquals(0L, fbody.instructions().get(8).operand(0));
+            assertEquals(9223372036854775807L, fbody.instructions().get(10).operand(0));
+            assertEquals(-2147483647L, fbody.instructions().get(12).operand(0));
+            assertEquals(2147483646L, fbody.instructions().get(14).operand(0));
+            assertEquals(-9223372036854775807L, fbody.instructions().get(16).operand(0));
+            assertEquals(9223372036854775806L, fbody.instructions().get(18).operand(0));
+            assertEquals(-1L, fbody.instructions().get(20).operand(0));
+            assertEquals(1L, fbody.instructions().get(22).operand(0));
+            assertEquals(-1L, fbody.instructions().get(24).operand(0));
+            assertEquals(1L, fbody.instructions().get(26).operand(0));
         }
     }
 


### PR DESCRIPTION
This keeps the `long[]` to avoid boxing, which might have a performance impact for the interpreter. It also adds a constant for the common case of an empty array, which avoids allocations and reduces memory usage.

The extra clone for instructions created during parsing could be eliminated by adding a trusted package-private constructor, but I hope we don't need to optimize to that level.