### PR TITLE
No jgit repo downloaders

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-  #   branches: [ main ]
-  # pull_request:
+    branches: [ main ]
+  pull_request:
 
 permissions:
   contents: read
@@ -24,20 +24,19 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      # Test in CI
-      # - name: Checkout testsuite
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: WebAssembly/testsuite
-      #     path: testsuite
-      #     # The ref needs to stay in sync with the default value in test-gen-plugin
-      #     ref: c2a67a575ddc815ff2212f68301d333e5e30a923
-      # - name: Checkout wasi-testsuite
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: WebAssembly/wasi-testsuite
-      #     path: wasi-testsuite
-      #     ref: prod/testsuite-base
+      - name: Checkout testsuite
+        uses: actions/checkout@v4
+        with:
+          repository: WebAssembly/testsuite
+          path: testsuite
+          # The ref needs to stay in sync with the default value in test-gen-plugin
+          ref: c2a67a575ddc815ff2212f68301d333e5e30a923
+      - name: Checkout wasi-testsuite
+        uses: actions/checkout@v4
+        with:
+          repository: WebAssembly/wasi-testsuite
+          path: wasi-testsuite
+          ref: prod/testsuite-base
       - name: Set up Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
+  #   branches: [ main ]
+  # pull_request:
 
 permissions:
   contents: read
@@ -24,19 +24,20 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - name: Checkout testsuite
-        uses: actions/checkout@v4
-        with:
-          repository: WebAssembly/testsuite
-          path: testsuite
-          # The ref needs to stay in sync with the default value in test-gen-plugin
-          ref: c2a67a575ddc815ff2212f68301d333e5e30a923
-      - name: Checkout wasi-testsuite
-        uses: actions/checkout@v4
-        with:
-          repository: WebAssembly/wasi-testsuite
-          path: wasi-testsuite
-          ref: prod/testsuite-base
+      # Test in CI
+      # - name: Checkout testsuite
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: WebAssembly/testsuite
+      #     path: testsuite
+      #     # The ref needs to stay in sync with the default value in test-gen-plugin
+      #     ref: c2a67a575ddc815ff2212f68301d333e5e30a923
+      # - name: Checkout wasi-testsuite
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: WebAssembly/wasi-testsuite
+      #     path: wasi-testsuite
+      #     ref: prod/testsuite-base
       - name: Set up Java
         uses: actions/setup-java@v4
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <commons-lang.version>3.17.0</commons-lang.version>
     <jackson.version>2.17.2</jackson.version>
     <javaparser.version>3.26.2</javaparser.version>
-    <jgit.version>6.10.0.202406032230-r</jgit.version>
+    <jgit.version>7.0.0.202409031743-r</jgit.version>
     <jmh.version>1.37</jmh.version>
     <junit.version>5.11.0</junit.version>
     <maven-plugin-annotations.version>3.15.0</maven-plugin-annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <commons-lang.version>3.17.0</commons-lang.version>
     <jackson.version>2.17.2</jackson.version>
     <javaparser.version>3.26.2</javaparser.version>
-    <jgit.version>7.0.0.202409031743-r</jgit.version>
+    <zip4j.version>2.11.5</zip4j.version>
     <jmh.version>1.37</jmh.version>
     <junit.version>5.11.0</junit.version>
     <maven-plugin-annotations.version>3.15.0</maven-plugin-annotations.version>

--- a/test-gen-plugin/pom.xml
+++ b/test-gen-plugin/pom.xml
@@ -34,9 +34,9 @@
       <version>${javaparser.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jgit</groupId>
-      <artifactId>org.eclipse.jgit</artifactId>
-      <version>${jgit.version}</version>
+      <groupId>net.lingala.zip4j</groupId>
+      <artifactId>zip4j</artifactId>
+      <version>${zip4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/wasi-test-gen-plugin/pom.xml
+++ b/wasi-test-gen-plugin/pom.xml
@@ -30,14 +30,14 @@
       <version>${javaparser.version}</version>
     </dependency>
     <dependency>
+      <groupId>net.lingala.zip4j</groupId>
+      <artifactId>zip4j</artifactId>
+      <version>${zip4j.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>file-management</artifactId>
       <version>3.1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jgit</groupId>
-      <artifactId>org.eclipse.jgit</artifactId>
-      <version>${jgit.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/wasi-test-gen-plugin/src/main/java/com/dylibso/chicory/maven/WasiTestGenMojo.java
+++ b/wasi-test-gen-plugin/src/main/java/com/dylibso/chicory/maven/WasiTestGenMojo.java
@@ -34,8 +34,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.model.fileset.FileSet;
 import org.apache.maven.shared.model.fileset.util.FileSetManager;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.errors.ConfigInvalidException;
 
 /**
  * This plugin generates test classes for the WASI test suite.
@@ -101,7 +99,7 @@ public class WasiTestGenMojo extends AbstractMojo {
         try {
             new WasiTestSuiteDownloader(log)
                     .downloadTestsuite(testSuiteRepo, testSuiteRepoRef, testSuiteFolder);
-        } catch (GitAPIException | ConfigInvalidException | IOException e) {
+        } catch (IOException e) {
             throw new MojoExecutionException("Failed to download testsuite: " + e.getMessage(), e);
         }
 


### PR DESCRIPTION
JGit [dropped support for Java 11](https://projects.eclipse.org/projects/technology.jgit/releases/7.0.0) with version 7.

It's convenient, but we don't really need it, here I'm replacing it using [this feature](https://docs.github.com/en/repositories/working-with-files/using-files/downloading-source-code-archives#source-code-archive-urls) of GitHub.

Tested on Windows in CI [here](https://github.com/andreaTP/chicory/actions/runs/10809074688)

Supersede #522 