### PR TITLE
Primitive, non boxing, long array based MStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ when we want to go back to Java. This export function takes an `i32` argument. W
 on the return value to get back the Java integer:
 
 ```java
-Value result = iterFact.apply(Value.i32(5))[0];
-System.out.println("Result: " + result.asInt()); // should print 120 (5!)
+long result = iterFact.apply(5)[0];
+System.out.println("Result: " + result); // should print 120 (5!)
 ```
 
 <!--
 ```java
-writeResultFile("factorial.result", "" + result.asInt());
+writeResultFile("factorial.result", "" + result);
 ```
 -->
 
@@ -192,7 +192,7 @@ Memory memory = instance.memory();
 String message = "Hello, World!";
 int len = message.getBytes().length;
 // allocate {len} bytes of memory, this returns a pointer to that memory
-int ptr = alloc.apply(Value.i32(len))[0].asInt();
+int ptr = (int) alloc.apply(len)[0];
 // We can now write the message to the module's memory:
 memory.writeString(ptr, message);
 ```
@@ -201,14 +201,14 @@ Now we can call `countVowels` with this pointer to the string. It will do it's j
 call `dealloc` to free that memory in the module. Though the module could do this itself if you want:
 
 ```java
-Value result = countVowels.apply(Value.i32(ptr), Value.i32(len))[0];
-dealloc.apply(Value.i32(ptr), Value.i32(len));
-assert(3 == result.asInt()); // 3 vowels in Hello, World!
+var result = countVowels.apply(ptr, len)[0];
+dealloc.apply(ptr, len);
+assert(3L == result); // 3 vowels in Hello, World!
 ```
 
 <!--
 ```java
-writeResultFile("countVowels.result", "" + result.asInt());
+writeResultFile("countVowels.result", "" + result);
 ```
 -->
 
@@ -253,9 +253,9 @@ import com.dylibso.chicory.wasm.types.ValueType;
 var func = new HostFunction(
     "console",
     "log",
-    (Instance instance, Value... args) -> { // decompiled is: console_log(13, 0);
-        var len = args[0].asInt();
-        var offset = args[1].asInt();
+    (Instance instance, long... args) -> { // decompiled is: console_log(13, 0);
+        var len = (int) args[0];
+        var offset = (int) args[1];
         var message = instance.memory().readString(offset, len);
         println(message);
         return null;

--- a/aot-tests/pom.xml
+++ b/aot-tests/pom.xml
@@ -50,6 +50,12 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Enable better debugging -->
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/aot-tests/pom.xml
+++ b/aot-tests/pom.xml
@@ -50,12 +50,6 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Enable better debugging -->
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-util</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/aot-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
+++ b/aot-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 // https://github.com/WebAssembly/spec/blob/ee82c8e50c5106e0cedada0a083d4cc4129034a2/interpreter/host/spectest.ml
 public final class Spectest {
-    private static final WasmFunctionHandle noop = (Instance instance, Value... args) -> null;
+    private static final WasmFunctionHandle noop = (Instance instance, long... args) -> null;
 
     private Spectest() {}
 

--- a/aot/pom.xml
+++ b/aot/pom.xml
@@ -34,7 +34,6 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-util</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.approvaltests</groupId>

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
@@ -228,7 +228,7 @@ final class AotEmitters {
         int globalIndex = (int) ins.operand(0);
 
         emitInvokeStatic(asm, boxer(ctx.globalTypes().get(globalIndex)));
-        asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
+        asm.visitVarInsn(Opcodes.LLOAD, ctx.instanceSlot());
         asm.visitInsn(Opcodes.SWAP);
         asm.visitLdcInsn(globalIndex);
         asm.visitInsn(Opcodes.SWAP);

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
@@ -219,7 +219,7 @@ final class AotEmitters {
         emitInvokeVirtual(asm, INSTANCE_READ_GLOBAL);
 
         Method unboxer = unboxer(ctx.globalTypes().get(globalIndex));
-        emitInvokeVirtual(asm, unboxer);
+        emitInvokeStatic(asm, unboxer);
 
         ctx.pushStackSize(stackSize(unboxer.getReturnType()));
     }
@@ -772,8 +772,8 @@ final class AotEmitters {
             ValueType type = types.get(i);
             asm.visitVarInsn(Opcodes.ALOAD, ctx.tempSlot());
             asm.visitLdcInsn(i);
-            asm.visitInsn(Opcodes.AALOAD);
-            emitInvokeVirtual(asm, unboxer(type));
+            asm.visitInsn(Opcodes.LALOAD);
+            emitInvokeStatic(asm, unboxer(type));
         }
     }
 }

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
@@ -771,10 +771,10 @@ final class AotEmitters {
     }
 
     private static void emitUnboxResult(MethodVisitor asm, AotContext ctx, List<ValueType> types) {
-        asm.visitVarInsn(Opcodes.LSTORE, ctx.tempSlot());
+        asm.visitVarInsn(Opcodes.ASTORE, ctx.tempSlot());
         for (int i = 0; i < types.size(); i++) {
             ValueType type = types.get(i);
-            asm.visitVarInsn(Opcodes.LLOAD, ctx.tempSlot());
+            asm.visitVarInsn(Opcodes.ALOAD, ctx.tempSlot());
             asm.visitLdcInsn(i);
             asm.visitInsn(Opcodes.LALOAD);
             emitInvokeStatic(asm, unboxer(type));

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
@@ -32,9 +32,10 @@ import static com.dylibso.chicory.aot.AotMethods.TABLE_SET;
 import static com.dylibso.chicory.aot.AotMethods.TABLE_SIZE;
 import static com.dylibso.chicory.aot.AotMethods.THROW_OUT_OF_BOUNDS_MEMORY_ACCESS;
 import static com.dylibso.chicory.aot.AotUtil.StackSize;
-import static com.dylibso.chicory.aot.AotUtil.boxer;
 import static com.dylibso.chicory.aot.AotUtil.callIndirectMethodName;
 import static com.dylibso.chicory.aot.AotUtil.callIndirectMethodType;
+import static com.dylibso.chicory.aot.AotUtil.convertFromLong;
+import static com.dylibso.chicory.aot.AotUtil.convertToLong;
 import static com.dylibso.chicory.aot.AotUtil.emitInvokeStatic;
 import static com.dylibso.chicory.aot.AotUtil.emitInvokeVirtual;
 import static com.dylibso.chicory.aot.AotUtil.emitPop;
@@ -45,7 +46,6 @@ import static com.dylibso.chicory.aot.AotUtil.methodNameFor;
 import static com.dylibso.chicory.aot.AotUtil.methodTypeFor;
 import static com.dylibso.chicory.aot.AotUtil.stackSize;
 import static com.dylibso.chicory.aot.AotUtil.storeTypeOpcode;
-import static com.dylibso.chicory.aot.AotUtil.unboxer;
 import static com.dylibso.chicory.aot.AotUtil.validateArgumentType;
 import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
 
@@ -218,7 +218,7 @@ final class AotEmitters {
         asm.visitLdcInsn(globalIndex);
         emitInvokeVirtual(asm, INSTANCE_READ_GLOBAL);
 
-        Method unboxer = unboxer(ctx.globalTypes().get(globalIndex));
+        Method unboxer = convertFromLong(ctx.globalTypes().get(globalIndex));
         emitInvokeStatic(asm, unboxer);
 
         ctx.pushStackSize(stackSize(unboxer.getReturnType()));
@@ -227,7 +227,7 @@ final class AotEmitters {
     public static void GLOBAL_SET(AotContext ctx, AnnotatedInstruction ins, MethodVisitor asm) {
         int globalIndex = (int) ins.operand(0);
 
-        emitInvokeStatic(asm, boxer(ctx.globalTypes().get(globalIndex)));
+        emitInvokeStatic(asm, convertToLong(ctx.globalTypes().get(globalIndex)));
         asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
         // from long | integer on top of the stack
         // to integer | long
@@ -777,7 +777,7 @@ final class AotEmitters {
             asm.visitVarInsn(Opcodes.ALOAD, ctx.tempSlot());
             asm.visitLdcInsn(i);
             asm.visitInsn(Opcodes.LALOAD);
-            emitInvokeStatic(asm, unboxer(type));
+            emitInvokeStatic(asm, convertFromLong(type));
         }
     }
 }

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
@@ -229,9 +229,13 @@ final class AotEmitters {
 
         emitInvokeStatic(asm, boxer(ctx.globalTypes().get(globalIndex)));
         asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
-        asm.visitInsn(Opcodes.SWAP);
+        // from long | integer on top of the stack
+        // to integer | long
+        asm.visitInsn(Opcodes.DUP_X2);
+        asm.visitInsn(Opcodes.POP);
         asm.visitLdcInsn(globalIndex);
-        asm.visitInsn(Opcodes.SWAP);
+        asm.visitInsn(Opcodes.DUP_X2);
+        asm.visitInsn(Opcodes.POP);
         emitInvokeVirtual(asm, INSTANCE_WRITE_GLOBAL);
     }
 

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotEmitters.java
@@ -228,7 +228,7 @@ final class AotEmitters {
         int globalIndex = (int) ins.operand(0);
 
         emitInvokeStatic(asm, boxer(ctx.globalTypes().get(globalIndex)));
-        asm.visitVarInsn(Opcodes.LLOAD, ctx.instanceSlot());
+        asm.visitVarInsn(Opcodes.ALOAD, ctx.instanceSlot());
         asm.visitInsn(Opcodes.SWAP);
         asm.visitLdcInsn(globalIndex);
         asm.visitInsn(Opcodes.SWAP);
@@ -767,10 +767,10 @@ final class AotEmitters {
     }
 
     private static void emitUnboxResult(MethodVisitor asm, AotContext ctx, List<ValueType> types) {
-        asm.visitVarInsn(Opcodes.ASTORE, ctx.tempSlot());
+        asm.visitVarInsn(Opcodes.LSTORE, ctx.tempSlot());
         for (int i = 0; i < types.size(); i++) {
             ValueType type = types.get(i);
-            asm.visitVarInsn(Opcodes.ALOAD, ctx.tempSlot());
+            asm.visitVarInsn(Opcodes.LLOAD, ctx.tempSlot());
             asm.visitLdcInsn(i);
             asm.visitInsn(Opcodes.LALOAD);
             emitInvokeStatic(asm, unboxer(type));

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
@@ -572,8 +572,8 @@ public final class AotMachine implements Machine {
         asm.visitVarInsn(Opcodes.ALOAD, slot + 2); // instance
 
         emitInvokeStatic(asm, AotMethods.CALL_INDIRECT);
+
         emitUnboxResult(type, asm);
-        asm.visitInsn(returnTypeOpcode(type));
     }
 
     private static void compileHostFunction(int funcId, FunctionType type, MethodVisitor asm) {

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
@@ -73,7 +73,6 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.commons.InstructionAdapter;
 import org.objectweb.asm.util.CheckClassAdapter;
-import org.objectweb.asm.util.TraceClassVisitor;
 
 /**
  * Simple Machine implementation that AOT compiles function bodies and runtime-links them
@@ -512,11 +511,8 @@ public final class AotMachine implements Machine {
         } catch (VerifyError e) {
             // run ASM verifier to help with debugging
             try {
-                PrintWriter pw = new PrintWriter(System.out, true, UTF_8);
                 ClassReader reader = new ClassReader(classBytes);
-                CheckClassAdapter.verify(reader, true, pw);
-
-                reader.accept(new TraceClassVisitor(pw), 0);
+                CheckClassAdapter.verify(reader, true, new PrintWriter(System.out, false, UTF_8));
             } catch (NoClassDefFoundError ignored) {
                 // the ASM verifier is an optional dependency
             } catch (Throwable t) {

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
@@ -593,10 +593,9 @@ public final class AotMachine implements Machine {
     }
 
     private static void emitBoxArguments(MethodVisitor asm, List<ValueType> types) {
-        int slotCount = types.stream().mapToInt(AotUtil::slotCount).sum();
         int slot = 0;
         // box the arguments into long[]
-        asm.visitLdcInsn(slotCount);
+        asm.visitLdcInsn(types.size());
         asm.visitIntInsn(Opcodes.NEWARRAY, Opcodes.T_LONG); // long
         for (int i = 0; i < types.size(); i++) {
             asm.visitInsn(Opcodes.DUP);

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMachine.java
@@ -390,6 +390,7 @@ public final class AotMachine implements Machine {
                                 instance.memory(),
                                 instance);
                 compiled[funcId] = adaptSignature(type, handle);
+
             } catch (ReflectiveOperationException e) {
                 throw new ChicoryException(e);
             }

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
@@ -12,7 +12,6 @@ import com.dylibso.chicory.runtime.exceptions.WASMRuntimeException;
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
 import com.dylibso.chicory.wasm.types.Element;
 import com.dylibso.chicory.wasm.types.FunctionType;
-import com.dylibso.chicory.wasm.types.Value;
 import java.lang.reflect.Method;
 import java.util.List;
 
@@ -66,7 +65,7 @@ public final class AotMethods {
                             int.class,
                             Instance.class);
             INSTANCE_CALL_HOST_FUNCTION =
-                    Instance.class.getMethod("callHostFunction", int.class, Value[].class);
+                    Instance.class.getMethod("callHostFunction", int.class, long[].class);
             INSTANCE_READ_GLOBAL = Instance.class.getMethod("readGlobal", int.class);
             INSTANCE_WRITE_GLOBAL = Instance.class.getMethod("writeGlobal", int.class, long.class);
             INSTANCE_SET_ELEMENT = Instance.class.getMethod("setElement", int.class, Element.class);

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
@@ -175,6 +175,7 @@ public final class AotMethods {
             throw new ChicoryException("uninitialized element " + funcTableIdx);
         }
 
+        // TODO: this check can be performed statically, I guess
         FunctionType expectedType = instance.type(typeId);
         FunctionType actualType = instance.type(instance.functionType(funcId));
         if (!actualType.typesMatch(expectedType)) {

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
@@ -170,7 +170,7 @@ public final class AotMethods {
 
         instance = requireNonNullElse(table.instance(funcTableIdx), instance);
 
-        int funcId = (int) table.ref(funcTableIdx);
+        int funcId = table.ref(funcTableIdx);
         if (funcId == REF_NULL_VALUE) {
             throw new ChicoryException("uninitialized element " + funcTableIdx);
         }

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
@@ -60,7 +60,7 @@ public final class AotMethods {
             CALL_INDIRECT =
                     AotMethods.class.getMethod(
                             "callIndirect",
-                            Value[].class,
+                            long[].class,
                             int.class,
                             int.class,
                             int.class,
@@ -68,7 +68,7 @@ public final class AotMethods {
             INSTANCE_CALL_HOST_FUNCTION =
                     Instance.class.getMethod("callHostFunction", int.class, Value[].class);
             INSTANCE_READ_GLOBAL = Instance.class.getMethod("readGlobal", int.class);
-            INSTANCE_WRITE_GLOBAL = Instance.class.getMethod("writeGlobal", int.class, Value.class);
+            INSTANCE_WRITE_GLOBAL = Instance.class.getMethod("writeGlobal", int.class, long.class);
             INSTANCE_SET_ELEMENT = Instance.class.getMethod("setElement", int.class, Element.class);
             MEMORY_COPY =
                     AotMethods.class.getMethod(
@@ -165,13 +165,13 @@ public final class AotMethods {
     private AotMethods() {}
 
     @UsedByGeneratedCode
-    public static Value[] callIndirect(
-            Value[] args, int typeId, int funcTableIdx, int tableIdx, Instance instance) {
+    public static long[] callIndirect(
+            long[] args, int typeId, int funcTableIdx, int tableIdx, Instance instance) {
         TableInstance table = instance.table(tableIdx);
 
         instance = requireNonNullElse(table.instance(funcTableIdx), instance);
 
-        int funcId = table.ref(funcTableIdx).asFuncRef();
+        int funcId = (int) table.ref(funcTableIdx);
         if (funcId == REF_NULL_VALUE) {
             throw new ChicoryException("uninitialized element " + funcTableIdx);
         }
@@ -183,6 +183,9 @@ public final class AotMethods {
         }
 
         checkInterruption();
+        // TODO: verify
+        // here we should not pass through the external "call" method
+        // but directly emit the invocation of the underlying function
         return instance.getMachine().call(funcId, args);
     }
 
@@ -193,7 +196,7 @@ public final class AotMethods {
 
     @UsedByGeneratedCode
     public static int tableGet(int index, int tableIndex, Instance instance) {
-        return OpcodeImpl.TABLE_GET(instance, tableIndex, index).asFuncRef();
+        return (int) OpcodeImpl.TABLE_GET(instance, tableIndex, index);
     }
 
     @UsedByGeneratedCode

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
@@ -175,7 +175,6 @@ public final class AotMethods {
             throw new ChicoryException("uninitialized element " + funcTableIdx);
         }
 
-        // TODO: this check can be performed statically, I guess
         FunctionType expectedType = instance.type(typeId);
         FunctionType actualType = instance.type(instance.functionType(funcId));
         if (!actualType.typesMatch(expectedType)) {
@@ -183,9 +182,6 @@ public final class AotMethods {
         }
 
         checkInterruption();
-        // TODO: verify
-        // here we should not pass through the external "call" method
-        // but directly emit the invocation of the underlying function
         return instance.getMachine().call(funcId, args);
     }
 

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
@@ -21,7 +21,7 @@ public final class AotMethods {
     static final Method CALL_INDIRECT;
     static final Method INSTANCE_CALL_HOST_FUNCTION;
     static final Method INSTANCE_READ_GLOBAL;
-    static final Method INSTANCE_WRITE_GLOBAL;
+    static final Method WRITE_GLOBAL;
     static final Method INSTANCE_SET_ELEMENT;
     static final Method MEMORY_COPY;
     static final Method MEMORY_FILL;
@@ -67,7 +67,9 @@ public final class AotMethods {
             INSTANCE_CALL_HOST_FUNCTION =
                     Instance.class.getMethod("callHostFunction", int.class, long[].class);
             INSTANCE_READ_GLOBAL = Instance.class.getMethod("readGlobal", int.class);
-            INSTANCE_WRITE_GLOBAL = Instance.class.getMethod("writeGlobal", int.class, long.class);
+            WRITE_GLOBAL =
+                    AotMethods.class.getMethod(
+                            "writeGlobal", long.class, int.class, Instance.class);
             INSTANCE_SET_ELEMENT = Instance.class.getMethod("setElement", int.class, Element.class);
             MEMORY_COPY =
                     AotMethods.class.getMethod(
@@ -339,5 +341,10 @@ public final class AotMethods {
         if (Thread.currentThread().isInterrupted()) {
             throw new ChicoryException("Thread interrupted");
         }
+    }
+
+    @UsedByGeneratedCode
+    public static void writeGlobal(long value, int index, Instance instance) {
+        instance.writeGlobal(index, value);
     }
 }

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
@@ -47,14 +47,14 @@ final class AotUtil {
             BOX_I64 = ValueConversions.class.getMethod("asLong", long.class);
             BOX_F32 = ValueConversions.class.getMethod("asLong", float.class);
             BOX_F64 = ValueConversions.class.getMethod("asLong", double.class);
-            BOX_EXTREF = ValueConversions.class.getMethod("asLong", long.class);
-            BOX_FUNCREF = ValueConversions.class.getMethod("asLong", long.class);
+            BOX_EXTREF = ValueConversions.class.getMethod("asLong", int.class);
+            BOX_FUNCREF = ValueConversions.class.getMethod("asLong", int.class);
             UNBOX_I32 = ValueConversions.class.getMethod("toInt", long.class);
             UNBOX_I64 = ValueConversions.class.getMethod("toLong", long.class);
             UNBOX_F32 = ValueConversions.class.getMethod("toFloat", long.class);
             UNBOX_F64 = ValueConversions.class.getMethod("toDouble", long.class);
-            UNBOX_EXTREF = ValueConversions.class.getMethod("toLong", long.class);
-            UNBOX_FUNCREF = ValueConversions.class.getMethod("toLong", long.class);
+            UNBOX_EXTREF = ValueConversions.class.getMethod("toInt", int.class);
+            UNBOX_FUNCREF = ValueConversions.class.getMethod("toInt", int.class);
         } catch (NoSuchMethodException e) {
             throw new AssertionError(e);
         }
@@ -63,9 +63,9 @@ final class AotUtil {
     public static Class<?> jvmType(ValueType type) {
         switch (type) {
             case I32:
-                return int.class;
             case ExternRef:
             case FuncRef:
+                return int.class;
             case I64:
                 return long.class;
             case F32:

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
@@ -28,33 +28,33 @@ final class AotUtil {
         TWO
     }
 
-    private static final Method UNBOX_I32;
-    private static final Method UNBOX_I64;
-    private static final Method UNBOX_F32;
-    private static final Method UNBOX_F64;
-    private static final Method UNBOX_EXTREF;
-    private static final Method UNBOX_FUNCREF;
-    private static final Method BOX_I32;
-    private static final Method BOX_I64;
-    private static final Method BOX_F32;
-    private static final Method BOX_F64;
-    private static final Method BOX_EXTREF;
-    private static final Method BOX_FUNCREF;
+    private static final Method LONG_2_I32;
+    private static final Method LONG_2_I64;
+    private static final Method LONG_2_F32;
+    private static final Method LONG_2_F64;
+    private static final Method LONG_2_EXTREF;
+    private static final Method LONG_2_FUNCREF;
+    private static final Method I32_2_LONG;
+    private static final Method I64_2_LONG;
+    private static final Method F32_2_LONG;
+    private static final Method F64_2_LONG;
+    private static final Method EXTREF_2_LONG;
+    private static final Method FUNCREF_2_LONG;
 
     static {
         try {
-            BOX_I32 = ValueConversions.class.getMethod("asLong", int.class);
-            BOX_I64 = ValueConversions.class.getMethod("asLong", long.class);
-            BOX_F32 = ValueConversions.class.getMethod("asLong", float.class);
-            BOX_F64 = ValueConversions.class.getMethod("asLong", double.class);
-            BOX_EXTREF = ValueConversions.class.getMethod("asLong", int.class);
-            BOX_FUNCREF = ValueConversions.class.getMethod("asLong", int.class);
-            UNBOX_I32 = ValueConversions.class.getMethod("toInt", long.class);
-            UNBOX_I64 = ValueConversions.class.getMethod("toLong", long.class);
-            UNBOX_F32 = ValueConversions.class.getMethod("toFloat", long.class);
-            UNBOX_F64 = ValueConversions.class.getMethod("toDouble", long.class);
-            UNBOX_EXTREF = ValueConversions.class.getMethod("toInt", long.class);
-            UNBOX_FUNCREF = ValueConversions.class.getMethod("toInt", long.class);
+            I32_2_LONG = ValueConversions.class.getMethod("asLong", int.class);
+            I64_2_LONG = ValueConversions.class.getMethod("asLong", long.class);
+            F32_2_LONG = ValueConversions.class.getMethod("asLong", float.class);
+            F64_2_LONG = ValueConversions.class.getMethod("asLong", double.class);
+            EXTREF_2_LONG = ValueConversions.class.getMethod("asLong", int.class);
+            FUNCREF_2_LONG = ValueConversions.class.getMethod("asLong", int.class);
+            LONG_2_I32 = ValueConversions.class.getMethod("toInt", long.class);
+            LONG_2_I64 = ValueConversions.class.getMethod("toLong", long.class);
+            LONG_2_F32 = ValueConversions.class.getMethod("toFloat", long.class);
+            LONG_2_F64 = ValueConversions.class.getMethod("toDouble", long.class);
+            LONG_2_EXTREF = ValueConversions.class.getMethod("toInt", long.class);
+            LONG_2_FUNCREF = ValueConversions.class.getMethod("toInt", long.class);
         } catch (NoSuchMethodException e) {
             throw new AssertionError(e);
         }
@@ -119,55 +119,55 @@ final class AotUtil {
         }
     }
 
-    public static Method unboxer(ValueType type) {
+    public static Method convertFromLong(ValueType type) {
         switch (type) {
             case I32:
-                return UNBOX_I32;
+                return LONG_2_I32;
             case I64:
-                return UNBOX_I64;
+                return LONG_2_I64;
             case F32:
-                return UNBOX_F32;
+                return LONG_2_F32;
             case F64:
-                return UNBOX_F64;
+                return LONG_2_F64;
             case ExternRef:
-                return UNBOX_EXTREF;
+                return LONG_2_EXTREF;
             case FuncRef:
-                return UNBOX_FUNCREF;
+                return LONG_2_FUNCREF;
             default:
                 throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
         }
     }
 
-    public static Method boxer(ValueType type) {
+    public static Method convertToLong(ValueType type) {
         switch (type) {
             case I32:
-                return BOX_I32;
+                return I32_2_LONG;
             case I64:
-                return BOX_I64;
+                return I64_2_LONG;
             case F32:
-                return BOX_F32;
+                return F32_2_LONG;
             case F64:
-                return BOX_F64;
+                return F64_2_LONG;
             case ExternRef:
-                return BOX_EXTREF;
+                return EXTREF_2_LONG;
             case FuncRef:
-                return BOX_FUNCREF;
+                return FUNCREF_2_LONG;
             default:
                 throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
         }
     }
 
-    public static MethodHandle unboxerHandle(ValueType type) {
+    public static MethodHandle convertFromLongHandle(ValueType type) {
         try {
-            return publicLookup().unreflect(unboxer(type));
+            return publicLookup().unreflect(convertFromLong(type));
         } catch (IllegalAccessException e) {
             throw new AssertionError(e);
         }
     }
 
-    public static MethodHandle boxerHandle(ValueType type) {
+    public static MethodHandle convertToLongHandle(ValueType type) {
         try {
-            return publicLookup().unreflect(boxer(type));
+            return publicLookup().unreflect(convertToLong(type));
         } catch (IllegalAccessException e) {
             throw new AssertionError(e);
         }

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
@@ -10,7 +10,6 @@ import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.wasm.types.FunctionBody;
 import com.dylibso.chicory.wasm.types.FunctionType;
-import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
@@ -44,18 +43,18 @@ final class AotUtil {
 
     static {
         try {
-            UNBOX_I32 = Value.class.getMethod("asInt");
-            UNBOX_I64 = Value.class.getMethod("asLong");
-            UNBOX_F32 = Value.class.getMethod("asFloat");
-            UNBOX_F64 = Value.class.getMethod("asDouble");
-            UNBOX_EXTREF = Value.class.getMethod("asExtRef");
-            UNBOX_FUNCREF = Value.class.getMethod("asFuncRef");
-            BOX_I32 = Value.class.getMethod("i32", int.class);
-            BOX_I64 = Value.class.getMethod("i64", long.class);
-            BOX_F32 = Value.class.getMethod("fromFloat", float.class);
-            BOX_F64 = Value.class.getMethod("fromDouble", double.class);
-            BOX_EXTREF = Value.class.getMethod("externRef", long.class);
-            BOX_FUNCREF = Value.class.getMethod("funcRef", long.class);
+            UNBOX_I32 = ValueConversions.class.getMethod("asLong", int.class);
+            UNBOX_I64 = ValueConversions.class.getMethod("asLong", long.class);
+            UNBOX_F32 = ValueConversions.class.getMethod("asLong", float.class);
+            UNBOX_F64 = ValueConversions.class.getMethod("asLong", double.class);
+            UNBOX_EXTREF = ValueConversions.class.getMethod("asLong", long.class);
+            UNBOX_FUNCREF = ValueConversions.class.getMethod("asLong", long.class);
+            BOX_I32 = ValueConversions.class.getMethod("toInt", long.class);
+            BOX_I64 = ValueConversions.class.getMethod("toLong", long.class);
+            BOX_F32 = ValueConversions.class.getMethod("toFloat", long.class);
+            BOX_F64 = ValueConversions.class.getMethod("toDouble", long.class);
+            BOX_EXTREF = ValueConversions.class.getMethod("toLong", long.class);
+            BOX_FUNCREF = ValueConversions.class.getMethod("toLong", long.class);
         } catch (NoSuchMethodException e) {
             throw new AssertionError(e);
         }

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
@@ -53,8 +53,8 @@ final class AotUtil {
             UNBOX_I64 = ValueConversions.class.getMethod("toLong", long.class);
             UNBOX_F32 = ValueConversions.class.getMethod("toFloat", long.class);
             UNBOX_F64 = ValueConversions.class.getMethod("toDouble", long.class);
-            UNBOX_EXTREF = ValueConversions.class.getMethod("toInt", int.class);
-            UNBOX_FUNCREF = ValueConversions.class.getMethod("toInt", int.class);
+            UNBOX_EXTREF = ValueConversions.class.getMethod("toInt", long.class);
+            UNBOX_FUNCREF = ValueConversions.class.getMethod("toInt", long.class);
         } catch (NoSuchMethodException e) {
             throw new AssertionError(e);
         }

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
@@ -43,18 +43,18 @@ final class AotUtil {
 
     static {
         try {
-            UNBOX_I32 = ValueConversions.class.getMethod("asLong", int.class);
-            UNBOX_I64 = ValueConversions.class.getMethod("asLong", long.class);
-            UNBOX_F32 = ValueConversions.class.getMethod("asLong", float.class);
-            UNBOX_F64 = ValueConversions.class.getMethod("asLong", double.class);
-            UNBOX_EXTREF = ValueConversions.class.getMethod("asLong", long.class);
-            UNBOX_FUNCREF = ValueConversions.class.getMethod("asLong", long.class);
-            BOX_I32 = ValueConversions.class.getMethod("toInt", long.class);
-            BOX_I64 = ValueConversions.class.getMethod("toLong", long.class);
-            BOX_F32 = ValueConversions.class.getMethod("toFloat", long.class);
-            BOX_F64 = ValueConversions.class.getMethod("toDouble", long.class);
-            BOX_EXTREF = ValueConversions.class.getMethod("toLong", long.class);
-            BOX_FUNCREF = ValueConversions.class.getMethod("toLong", long.class);
+            BOX_I32 = ValueConversions.class.getMethod("asLong", int.class);
+            BOX_I64 = ValueConversions.class.getMethod("asLong", long.class);
+            BOX_F32 = ValueConversions.class.getMethod("asLong", float.class);
+            BOX_F64 = ValueConversions.class.getMethod("asLong", double.class);
+            BOX_EXTREF = ValueConversions.class.getMethod("asLong", long.class);
+            BOX_FUNCREF = ValueConversions.class.getMethod("asLong", long.class);
+            UNBOX_I32 = ValueConversions.class.getMethod("toInt", long.class);
+            UNBOX_I64 = ValueConversions.class.getMethod("toLong", long.class);
+            UNBOX_F32 = ValueConversions.class.getMethod("toFloat", long.class);
+            UNBOX_F64 = ValueConversions.class.getMethod("toDouble", long.class);
+            UNBOX_EXTREF = ValueConversions.class.getMethod("toLong", long.class);
+            UNBOX_FUNCREF = ValueConversions.class.getMethod("toLong", long.class);
         } catch (NoSuchMethodException e) {
             throw new AssertionError(e);
         }

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
@@ -54,8 +54,8 @@ final class AotUtil {
             BOX_I64 = Value.class.getMethod("i64", long.class);
             BOX_F32 = Value.class.getMethod("fromFloat", float.class);
             BOX_F64 = Value.class.getMethod("fromDouble", double.class);
-            BOX_EXTREF = Value.class.getMethod("externRef", int.class);
-            BOX_FUNCREF = Value.class.getMethod("funcRef", int.class);
+            BOX_EXTREF = Value.class.getMethod("externRef", long.class);
+            BOX_FUNCREF = Value.class.getMethod("funcRef", long.class);
         } catch (NoSuchMethodException e) {
             throw new AssertionError(e);
         }
@@ -64,9 +64,9 @@ final class AotUtil {
     public static Class<?> jvmType(ValueType type) {
         switch (type) {
             case I32:
+                return int.class;
             case ExternRef:
             case FuncRef:
-                return int.class;
             case I64:
                 return long.class;
             case F32:
@@ -202,7 +202,7 @@ final class AotUtil {
             case 1:
                 return jvmType(type.returns().get(0));
             default:
-                return Value[].class;
+                return long[].class;
         }
     }
 

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
@@ -1,6 +1,7 @@
 package com.dylibso.chicory.aot;
 
 import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
+import static java.lang.invoke.MethodHandles.identity;
 import static java.lang.invoke.MethodHandles.publicLookup;
 import static java.lang.invoke.MethodType.methodType;
 import static org.objectweb.asm.Type.getInternalName;
@@ -29,39 +30,31 @@ final class AotUtil {
     }
 
     private static final Method LONG_TO_I32;
-    private static final Method LONG_TO_I64;
     private static final Method LONG_TO_F32;
     private static final Method LONG_TO_F64;
     private static final Method I32_TO_LONG;
-    private static final Method I64_TO_LONG;
     private static final Method F32_TO_LONG;
     private static final Method F64_TO_LONG;
     private static final MethodHandle LONG_TO_I32_MH;
-    private static final MethodHandle LONG_TO_I64_MH;
     private static final MethodHandle LONG_TO_F32_MH;
     private static final MethodHandle LONG_TO_F64_MH;
     private static final MethodHandle I32_TO_LONG_MH;
-    private static final MethodHandle I64_TO_LONG_MH;
     private static final MethodHandle F32_TO_LONG_MH;
     private static final MethodHandle F64_TO_LONG_MH;
 
     static {
         try {
             LONG_TO_I32 = ValueConversions.class.getMethod("longToI32", long.class);
-            LONG_TO_I64 = ValueConversions.class.getMethod("longToI64", long.class);
             LONG_TO_F32 = ValueConversions.class.getMethod("longToF32", long.class);
             LONG_TO_F64 = ValueConversions.class.getMethod("longToF64", long.class);
             I32_TO_LONG = ValueConversions.class.getMethod("i32ToLong", int.class);
-            I64_TO_LONG = ValueConversions.class.getMethod("i64ToLong", long.class);
             F32_TO_LONG = ValueConversions.class.getMethod("f32ToLong", float.class);
             F64_TO_LONG = ValueConversions.class.getMethod("f64ToLong", double.class);
 
             LONG_TO_I32_MH = publicLookup().unreflect(LONG_TO_I32);
-            LONG_TO_I64_MH = publicLookup().unreflect(LONG_TO_I64);
             LONG_TO_F32_MH = publicLookup().unreflect(LONG_TO_F32);
             LONG_TO_F64_MH = publicLookup().unreflect(LONG_TO_F64);
             I32_TO_LONG_MH = publicLookup().unreflect(I32_TO_LONG);
-            I64_TO_LONG_MH = publicLookup().unreflect(I64_TO_LONG);
             F32_TO_LONG_MH = publicLookup().unreflect(F32_TO_LONG);
             F64_TO_LONG_MH = publicLookup().unreflect(F64_TO_LONG);
         } catch (NoSuchMethodException e) {
@@ -196,7 +189,7 @@ final class AotUtil {
             case FuncRef:
                 return I32_TO_LONG_MH;
             case I64:
-                return I64_TO_LONG_MH;
+                return identity(long.class);
             case F32:
                 return F32_TO_LONG_MH;
             case F64:

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotUtil.java
@@ -28,34 +28,45 @@ final class AotUtil {
         TWO
     }
 
-    private static final Method LONG_2_I32;
-    private static final Method LONG_2_I64;
-    private static final Method LONG_2_F32;
-    private static final Method LONG_2_F64;
-    private static final Method LONG_2_EXTREF;
-    private static final Method LONG_2_FUNCREF;
-    private static final Method I32_2_LONG;
-    private static final Method I64_2_LONG;
-    private static final Method F32_2_LONG;
-    private static final Method F64_2_LONG;
-    private static final Method EXTREF_2_LONG;
-    private static final Method FUNCREF_2_LONG;
+    private static final Method LONG_TO_I32;
+    private static final Method LONG_TO_I64;
+    private static final Method LONG_TO_F32;
+    private static final Method LONG_TO_F64;
+    private static final Method I32_TO_LONG;
+    private static final Method I64_TO_LONG;
+    private static final Method F32_TO_LONG;
+    private static final Method F64_TO_LONG;
+    private static final MethodHandle LONG_TO_I32_MH;
+    private static final MethodHandle LONG_TO_I64_MH;
+    private static final MethodHandle LONG_TO_F32_MH;
+    private static final MethodHandle LONG_TO_F64_MH;
+    private static final MethodHandle I32_TO_LONG_MH;
+    private static final MethodHandle I64_TO_LONG_MH;
+    private static final MethodHandle F32_TO_LONG_MH;
+    private static final MethodHandle F64_TO_LONG_MH;
 
     static {
         try {
-            I32_2_LONG = ValueConversions.class.getMethod("asLong", int.class);
-            I64_2_LONG = ValueConversions.class.getMethod("asLong", long.class);
-            F32_2_LONG = ValueConversions.class.getMethod("asLong", float.class);
-            F64_2_LONG = ValueConversions.class.getMethod("asLong", double.class);
-            EXTREF_2_LONG = ValueConversions.class.getMethod("asLong", int.class);
-            FUNCREF_2_LONG = ValueConversions.class.getMethod("asLong", int.class);
-            LONG_2_I32 = ValueConversions.class.getMethod("toInt", long.class);
-            LONG_2_I64 = ValueConversions.class.getMethod("toLong", long.class);
-            LONG_2_F32 = ValueConversions.class.getMethod("toFloat", long.class);
-            LONG_2_F64 = ValueConversions.class.getMethod("toDouble", long.class);
-            LONG_2_EXTREF = ValueConversions.class.getMethod("toInt", long.class);
-            LONG_2_FUNCREF = ValueConversions.class.getMethod("toInt", long.class);
+            LONG_TO_I32 = ValueConversions.class.getMethod("longToI32", long.class);
+            LONG_TO_I64 = ValueConversions.class.getMethod("longToI64", long.class);
+            LONG_TO_F32 = ValueConversions.class.getMethod("longToF32", long.class);
+            LONG_TO_F64 = ValueConversions.class.getMethod("longToF64", long.class);
+            I32_TO_LONG = ValueConversions.class.getMethod("i32ToLong", int.class);
+            I64_TO_LONG = ValueConversions.class.getMethod("i64ToLong", long.class);
+            F32_TO_LONG = ValueConversions.class.getMethod("f32ToLong", float.class);
+            F64_TO_LONG = ValueConversions.class.getMethod("f64ToLong", double.class);
+
+            LONG_TO_I32_MH = publicLookup().unreflect(LONG_TO_I32);
+            LONG_TO_I64_MH = publicLookup().unreflect(LONG_TO_I64);
+            LONG_TO_F32_MH = publicLookup().unreflect(LONG_TO_F32);
+            LONG_TO_F64_MH = publicLookup().unreflect(LONG_TO_F64);
+            I32_TO_LONG_MH = publicLookup().unreflect(I32_TO_LONG);
+            I64_TO_LONG_MH = publicLookup().unreflect(I64_TO_LONG);
+            F32_TO_LONG_MH = publicLookup().unreflect(F32_TO_LONG);
+            F64_TO_LONG_MH = publicLookup().unreflect(F64_TO_LONG);
         } catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        } catch (IllegalAccessException e) {
             throw new AssertionError(e);
         }
     }
@@ -119,57 +130,79 @@ final class AotUtil {
         }
     }
 
-    public static Method convertFromLong(ValueType type) {
+    public static void emitLongToJvm(MethodVisitor asm, ValueType type) {
         switch (type) {
             case I32:
-                return LONG_2_I32;
-            case I64:
-                return LONG_2_I64;
-            case F32:
-                return LONG_2_F32;
-            case F64:
-                return LONG_2_F64;
             case ExternRef:
-                return LONG_2_EXTREF;
             case FuncRef:
-                return LONG_2_FUNCREF;
+                asm.visitInsn(Opcodes.L2I);
+                return;
+            case I64:
+                return;
+            case F32:
+                emitInvokeStatic(asm, LONG_TO_F32);
+                return;
+            case F64:
+                emitInvokeStatic(asm, LONG_TO_F64);
+                return;
             default:
                 throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
         }
     }
 
-    public static Method convertToLong(ValueType type) {
+    public static void emitJvmToLong(MethodVisitor asm, ValueType type) {
         switch (type) {
             case I32:
-                return I32_2_LONG;
-            case I64:
-                return I64_2_LONG;
-            case F32:
-                return F32_2_LONG;
-            case F64:
-                return F64_2_LONG;
             case ExternRef:
-                return EXTREF_2_LONG;
             case FuncRef:
-                return FUNCREF_2_LONG;
+                asm.visitInsn(Opcodes.I2L);
+                return;
+            case I64:
+                return;
+            case F32:
+                emitInvokeStatic(asm, F32_TO_LONG);
+                return;
+            case F64:
+                emitInvokeStatic(asm, F64_TO_LONG);
+                return;
             default:
                 throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
         }
     }
 
-    public static MethodHandle convertFromLongHandle(ValueType type) {
-        try {
-            return publicLookup().unreflect(convertFromLong(type));
-        } catch (IllegalAccessException e) {
-            throw new AssertionError(e);
+    public static MethodHandle longToJvmHandle(ValueType type) {
+        switch (type) {
+            case I32:
+            case ExternRef:
+            case FuncRef:
+                return LONG_TO_I32_MH;
+            case I64:
+                // filterArguments:
+                // Null arguments in the array are treated as identity functions
+                return null;
+            case F32:
+                return LONG_TO_F32_MH;
+            case F64:
+                return LONG_TO_F64_MH;
+            default:
+                throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
         }
     }
 
-    public static MethodHandle convertToLongHandle(ValueType type) {
-        try {
-            return publicLookup().unreflect(convertToLong(type));
-        } catch (IllegalAccessException e) {
-            throw new AssertionError(e);
+    public static MethodHandle jvmToLongHandle(ValueType type) {
+        switch (type) {
+            case I32:
+            case ExternRef:
+            case FuncRef:
+                return I32_TO_LONG_MH;
+            case I64:
+                return I64_TO_LONG_MH;
+            case F32:
+                return F32_TO_LONG_MH;
+            case F64:
+                return F64_TO_LONG_MH;
+            default:
+                throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
         }
     }
 
@@ -236,6 +269,21 @@ final class AotUtil {
             return StackSize.TWO;
         }
         throw new IllegalArgumentException("Unsupported JVM type: " + clazz);
+    }
+
+    public static StackSize stackSize(ValueType type) {
+        switch (type) {
+            case I32:
+            case F32:
+            case ExternRef:
+            case FuncRef:
+                return StackSize.ONE;
+            case I64:
+            case F64:
+                return StackSize.TWO;
+            default:
+                throw new IllegalArgumentException("Unsupported type: " + type);
+        }
     }
 
     public static int slotCount(ValueType type) {

--- a/aot/src/main/java/com/dylibso/chicory/aot/HostFunctionInvoker.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/HostFunctionInvoker.java
@@ -3,7 +3,6 @@ package com.dylibso.chicory.aot;
 import static java.lang.invoke.MethodHandles.lookup;
 
 import com.dylibso.chicory.runtime.Instance;
-import com.dylibso.chicory.wasm.types.Value;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 
@@ -15,7 +14,7 @@ final class HostFunctionInvoker {
             HANDLE =
                     lookup().unreflect(
                                     HostFunctionInvoker.class.getMethod(
-                                            "invoke", Instance.class, int.class, Value[].class));
+                                            "invoke", Instance.class, int.class, long[].class));
         } catch (NoSuchMethodException | IllegalAccessException e) {
             throw new LinkageError(e.getMessage(), e);
         }
@@ -27,7 +26,7 @@ final class HostFunctionInvoker {
         return MethodHandles.insertArguments(HANDLE, 0, instance, funcId);
     }
 
-    public static Value[] invoke(Instance instance, int funcId, Value[] args) {
+    public static long[] invoke(Instance instance, int funcId, long[] args) {
         return instance.callHostFunction(funcId, args);
     }
 }

--- a/aot/src/main/java/com/dylibso/chicory/aot/LongArrayWrapper.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/LongArrayWrapper.java
@@ -2,23 +2,22 @@ package com.dylibso.chicory.aot;
 
 import static java.lang.invoke.MethodHandles.lookup;
 
-import com.dylibso.chicory.wasm.types.Value;
 import java.lang.invoke.MethodHandle;
 
-final class ValueWrapper {
+final class LongArrayWrapper {
     public static final MethodHandle HANDLE;
 
     static {
         try {
-            HANDLE = lookup().unreflect(ValueWrapper.class.getMethod("wrap", Value.class));
+            HANDLE = lookup().unreflect(LongArrayWrapper.class.getMethod("wrap", long.class));
         } catch (NoSuchMethodException | IllegalAccessException e) {
             throw new LinkageError(e.getMessage(), e);
         }
     }
 
-    private ValueWrapper() {}
+    private LongArrayWrapper() {}
 
-    public static Value[] wrap(Value value) {
-        return new Value[] {value};
+    public static long[] wrap(long value) {
+        return new long[] {value};
     }
 }

--- a/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
@@ -1,6 +1,8 @@
 package com.dylibso.chicory.aot;
 
-public class ValueConversions {
+public final class ValueConversions {
+
+    private ValueConversions() {}
 
     // From long
     public static int toInt(long val) {

--- a/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
@@ -1,5 +1,7 @@
 package com.dylibso.chicory.aot;
 
+import com.dylibso.chicory.wasm.types.Value;
+
 public final class ValueConversions {
 
     private ValueConversions() {}
@@ -14,11 +16,11 @@ public final class ValueConversions {
     }
 
     public static float toFloat(long val) {
-        return Float.intBitsToFloat((int) val);
+        return Value.longToFloat(val);
     }
 
     public static double toDouble(long val) {
-        return Double.longBitsToDouble(val);
+        return Value.longToDouble(val);
     }
 
     // To Long
@@ -31,10 +33,10 @@ public final class ValueConversions {
     }
 
     public static long asLong(float val) {
-        return Float.floatToRawIntBits(val);
+        return Value.floatToLong(val);
     }
 
     public static long asLong(double val) {
-        return Double.doubleToLongBits(val);
+        return Value.doubleToLong(val);
     }
 }

--- a/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
@@ -9,11 +9,6 @@ public final class ValueConversions {
         return (int) val;
     }
 
-    // for compatibility with Refs, can this be removed?
-    public static int toInt(int val) {
-        return val;
-    }
-
     public static long toLong(long val) {
         return val;
     }

--- a/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
@@ -1,0 +1,38 @@
+package com.dylibso.chicory.aot;
+
+public class ValueConversions {
+
+    // From long
+    public static int toInt(long val) {
+        return (int) val;
+    }
+
+    public static long toLong(long val) {
+        return val;
+    }
+
+    public static float toFloat(long val) {
+        return Float.intBitsToFloat((int) val);
+    }
+
+    public static double toDouble(long val) {
+        return Double.longBitsToDouble(val);
+    }
+
+    // To Long
+    public static long asLong(int val) {
+        return val;
+    }
+
+    public static long asLong(long val) {
+        return val;
+    }
+
+    public static long asLong(float val) {
+        return Float.floatToRawIntBits(val);
+    }
+
+    public static long asLong(double val) {
+        return Double.doubleToLongBits(val);
+    }
+}

--- a/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
@@ -9,6 +9,11 @@ public final class ValueConversions {
         return (int) val;
     }
 
+    // for compatibility with Refs, can this be removed?
+    public static int toInt(int val) {
+        return val;
+    }
+
     public static long toLong(long val) {
         return val;
     }

--- a/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
@@ -11,10 +11,6 @@ public final class ValueConversions {
         return (int) val;
     }
 
-    public static long longToI64(long val) {
-        return val;
-    }
-
     public static float longToF32(long val) {
         return Value.longToFloat(val);
     }
@@ -25,10 +21,6 @@ public final class ValueConversions {
 
     // To Long
     public static long i32ToLong(int val) {
-        return val;
-    }
-
-    public static long i64ToLong(long val) {
         return val;
     }
 

--- a/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/ValueConversions.java
@@ -7,36 +7,36 @@ public final class ValueConversions {
     private ValueConversions() {}
 
     // From long
-    public static int toInt(long val) {
+    public static int longToI32(long val) {
         return (int) val;
     }
 
-    public static long toLong(long val) {
+    public static long longToI64(long val) {
         return val;
     }
 
-    public static float toFloat(long val) {
+    public static float longToF32(long val) {
         return Value.longToFloat(val);
     }
 
-    public static double toDouble(long val) {
+    public static double longToF64(long val) {
         return Value.longToDouble(val);
     }
 
     // To Long
-    public static long asLong(int val) {
+    public static long i32ToLong(int val) {
         return val;
     }
 
-    public static long asLong(long val) {
+    public static long i64ToLong(long val) {
         return val;
     }
 
-    public static long asLong(float val) {
+    public static long f32ToLong(float val) {
         return Value.floatToLong(val);
     }
 
-    public static long asLong(double val) {
+    public static long f64ToLong(double val) {
         return Value.doubleToLong(val);
     }
 }

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyBrTable.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyBrTable.approved.txt
@@ -59,20 +59,20 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
   // access flags 0x9
   public static call_indirect_0(IIILcom/dylibso/chicory/runtime/Instance;)I
     ICONST_1
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     ICONST_0
     ILOAD 1
     ILOAD 2
     ALOAD 3
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
-    AALOAD
-    INVOKEVIRTUAL com/dylibso/chicory/wasm/types/Value.asInt ()I
+    LALOAD
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
     IRETURN
     MAXSTACK = 5
     MAXLOCALS = 4

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyBrTable.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyBrTable.approved.txt
@@ -63,7 +63,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     ICONST_0
     ILOAD 1
@@ -72,7 +72,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
     LALOAD
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
+    L2I
     IRETURN
     MAXSTACK = 5
     MAXLOCALS = 4

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyBranching.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyBranching.approved.txt
@@ -52,20 +52,20 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
   // access flags 0x9
   public static call_indirect_0(IIILcom/dylibso/chicory/runtime/Instance;)I
     ICONST_1
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     ICONST_0
     ILOAD 1
     ILOAD 2
     ALOAD 3
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
-    AALOAD
-    INVOKEVIRTUAL com/dylibso/chicory/wasm/types/Value.asInt ()I
+    LALOAD
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
     IRETURN
     MAXSTACK = 5
     MAXLOCALS = 4

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyBranching.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyBranching.approved.txt
@@ -56,7 +56,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     ICONST_0
     ILOAD 1
@@ -65,7 +65,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
     LALOAD
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
+    L2I
     IRETURN
     MAXSTACK = 5
     MAXLOCALS = 4

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyFloat.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyFloat.approved.txt
@@ -26,12 +26,12 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
   // access flags 0x9
   public static call_indirect_0(IILcom/dylibso/chicory/runtime/Instance;)V
     ICONST_0
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     ICONST_0
     ILOAD 0
     ILOAD 1
     ALOAD 2
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     RETURN
     MAXSTACK = 5
     MAXLOCALS = 3

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyHelloWasi.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyHelloWasi.approved.txt
@@ -18,33 +18,33 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     ALOAD 5
     ICONST_0
     ICONST_4
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     DUP
     ICONST_1
     ILOAD 1
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     DUP
     ICONST_2
     ILOAD 2
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     DUP
     ICONST_3
     ILOAD 3
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
-    INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.callHostFunction (I[Lcom/dylibso/chicory/wasm/types/Value;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
+    INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.callHostFunction (I[J)[J
     ICONST_0
-    AALOAD
-    INVOKEVIRTUAL com/dylibso/chicory/wasm/types/Value.asInt ()I
+    LALOAD
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
     IRETURN
-    MAXSTACK = 6
+    MAXSTACK = 7
     MAXLOCALS = 6
 
   // access flags 0x9
@@ -75,35 +75,35 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
   // access flags 0x9
   public static call_indirect_0(IIIIIILcom/dylibso/chicory/runtime/Instance;)I
     ICONST_4
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     DUP
     ICONST_1
     ILOAD 1
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     DUP
     ICONST_2
     ILOAD 2
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     DUP
     ICONST_3
     ILOAD 3
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     ICONST_0
     ILOAD 4
     ILOAD 5
     ALOAD 6
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
-    AALOAD
-    INVOKEVIRTUAL com/dylibso/chicory/wasm/types/Value.asInt ()I
+    LALOAD
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
     IRETURN
     MAXSTACK = 5
     MAXLOCALS = 7
@@ -111,12 +111,12 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
   // access flags 0x9
   public static call_indirect_1(IILcom/dylibso/chicory/runtime/Instance;)V
     ICONST_0
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     ICONST_1
     ILOAD 0
     ILOAD 1
     ALOAD 2
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     RETURN
     MAXSTACK = 5
     MAXLOCALS = 3

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyHelloWasi.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyHelloWasi.approved.txt
@@ -22,27 +22,27 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     DUP
     ICONST_1
     ILOAD 1
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     DUP
     ICONST_2
     ILOAD 2
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     DUP
     ICONST_3
     ILOAD 3
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.callHostFunction (I[J)[J
     ICONST_0
     LALOAD
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
+    L2I
     IRETURN
     MAXSTACK = 7
     MAXLOCALS = 6
@@ -79,22 +79,22 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     DUP
     ICONST_1
     ILOAD 1
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     DUP
     ICONST_2
     ILOAD 2
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     DUP
     ICONST_3
     ILOAD 3
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     ICONST_0
     ILOAD 4
@@ -103,7 +103,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
     LALOAD
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
+    L2I
     IRETURN
     MAXSTACK = 5
     MAXLOCALS = 7

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32.approved.txt
@@ -50,12 +50,12 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
   // access flags 0x9
   public static call_indirect_0(IILcom/dylibso/chicory/runtime/Instance;)V
     ICONST_0
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     ICONST_0
     ILOAD 0
     ILOAD 1
     ALOAD 2
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     RETURN
     MAXSTACK = 5
     MAXLOCALS = 3

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
@@ -50,12 +50,12 @@ public final class FOO {
   // access flags 0x9
   public static call_indirect_0(IILcom/dylibso/chicory/runtime/Instance;)V
     ICONST_0
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     ICONST_0
     ILOAD 0
     ILOAD 1
     ALOAD 2
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     RETURN
     MAXSTACK = 5
     MAXLOCALS = 3

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyIterFact.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyIterFact.approved.txt
@@ -51,20 +51,20 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
   // access flags 0x9
   public static call_indirect_0(IIILcom/dylibso/chicory/runtime/Instance;)I
     ICONST_1
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     ICONST_0
     ILOAD 1
     ILOAD 2
     ALOAD 3
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
-    AALOAD
-    INVOKEVIRTUAL com/dylibso/chicory/wasm/types/Value.asInt ()I
+    LALOAD
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
     IRETURN
     MAXSTACK = 5
     MAXLOCALS = 4

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyIterFact.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyIterFact.approved.txt
@@ -55,7 +55,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     ICONST_0
     ILOAD 1
@@ -64,7 +64,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
     LALOAD
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
+    L2I
     IRETURN
     MAXSTACK = 5
     MAXLOCALS = 4

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyKitchenSink.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyKitchenSink.approved.txt
@@ -46,20 +46,20 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
   // access flags 0x9
   public static call_indirect_0(IIILcom/dylibso/chicory/runtime/Instance;)I
     ICONST_1
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     ICONST_0
     ILOAD 1
     ILOAD 2
     ALOAD 3
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
-    AALOAD
-    INVOKEVIRTUAL com/dylibso/chicory/wasm/types/Value.asInt ()I
+    LALOAD
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
     IRETURN
     MAXSTACK = 5
     MAXLOCALS = 4

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyKitchenSink.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyKitchenSink.approved.txt
@@ -50,7 +50,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     ICONST_0
     ILOAD 1
@@ -59,7 +59,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
     LALOAD
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
+    L2I
     IRETURN
     MAXSTACK = 5
     MAXLOCALS = 4

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyMemory.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyMemory.approved.txt
@@ -52,41 +52,41 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
   // access flags 0x9
   public static call_indirect_0(IIILcom/dylibso/chicory/runtime/Instance;)I
     ICONST_1
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     ICONST_0
     ILOAD 1
     ILOAD 2
     ALOAD 3
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
-    AALOAD
-    INVOKEVIRTUAL com/dylibso/chicory/wasm/types/Value.asInt ()I
+    LALOAD
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
     IRETURN
     MAXSTACK = 5
     MAXLOCALS = 4
 
   // access flags 0x9
   public static call_indirect_1(JIILcom/dylibso/chicory/runtime/Instance;)J
-    ICONST_1
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    ICONST_2
+    NEWARRAY T_LONG
     DUP
     ICONST_0
     LLOAD 0
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i64 (J)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (J)J
+    LASTORE
     ICONST_1
     ILOAD 2
     ILOAD 3
     ALOAD 4
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
-    AALOAD
-    INVOKEVIRTUAL com/dylibso/chicory/wasm/types/Value.asLong ()J
+    LALOAD
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toLong (J)J
     LRETURN
     MAXSTACK = 5
     MAXLOCALS = 5

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyMemory.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyMemory.approved.txt
@@ -72,7 +72,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
 
   // access flags 0x9
   public static call_indirect_1(JIILcom/dylibso/chicory/runtime/Instance;)J
-    ICONST_2
+    ICONST_1
     NEWARRAY T_LONG
     DUP
     ICONST_0

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyMemory.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyMemory.approved.txt
@@ -56,7 +56,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     ICONST_0
     ILOAD 1
@@ -65,7 +65,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
     LALOAD
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toInt (J)I
+    L2I
     IRETURN
     MAXSTACK = 5
     MAXLOCALS = 4
@@ -77,7 +77,6 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     DUP
     ICONST_0
     LLOAD 0
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (J)J
     LASTORE
     ICONST_1
     ILOAD 2
@@ -86,7 +85,6 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     ICONST_0
     LALOAD
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.toLong (J)J
     LRETURN
     MAXSTACK = 5
     MAXLOCALS = 5

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyStart.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyStart.approved.txt
@@ -18,15 +18,15 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     ALOAD 2
     ICONST_0
     ICONST_1
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
-    INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.callHostFunction (I[Lcom/dylibso/chicory/wasm/types/Value;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
+    INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.callHostFunction (I[J)[J
     RETURN
-    MAXSTACK = 6
+    MAXSTACK = 7
     MAXLOCALS = 3
 
   // access flags 0x9
@@ -43,17 +43,17 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
   // access flags 0x9
   public static call_indirect_0(IIILcom/dylibso/chicory/runtime/Instance;)V
     ICONST_1
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/wasm/types/Value.i32 (I)Lcom/dylibso/chicory/wasm/types/Value;
-    AASTORE
+    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    LASTORE
     ICONST_0
     ILOAD 1
     ILOAD 2
     ALOAD 3
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     RETURN
     MAXSTACK = 5
     MAXLOCALS = 4
@@ -61,12 +61,12 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
   // access flags 0x9
   public static call_indirect_1(IILcom/dylibso/chicory/runtime/Instance;)V
     ICONST_0
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     ICONST_1
     ILOAD 0
     ILOAD 1
     ALOAD 2
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     RETURN
     MAXSTACK = 5
     MAXLOCALS = 3

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyStart.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyStart.approved.txt
@@ -22,7 +22,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.callHostFunction (I[J)[J
     RETURN
@@ -47,7 +47,7 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
     DUP
     ICONST_0
     ILOAD 0
-    INVOKESTATIC com/dylibso/chicory/aot/ValueConversions.asLong (I)J
+    I2L
     LASTORE
     ICONST_0
     ILOAD 1

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyTrap.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyTrap.approved.txt
@@ -46,12 +46,12 @@ public final class com/dylibso/chicory/$gen/CompiledModule {
   // access flags 0x9
   public static call_indirect_0(IILcom/dylibso/chicory/runtime/Instance;)V
     ICONST_0
-    ANEWARRAY com/dylibso/chicory/wasm/types/Value
+    NEWARRAY T_LONG
     ICONST_0
     ILOAD 0
     ILOAD 1
     ALOAD 2
-    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([Lcom/dylibso/chicory/wasm/types/Value;IIILcom/dylibso/chicory/runtime/Instance;)[Lcom/dylibso/chicory/wasm/types/Value;
+    INVOKESTATIC com/dylibso/chicory/aot/AotMethods.callIndirect ([JIIILcom/dylibso/chicory/runtime/Instance;)[J
     RETURN
     MAXSTACK = 5
     MAXLOCALS = 3

--- a/cli/src/main/java/com/dylibso/chicory/cli/Cli.java
+++ b/cli/src/main/java/com/dylibso/chicory/cli/Cli.java
@@ -6,7 +6,6 @@ import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasi.WasiOptions;
 import com.dylibso.chicory.wasi.WasiPreview1;
 import com.dylibso.chicory.wasm.Parser;
-import com.dylibso.chicory.wasm.types.Value;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -76,9 +75,9 @@ public class Cli implements Runnable {
         if (functionName != null) {
             var type = instance.exportType(functionName);
             var export = instance.export(functionName);
-            var params = new Value[type.params().size()];
+            var params = new long[type.params().size()];
             for (var i = 0; i < type.params().size(); i++) {
-                params[i] = new Value(type.params().get(i), Long.valueOf(arguments[i]));
+                params[i] = Long.valueOf(arguments[i]);
             }
 
             var result = export.apply(params);
@@ -87,7 +86,7 @@ public class Cli implements Runnable {
                     if (result == null) {
                         System.out.println(0);
                     } else {
-                        System.out.println(r.asLong()); // Check floating point results
+                        System.out.println(r); // Check floating point results
                     }
                 }
             }

--- a/function-processor/src/main/java/com/dylibso/chicory/function/processor/FunctionProcessor.java
+++ b/function-processor/src/main/java/com/dylibso/chicory/function/processor/FunctionProcessor.java
@@ -100,6 +100,7 @@ public final class FunctionProcessor extends AbstractProcessor {
         }
         cu.addImport("com.dylibso.chicory.runtime.HostFunction");
         cu.addImport("com.dylibso.chicory.runtime.Instance");
+        cu.addImport("com.dylibso.chicory.wasm.types.Value");
         cu.addImport("com.dylibso.chicory.wasm.types.ValueType");
         cu.addImport("java.util.List");
 
@@ -161,16 +162,14 @@ public final class FunctionProcessor extends AbstractProcessor {
                     paramTypes.add(valueType("F32"));
                     arguments.add(
                             new MethodCallExpr(
-                                    new NameExpr("Float"),
-                                    "intBitsToFloat",
-                                    new NodeList<>(new CastExpr(parseType("int"), argExpr))));
+                                    new NameExpr("Value"), "longToFloat", new NodeList<>(argExpr)));
                     break;
                 case "double":
                     paramTypes.add(valueType("F64"));
                     arguments.add(
                             new MethodCallExpr(
-                                    new NameExpr("Double"),
-                                    "doubleToLongBits",
+                                    new NameExpr("Value"),
+                                    "longToDouble",
                                     new NodeList<>(argExpr)));
                     break;
                 case "java.lang.String":
@@ -228,16 +227,16 @@ public final class FunctionProcessor extends AbstractProcessor {
                 returnType.add(valueType("F32"));
                 returnExpr =
                         new MethodCallExpr(
-                                new NameExpr("Float"),
-                                "floatToRawIntBits",
+                                new NameExpr("Value"),
+                                "floatToLong",
                                 new NodeList<>(new NameExpr("result")));
                 break;
             case "double":
                 returnType.add(valueType("F64"));
                 returnExpr =
                         new MethodCallExpr(
-                                new NameExpr("Double"),
-                                "doubleToLongBits",
+                                new NameExpr("Value"),
+                                "doubleToLong",
                                 new NodeList<>(new NameExpr("result")));
                 break;
             default:

--- a/function-processor/src/test/resources/BasicMathGenerated.java
+++ b/function-processor/src/test/resources/BasicMathGenerated.java
@@ -2,7 +2,6 @@ package chicory.testing;
 
 import com.dylibso.chicory.runtime.HostFunction;
 import com.dylibso.chicory.runtime.Instance;
-import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 import javax.annotation.processing.Generated;
@@ -10,34 +9,38 @@ import javax.annotation.processing.Generated;
 @Generated("com.dylibso.chicory.function.processor.FunctionProcessor")
 public final class BasicMath_ModuleFactory {
 
-    private BasicMath_ModuleFactory() {}
+    private BasicMath_ModuleFactory() {
+    }
 
     public static HostFunction[] toHostFunctions(BasicMath functions) {
-        return new HostFunction[] {
-            new HostFunction(
-                    "math", "add", (Instance instance, Value... args) -> {
-                        long result = functions.add(args[0].asInt(), args[1].asInt());
-                        return new Value[] { Value.i64(result) };
-                    },
-                    List.of(ValueType.I32, ValueType.I32),
-                    List.of(ValueType.I64)
-            ),
-            new HostFunction(
-                    "math", "square", (Instance instance, Value... args) -> {
-                        double result = functions.pow2(args[0].asFloat());
-                        return new Value[] { Value.fromDouble(result) };
-                    },
-                    List.of(ValueType.F32),
-                    List.of(ValueType.F64)
-            ),
-            new HostFunction(
-                    "math", "floor_div", (Instance instance, Value... args) -> {
-                        int result = functions.floorDiv(args[0].asInt(), args[1].asInt())
-                        return new Value[] { Value.i32(result) };
-                    },
-                    List.of(ValueType.I32, ValueType.I32),
-                    List.of(ValueType.I32)
-            ),
-        };
+        return new HostFunction[] { //
+                new HostFunction("math",
+                        "add",
+                        (Instance instance, long... args) -> {
+                            long result = functions.add((int) args[0],
+                                    (int) args[1]);
+                            return new long[] { result };
+                        },
+                        List.of(ValueType.I32,
+                                ValueType.I32),
+                        List.of(ValueType.I64)), //
+                new HostFunction("math",
+                        "square",
+                        (Instance instance, long... args) -> {
+                            double result = functions.pow2(Float.intBitsToFloat((int) args[0]));
+                            return new long[] { Double.doubleToLongBits(result) };
+                        },
+                        List.of(ValueType.F32),
+                        List.of(ValueType.F64)), //
+                new HostFunction("math",
+                        "floor_div",
+                        (Instance instance, long... args) -> {
+                            int result = functions.floorDiv((int) args[0],
+                                    (int) args[1]);
+                            return new long[] { (long) result };
+                        },
+                        List.of(ValueType.I32,
+                                ValueType.I32),
+                        List.of(ValueType.I32)) };
     }
 }

--- a/function-processor/src/test/resources/BasicMathGenerated.java
+++ b/function-processor/src/test/resources/BasicMathGenerated.java
@@ -2,6 +2,7 @@ package chicory.testing;
 
 import com.dylibso.chicory.runtime.HostFunction;
 import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 import javax.annotation.processing.Generated;
@@ -27,8 +28,8 @@ public final class BasicMath_ModuleFactory {
                 new HostFunction("math",
                         "square",
                         (Instance instance, long... args) -> {
-                            double result = functions.pow2(Float.intBitsToFloat((int) args[0]));
-                            return new long[] { Double.doubleToLongBits(result) };
+                            double result = functions.pow2(Value.longToFloat(args[0]));
+                            return new long[] { Value.doubleToLong(result) };
                         },
                         List.of(ValueType.F32),
                         List.of(ValueType.F64)), //

--- a/function-processor/src/test/resources/NestedGenerated.java
+++ b/function-processor/src/test/resources/NestedGenerated.java
@@ -3,7 +3,6 @@ package chicory.testing;
 import chicory.testing.Box.Nested;
 import com.dylibso.chicory.runtime.HostFunction;
 import com.dylibso.chicory.runtime.Instance;
-import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 import javax.annotation.processing.Generated;
@@ -11,26 +10,29 @@ import javax.annotation.processing.Generated;
 @Generated("com.dylibso.chicory.function.processor.FunctionProcessor")
 public final class Nested_ModuleFactory {
 
-    private Nested_ModuleFactory() {}
+    private Nested_ModuleFactory() {
+    }
 
     public static HostFunction[] toHostFunctions(Nested functions) {
-        return new HostFunction[] {
-            new HostFunction(
-                    "nested", "print", (Instance instance, Value... args) -> {
-                        functions.print(instance.memory(), args[0].asInt(), args[1].asInt());
-                        return null;
-                    },
-                    List.of(ValueType.I32, ValueType.I32),
-                    List.of()
-            ),
-            new HostFunction(
-                    "nested", "exit", (Instance instance, Value... args) -> {
-                        functions.exit();
-                        return null;
-                    },
-                    List.of(),
-                    List.of()
-            ),
-        };
+        return new HostFunction[] { //
+                new HostFunction("nested",
+                        "print",
+                        (Instance instance, long... args) -> {
+                            functions.print(instance.memory(),
+                                    (int) args[0],
+                                    (int) args[1]);
+                            return null;
+                        },
+                        List.of(ValueType.I32,
+                                ValueType.I32),
+                        List.of()), //
+                new HostFunction("nested",
+                        "exit",
+                        (Instance instance, long... args) -> {
+                            functions.exit();
+                            return null;
+                        },
+                        List.of(),
+                        List.of()) };
     }
 }

--- a/function-processor/src/test/resources/NestedGenerated.java
+++ b/function-processor/src/test/resources/NestedGenerated.java
@@ -3,6 +3,7 @@ package chicory.testing;
 import chicory.testing.Box.Nested;
 import com.dylibso.chicory.runtime.HostFunction;
 import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 import javax.annotation.processing.Generated;

--- a/function-processor/src/test/resources/NoPackageGenerated.java
+++ b/function-processor/src/test/resources/NoPackageGenerated.java
@@ -1,6 +1,5 @@
 import com.dylibso.chicory.runtime.HostFunction;
 import com.dylibso.chicory.runtime.Instance;
-import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 import javax.annotation.processing.Generated;
@@ -8,26 +7,29 @@ import javax.annotation.processing.Generated;
 @Generated("com.dylibso.chicory.function.processor.FunctionProcessor")
 public final class NoPackage_ModuleFactory {
 
-    private Nested_ModuleFactory() {}
+    private NoPackage_ModuleFactory() {
+    }
 
     public static HostFunction[] toHostFunctions(NoPackage functions) {
-        return new HostFunction[] {
-            new HostFunction(
-                    "nopackage", "print", (Instance instance, Value... args) -> {
-                        functions.print(instance.memory(), args[0].asInt(), args[1].asInt());
-                        return null;
-                    },
-                    List.of(ValueType.I32, ValueType.I32),
-                    List.of()
-            ),
-            new HostFunction(
-                    "nopackage", "exit", (Instance instance, Value... args) -> {
-                        functions.exit();
-                        return null;
-                    },
-                    List.of(),
-                    List.of()
-            ),
-        };
+        return new HostFunction[] { //
+                new HostFunction("nopackage",
+                        "print",
+                        (Instance instance, long... args) -> {
+                            functions.print(instance.memory(),
+                                    (int) args[0],
+                                    (int) args[1]);
+                            return null;
+                        },
+                        List.of(ValueType.I32,
+                                ValueType.I32),
+                        List.of()), //
+                new HostFunction("nopackage",
+                        "exit",
+                        (Instance instance, long... args) -> {
+                            functions.exit();
+                            return null;
+                        },
+                        List.of(),
+                        List.of()) };
     }
 }

--- a/function-processor/src/test/resources/NoPackageGenerated.java
+++ b/function-processor/src/test/resources/NoPackageGenerated.java
@@ -1,5 +1,6 @@
 import com.dylibso.chicory.runtime.HostFunction;
 import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 import javax.annotation.processing.Generated;

--- a/function-processor/src/test/resources/SimpleGenerated.java
+++ b/function-processor/src/test/resources/SimpleGenerated.java
@@ -2,7 +2,6 @@ package chicory.testing;
 
 import com.dylibso.chicory.runtime.HostFunction;
 import com.dylibso.chicory.runtime.Instance;
-import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 import javax.annotation.processing.Generated;
@@ -10,43 +9,47 @@ import javax.annotation.processing.Generated;
 @Generated("com.dylibso.chicory.function.processor.FunctionProcessor")
 public final class Simple_ModuleFactory {
 
-    private Simple_ModuleFactory() {}
+    private Simple_ModuleFactory() {
+    }
 
     public static HostFunction[] toHostFunctions(Simple functions) {
-        return new HostFunction[] {
-            new HostFunction(
-                    "simple", "print", (Instance instance, Value... args) -> {
-                        functions.print(
-                                instance.memory().readString(args[0].asInt(), args[1].asInt()));
-                        return null;
-                    },
-                    List.of(ValueType.I32, ValueType.I32),
-                    List.of()
-            ),
-            new HostFunction(
-                    "simple", "printx", (Instance instance, Value... args) -> {
-                        functions.printx(instance.memory().readCString(args[0].asInt()));
-                        return null;
-                    },
-                    List.of(ValueType.I32),
-                    List.of()
-            ),
-            new HostFunction(
-                    "simple", "random_get", (Instance instance, Value... args) -> {
-                        functions.randomGet(instance.memory(), args[0].asInt(), args[1].asInt());
-                        return null;
-                    },
-                    List.of(ValueType.I32, ValueType.I32),
-                    List.of()
-            ),
-            new HostFunction(
-                    "simple", "exit", (Instance instance, Value... args) -> {
-                        functions.exit();
-                        return null;
-                    },
-                    List.of(),
-                    List.of()
-            ),
-        };
+        return new HostFunction[] { //
+                new HostFunction("simple",
+                        "print",
+                        (Instance instance, long... args) -> {
+                            functions.print(instance.memory().readString((int) args[0],
+                                    (int) args[1]));
+                            return null;
+                        },
+                        List.of(ValueType.I32,
+                                ValueType.I32),
+                        List.of()), //
+                new HostFunction("simple",
+                        "printx",
+                        (Instance instance, long... args) -> {
+                            functions.printx(instance.memory().readCString((int) args[0]));
+                            return null;
+                        },
+                        List.of(ValueType.I32),
+                        List.of()), //
+                new HostFunction("simple",
+                        "random_get",
+                        (Instance instance, long... args) -> {
+                            functions.randomGet(instance.memory(),
+                                    (int) args[0],
+                                    (int) args[1]);
+                            return null;
+                        },
+                        List.of(ValueType.I32,
+                                ValueType.I32),
+                        List.of()), //
+                new HostFunction("simple",
+                        "exit",
+                        (Instance instance, long... args) -> {
+                            functions.exit();
+                            return null;
+                        },
+                        List.of(),
+                        List.of()) };
     }
 }

--- a/function-processor/src/test/resources/SimpleGenerated.java
+++ b/function-processor/src/test/resources/SimpleGenerated.java
@@ -2,6 +2,7 @@ package chicory.testing;
 
 import com.dylibso.chicory.runtime.HostFunction;
 import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 import javax.annotation.processing.Generated;

--- a/jmh/src/main/java/com/dylibso/chicory/bench/BenchmarkFactorialExecution.java
+++ b/jmh/src/main/java/com/dylibso/chicory/bench/BenchmarkFactorialExecution.java
@@ -4,7 +4,6 @@ import com.dylibso.chicory.aot.AotMachine;
 import com.dylibso.chicory.runtime.ExportFunction;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasm.Parser;
-import com.dylibso.chicory.wasm.types.Value;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -51,12 +50,12 @@ public class BenchmarkFactorialExecution {
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
     public void benchmarkInt(Blackhole bh) {
-        bh.consume(iterFactInt.apply(Value.i32(input)));
+        bh.consume(iterFactInt.apply(input));
     }
 
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
     public void benchmarkAot(Blackhole bh) {
-        bh.consume(iterFactAot.apply(Value.i32(input)));
+        bh.consume(iterFactAot.apply(input));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -567,6 +567,7 @@
           <ignoredUnusedDeclaredDependencies>
             <dependency>com.dylibso.chicory:wasm-corpus</dependency>
             <dependency>org.junit.jupiter:junit-jupiter-engine</dependency>
+            <dependency>org.ow2.asm:asm-util</dependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
         <executions>

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 // https://github.com/WebAssembly/spec/blob/ee82c8e50c5106e0cedada0a083d4cc4129034a2/interpreter/host/spectest.ml
 public final class Spectest {
-    private static final WasmFunctionHandle noop = (Instance instance, Value... args) -> null;
+    private static final WasmFunctionHandle noop = (Instance instance, long... args) -> null;
 
     private Spectest() {}
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ConstantEvaluators.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ConstantEvaluators.java
@@ -71,7 +71,8 @@ public final class ConstantEvaluators {
                                         "constant expression required, initializer expression"
                                                 + " cannot reference a mutable global");
                             }
-                            return instance.readGlobal(idx);
+                            var t = instance.imports().global(idx).instance().getType();
+                            return new Value(t, instance.readGlobal(idx));
                         } else {
                             throw new InvalidException(
                                     "unknown global "

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExportFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExportFunction.java
@@ -1,12 +1,11 @@
 package com.dylibso.chicory.runtime;
 
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
-import com.dylibso.chicory.wasm.types.Value;
 
 /**
  * This represents an Exported function from the Wasm module.
  */
 @FunctionalInterface
 public interface ExportFunction {
-    Value[] apply(Value... args) throws ChicoryException;
+    long[] apply(long... args) throws ChicoryException;
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/GlobalInstance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/GlobalInstance.java
@@ -10,16 +10,14 @@ public class GlobalInstance {
     private Instance instance;
     private final MutabilityType mutabilityType;
 
+    public GlobalInstance(Value value) {
+        this(value, MutabilityType.Const);
+    }
+
     public GlobalInstance(Value value, MutabilityType mutabilityType) {
         this.value = value.raw();
         this.valueType = value.type();
         this.mutabilityType = mutabilityType;
-    }
-
-    public GlobalInstance(Value value) {
-        this.value = value.raw();
-        this.valueType = value.type();
-        this.mutabilityType = MutabilityType.Const;
     }
 
     public long getValue() {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/GlobalInstance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/GlobalInstance.java
@@ -2,19 +2,24 @@ package com.dylibso.chicory.runtime;
 
 import com.dylibso.chicory.wasm.types.MutabilityType;
 import com.dylibso.chicory.wasm.types.Value;
+import com.dylibso.chicory.wasm.types.ValueType;
 
 public class GlobalInstance {
     private Value value;
+    // TODO: we can remove the boxing also here
+    private final ValueType valueType;
     private Instance instance;
     private final MutabilityType mutabilityType;
 
     public GlobalInstance(Value value, MutabilityType mutabilityType) {
         this.value = value;
+        this.valueType = value.type();
         this.mutabilityType = mutabilityType;
     }
 
     public GlobalInstance(Value value) {
         this.value = value;
+        this.valueType = value.type();
         this.mutabilityType = MutabilityType.Const;
     }
 
@@ -24,6 +29,10 @@ public class GlobalInstance {
 
     public void setValue(Value value) {
         this.value = value;
+    }
+
+    public void setValue(long value) {
+        this.value = new Value(valueType, value);
     }
 
     public Instance getInstance() {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/GlobalInstance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/GlobalInstance.java
@@ -5,34 +5,39 @@ import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 
 public class GlobalInstance {
-    private Value value;
-    // TODO: we can remove the boxing also here
+    private long value;
     private final ValueType valueType;
     private Instance instance;
     private final MutabilityType mutabilityType;
 
     public GlobalInstance(Value value, MutabilityType mutabilityType) {
-        this.value = value;
+        this.value = value.raw();
         this.valueType = value.type();
         this.mutabilityType = mutabilityType;
     }
 
     public GlobalInstance(Value value) {
-        this.value = value;
+        this.value = value.raw();
         this.valueType = value.type();
         this.mutabilityType = MutabilityType.Const;
     }
 
-    public Value getValue() {
+    public long getValue() {
         return value;
     }
 
+    public ValueType getType() {
+        return valueType;
+    }
+
     public void setValue(Value value) {
-        this.value = value;
+        // globals can not be type polimorphic
+        assert (value.type() == valueType);
+        this.value = value.raw();
     }
 
     public void setValue(long value) {
-        this.value = new Value(valueType, value);
+        this.value = value;
     }
 
     public Instance getInstance() {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -133,7 +133,7 @@ public class Instance {
                 }
                 for (int i = 0; i < initializers.size(); i++) {
                     final List<Instruction> init = initializers.get(i);
-                    var index = offset.asInt() + i;
+                    int index = offset.asInt() + i;
                     if (init.stream().filter(e -> e.opcode() != OpCode.END).count() > 1L) {
                         throw new InvalidException(
                                 "constant expression required, type mismatch, expected [] but found"
@@ -151,17 +151,17 @@ public class Instance {
                                         + value.type());
                     }
                     if (ae.type() == ValueType.FuncRef) {
-                        if (value.asFuncRef() != REF_NULL_VALUE) {
+                        if (((int) value.raw()) != REF_NULL_VALUE) {
                             try {
-                                function(value.asFuncRef());
+                                function(value.raw());
                             } catch (InvalidException e) {
                                 throw new InvalidException("type mismatch, " + e.getMessage(), e);
                             }
                         }
-                        table.setRef(index, value.asFuncRef(), inst);
+                        table.setRef(index, (int) value.raw(), inst);
                     } else {
                         assert ae.type() == ValueType.ExternRef;
-                        table.setRef(index, value.asExtRef(), inst);
+                        table.setRef(index, (int) value.raw(), inst);
                     }
                 }
             } else if (el instanceof DeclarativeElement) {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -233,7 +233,9 @@ public class Instance {
                 {
                     return args -> {
                         assert (args.length == 0);
-                        return new Value[] {readGlobal(export.index())};
+                        var t = readGlobalType(export.index());
+                        var v = readGlobal(export.index());
+                        return new Value[] {new Value(t, v)};
                     };
                 }
             default:
@@ -274,7 +276,15 @@ public class Instance {
         globals[idx - importedGlobalsOffset].setValue(val);
     }
 
-    public Value readGlobal(int idx) {
+    public ValueType readGlobalType(int idx) {
+        if (idx < importedGlobalsOffset) {
+            return imports.global(idx).instance().getType();
+        }
+        var i = idx - importedGlobalsOffset;
+        return globals[idx - importedGlobalsOffset].getType();
+    }
+
+    public long readGlobal(int idx) {
         if (idx < importedGlobalsOffset) {
             return imports.global(idx).instance().getValue();
         }
@@ -430,7 +440,7 @@ public class Instance {
         }
 
         private void validateHostGlobalType(GlobalImport i, ExternalGlobal g) {
-            if (i.type() != g.instance().getValue().type()
+            if (i.type() != g.instance().getType()
                     || i.mutabilityType() != g.instance().getMutabilityType()) {
                 throw new UnlinkableException("incompatible import type");
             }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -227,7 +227,20 @@ public class Instance {
         switch (export.exportType()) {
             case FUNCTION:
                 {
-                    return args -> machine.call(export.index(), args);
+                    return args -> {
+                        var functionType = type(functionType(export.index()));
+                        // we can do additional validation logic here
+                        var unboxedArgs = new long[functionType.params().size()];
+                        for (int i = 0; i < functionType.params().size(); i++) {
+                            unboxedArgs[i] = args[i].raw();
+                        }
+                        var result = machine.call(export.index(), unboxedArgs);
+                        var boxedResults = new Value[functionType.returns().size()];
+                        for (int i = 0; i < functionType.returns().size(); i++) {
+                            boxedResults[i] = new Value(functionType.returns().get(i), result[i]);
+                        }
+                        return boxedResults;
+                    };
                 }
             case GLOBAL:
                 {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -293,7 +293,6 @@ public class Instance {
         if (idx < importedGlobalsOffset) {
             return imports.global(idx).instance().getType();
         }
-        var i = idx - importedGlobalsOffset;
         return globals[idx - importedGlobalsOffset].getType();
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -267,7 +267,7 @@ public class Instance {
         return globals[idx - importedGlobalsOffset];
     }
 
-    public void writeGlobal(int idx, Value val) {
+    public void writeGlobal(int idx, long val) {
         if (idx < importedGlobalsOffset) {
             imports.global(idx).instance().setValue(val);
         }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -227,28 +227,14 @@ public class Instance {
         switch (export.exportType()) {
             case FUNCTION:
                 {
-                    return args -> {
-                        var functionType = type(functionType(export.index()));
-                        // we can do additional validation logic here
-                        var unboxedArgs = new long[functionType.params().size()];
-                        for (int i = 0; i < functionType.params().size(); i++) {
-                            unboxedArgs[i] = args[i].raw();
-                        }
-                        var result = machine.call(export.index(), unboxedArgs);
-                        var boxedResults = new Value[functionType.returns().size()];
-                        for (int i = 0; i < functionType.returns().size(); i++) {
-                            boxedResults[i] = new Value(functionType.returns().get(i), result[i]);
-                        }
-                        return boxedResults;
-                    };
+                    return args -> machine.call(export.index(), args);
                 }
             case GLOBAL:
                 {
                     return args -> {
                         assert (args.length == 0);
-                        var t = readGlobalType(export.index());
                         var v = readGlobal(export.index());
-                        return new Value[] {new Value(t, v)};
+                        return new long[] {v};
                     };
                 }
             default:
@@ -358,7 +344,7 @@ public class Instance {
         return machine;
     }
 
-    public Value[] callHostFunction(int funcId, Value[] args) {
+    public long[] callHostFunction(int funcId, long[] args) {
         var imprt = imports.function(funcId);
         if (imprt == null) {
             throw new ChicoryException("Missing host import, number: " + funcId);

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -40,7 +40,7 @@ class InterpreterMachine implements Machine {
             Instance instance,
             Deque<StackFrame> callStack,
             int funcId,
-            Value[] args,
+            Value[] typedArgs,
             FunctionType callType,
             boolean popResults)
             throws ChicoryException {
@@ -51,6 +51,12 @@ class InterpreterMachine implements Machine {
 
         if (callType != null) {
             verifyIndirectCall(type, callType);
+        }
+
+        // TODO: verify if we should push higher the boundary long/Value here
+        var args = new long[typedArgs.length];
+        for (int i = 0; i < typedArgs.length; i++) {
+            args[i] = typedArgs[i].raw();
         }
 
         var func = instance.function(funcId);
@@ -70,12 +76,12 @@ class InterpreterMachine implements Machine {
             stackFrame.pushCtrl(OpCode.CALL, 0, type.returns().size(), stack.size());
             callStack.push(stackFrame);
 
-            var results = instance.callHostFunction(funcId, args);
+            var results = instance.callHostFunction(funcId, typedArgs);
             // a host function can return null or an array of ints
             // which we will push onto the stack
             if (results != null) {
                 for (var result : results) {
-                    stack.push(result);
+                    stack.push(result.raw());
                 }
             }
         }
@@ -98,7 +104,8 @@ class InterpreterMachine implements Machine {
         var totalResults = type.returns().size();
         var results = new Value[totalResults];
         for (var i = totalResults - 1; i >= 0; i--) {
-            results[i] = stack.pop();
+            var t = type.returns().get(i);
+            results[i] = new Value(t, stack.pop());
         }
         return results;
     }
@@ -283,16 +290,16 @@ class InterpreterMachine implements Machine {
                     break;
                     // TODO 32bit and 64 bit operations are the same for now
                 case I32_CONST:
-                    stack.push(Value.i32(operands.get(0)));
+                    stack.push(operands.get(0));
                     break;
                 case I64_CONST:
-                    stack.push(Value.i64(operands.get(0)));
+                    stack.push(operands.get(0));
                     break;
                 case F32_CONST:
-                    stack.push(Value.f32(operands.get(0)));
+                    stack.push(operands.get(0));
                     break;
                 case F64_CONST:
-                    stack.push(Value.f64(operands.get(0)));
+                    stack.push(operands.get(0));
                     break;
                 case I32_EQ:
                     I32_EQ(stack);
@@ -733,7 +740,7 @@ class InterpreterMachine implements Machine {
                     TABLE_GROW(stack, instance, operands);
                     break;
                 case REF_FUNC:
-                    stack.push(Value.funcRef((int) operands.get(0)));
+                    stack.push((int) operands.get(0));
                     break;
                 case REF_NULL:
                     REF_NULL(stack, operands);
@@ -752,676 +759,661 @@ class InterpreterMachine implements Machine {
     }
 
     private static void I32_GE_U(MStack stack) {
-        var b = stack.pop().asInt();
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_GE_U(a, b)));
+        var b = (int) stack.pop();
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_GE_U(a, b));
     }
 
     private static void I64_GT_U(MStack stack) {
-        var b = stack.pop().asLong();
-        var a = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_GT_U(a, b)));
+        var b = stack.pop();
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_GT_U(a, b));
     }
 
     private static void I32_GE_S(MStack stack) {
-        var b = stack.pop().asInt();
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_GE_S(a, b)));
+        var b = (int) stack.pop();
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_GE_S(a, b));
     }
 
     private static void I64_GE_U(MStack stack) {
-        var b = stack.pop().asLong();
-        var a = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_GE_U(a, b)));
+        var b = stack.pop();
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_GE_U(a, b));
     }
 
     private static void I64_GE_S(MStack stack) {
-        var b = stack.pop().asLong();
-        var a = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_GE_S(a, b)));
+        var b = stack.pop();
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_GE_S(a, b));
     }
 
     private static void I32_LE_S(MStack stack) {
-        var b = stack.pop().asInt();
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_LE_S(a, b)));
+        var b = (int) stack.pop();
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_LE_S(a, b));
     }
 
     private static void I32_LE_U(MStack stack) {
-        var b = stack.pop().asInt();
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_LE_U(a, b)));
+        var b = (int) stack.pop();
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_LE_U(a, b));
     }
 
     private static void I64_LE_S(MStack stack) {
-        var b = stack.pop().asLong();
-        var a = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_LE_S(a, b)));
+        var b = stack.pop();
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_LE_S(a, b));
     }
 
     private static void I64_LE_U(MStack stack) {
-        var b = stack.pop().asLong();
-        var a = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_LE_U(a, b)));
+        var b = stack.pop();
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_LE_U(a, b));
     }
 
     private static void F32_EQ(MStack stack) {
-        var b = stack.pop().asFloat();
-        var a = stack.pop().asFloat();
-        stack.push(Value.i32(OpcodeImpl.F32_EQ(a, b)));
+        var b = Value.longToFloat(stack.pop());
+        var a = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.F32_EQ(a, b));
     }
 
     private static void F64_EQ(MStack stack) {
-        var b = stack.pop().asDouble();
-        var a = stack.pop().asDouble();
-        stack.push(Value.i32(OpcodeImpl.F64_EQ(a, b)));
+        var b = Value.longToDouble(stack.pop());
+        var a = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.F64_EQ(a, b));
     }
 
     private static void I32_CLZ(MStack stack) {
-        var tos = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_CLZ(tos)));
+        var tos = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_CLZ(tos));
     }
 
     private static void I32_CTZ(MStack stack) {
-        var tos = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_CTZ(tos)));
+        var tos = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_CTZ(tos));
     }
 
     private static void I32_POPCNT(MStack stack) {
-        var tos = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_POPCNT(tos)));
+        var tos = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_POPCNT(tos));
     }
 
     private static void I32_ADD(MStack stack) {
-        var a = stack.pop().asInt();
-        var b = stack.pop().asInt();
-        stack.push(Value.i32(a + b));
+        var a = (int) stack.pop();
+        var b = (int) stack.pop();
+        stack.push(a + b);
     }
 
     private static void I64_ADD(MStack stack) {
-        var a = stack.pop().asLong();
-        var b = stack.pop().asLong();
-        stack.push(Value.i64(a + b));
+        var a = stack.pop();
+        var b = stack.pop();
+        stack.push(a + b);
     }
 
     private static void I32_SUB(MStack stack) {
-        var a = stack.pop().asInt();
-        var b = stack.pop().asInt();
-        stack.push(Value.i32(b - a));
+        var a = (int) stack.pop();
+        var b = (int) stack.pop();
+        stack.push(b - a);
     }
 
     private static void I64_SUB(MStack stack) {
-        var a = stack.pop().asLong();
-        var b = stack.pop().asLong();
-        stack.push(Value.i64(b - a));
+        var a = stack.pop();
+        var b = stack.pop();
+        stack.push(b - a);
     }
 
     private static void I32_MUL(MStack stack) {
-        var a = stack.pop().asInt();
-        var b = stack.pop().asInt();
-        stack.push(Value.i32(a * b));
+        var a = (int) stack.pop();
+        var b = (int) stack.pop();
+        stack.push(a * b);
     }
 
     private static void I64_MUL(MStack stack) {
-        var a = stack.pop().asLong();
-        var b = stack.pop().asLong();
-        stack.push(Value.i64(a * b));
+        var a = stack.pop();
+        var b = stack.pop();
+        stack.push(a * b);
     }
 
     private static void I32_DIV_S(MStack stack) {
-        var b = stack.pop().asInt();
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_DIV_S(a, b)));
+        var b = (int) stack.pop();
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_DIV_S(a, b));
     }
 
     private static void I32_DIV_U(MStack stack) {
-        var b = stack.pop().asInt();
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_DIV_U(a, b)));
+        var b = (int) stack.pop();
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_DIV_U(a, b));
     }
 
     private static void I64_EXTEND_8_S(MStack stack) {
-        var tos = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_EXTEND_8_S(tos)));
+        var tos = stack.pop();
+        stack.push(OpcodeImpl.I64_EXTEND_8_S(tos));
     }
 
     private static void I64_EXTEND_16_S(MStack stack) {
-        var tos = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_EXTEND_16_S(tos)));
+        var tos = stack.pop();
+        stack.push(OpcodeImpl.I64_EXTEND_16_S(tos));
     }
 
     private static void I64_EXTEND_32_S(MStack stack) {
-        var tos = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_EXTEND_32_S(tos)));
+        var tos = stack.pop();
+        stack.push(OpcodeImpl.I64_EXTEND_32_S(tos));
     }
 
     private static void F64_CONVERT_I64_U(MStack stack) {
-        var tos = stack.pop().asLong();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_CONVERT_I64_U(tos)));
+        var tos = stack.pop();
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_CONVERT_I64_U(tos)));
     }
 
     private static void F64_CONVERT_I32_U(MStack stack) {
-        var tos = stack.pop().asInt();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_CONVERT_I32_U(tos)));
+        var tos = (int) stack.pop();
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_CONVERT_I32_U(tos)));
     }
 
     private static void F64_CONVERT_I32_S(MStack stack) {
-        var tos = stack.pop().asInt();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_CONVERT_I32_S(tos)));
+        var tos = (int) stack.pop();
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_CONVERT_I32_S(tos)));
     }
 
     private static void I32_EXTEND_8_S(MStack stack) {
-        var tos = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_EXTEND_8_S(tos)));
+        var tos = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_EXTEND_8_S(tos));
     }
 
     private static void F64_NEAREST(MStack stack) {
-        var val = stack.pop().asDouble();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_NEAREST(val)));
+        var val = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_NEAREST(val)));
     }
 
     private static void F32_NEAREST(MStack stack) {
-        var val = stack.pop().asFloat();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_NEAREST(val)));
+        var val = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(OpcodeImpl.F32_NEAREST(val)));
     }
 
     private static void F64_TRUNC(MStack stack) {
-        var val = stack.pop().asDouble();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_TRUNC(val)));
+        var val = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_TRUNC(val)));
     }
 
     private static void F64_CEIL(MStack stack) {
-        var val = stack.pop().asDouble();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_CEIL(val)));
+        var val = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_CEIL(val)));
     }
 
     private static void F32_CEIL(MStack stack) {
-        var val = stack.pop().asFloat();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_CEIL(val)));
+        var val = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(OpcodeImpl.F32_CEIL(val)));
     }
 
     private static void F64_FLOOR(MStack stack) {
-        var val = stack.pop().asDouble();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_FLOOR(val)));
+        var val = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_FLOOR(val)));
     }
 
     private static void F32_FLOOR(MStack stack) {
-        var val = stack.pop().asFloat();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_FLOOR(val)));
+        var val = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(OpcodeImpl.F32_FLOOR(val)));
     }
 
     private static void F64_SQRT(MStack stack) {
-        var val = stack.pop().asDouble();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_SQRT(val)));
+        var val = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_SQRT(val)));
     }
 
     private static void F32_SQRT(MStack stack) {
-        var val = stack.pop().asFloat();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_SQRT(val)));
+        var val = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(OpcodeImpl.F32_SQRT(val)));
     }
 
     private static void F64_MAX(MStack stack) {
-        var a = stack.pop().asDouble();
-        var b = stack.pop().asDouble();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_MAX(a, b)));
+        var a = Value.longToDouble(stack.pop());
+        var b = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_MAX(a, b)));
     }
 
     private static void F32_MAX(MStack stack) {
-        var a = stack.pop().asFloat();
-        var b = stack.pop().asFloat();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_MAX(a, b)));
+        var a = Value.longToFloat(stack.pop());
+        var b = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(OpcodeImpl.F32_MAX(a, b)));
     }
 
     private static void F64_MIN(MStack stack) {
-        var a = stack.pop().asDouble();
-        var b = stack.pop().asDouble();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_MIN(a, b)));
+        var a = Value.longToDouble(stack.pop());
+        var b = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_MIN(a, b)));
     }
 
     private static void F32_MIN(MStack stack) {
-        var a = stack.pop().asFloat();
-        var b = stack.pop().asFloat();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_MIN(a, b)));
+        var a = Value.longToFloat(stack.pop());
+        var b = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(OpcodeImpl.F32_MIN(a, b)));
     }
 
     private static void F64_DIV(MStack stack) {
-        var a = stack.pop().asDouble();
-        var b = stack.pop().asDouble();
-        stack.push(Value.fromDouble(b / a));
+        var a = Value.longToDouble(stack.pop());
+        var b = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(b / a));
     }
 
     private static void F32_DIV(MStack stack) {
-        var a = stack.pop().asFloat();
-        var b = stack.pop().asFloat();
-        stack.push(Value.fromFloat(b / a));
+        var a = Value.longToFloat(stack.pop());
+        var b = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(b / a));
     }
 
     private static void F64_MUL(MStack stack) {
-        var a = stack.pop().asDouble();
-        var b = stack.pop().asDouble();
-        stack.push(Value.fromDouble(b * a));
+        var a = Value.longToDouble(stack.pop());
+        var b = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(b * a));
     }
 
     private static void F32_MUL(MStack stack) {
-        var a = stack.pop().asFloat();
-        var b = stack.pop().asFloat();
-        stack.push(Value.fromFloat(b * a));
+        var a = Value.longToFloat(stack.pop());
+        var b = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(b * a));
     }
 
     private static void F64_SUB(MStack stack) {
-        var a = stack.pop().asDouble();
-        var b = stack.pop().asDouble();
-        stack.push(Value.fromDouble(b - a));
+        var a = Value.longToDouble(stack.pop());
+        var b = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(b - a));
     }
 
     private static void F32_SUB(MStack stack) {
-        var a = stack.pop().asFloat();
-        var b = stack.pop().asFloat();
-        stack.push(Value.fromFloat(b - a));
+        var a = Value.longToFloat(stack.pop());
+        var b = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(b - a));
     }
 
     private static void F64_ADD(MStack stack) {
-        var a = stack.pop().asDouble();
-        var b = stack.pop().asDouble();
-        stack.push(Value.fromDouble(a + b));
+        var a = Value.longToDouble(stack.pop());
+        var b = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(a + b));
     }
 
     private static void F32_ADD(MStack stack) {
-        var a = stack.pop().asFloat();
-        var b = stack.pop().asFloat();
-        stack.push(Value.fromFloat(a + b));
+        var a = Value.longToFloat(stack.pop());
+        var b = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(a + b));
     }
 
     private static void I32_ROTR(MStack stack) {
-        var c = stack.pop().asInt();
-        var v = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_ROTR(v, c)));
+        var c = (int) stack.pop();
+        var v = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_ROTR(v, c));
     }
 
     private static void I32_ROTL(MStack stack) {
-        var c = stack.pop().asInt();
-        var v = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_ROTL(v, c)));
+        var c = (int) stack.pop();
+        var v = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_ROTL(v, c));
     }
 
     private static void I32_SHR_U(MStack stack) {
-        var c = stack.pop().asInt();
-        var v = stack.pop().asInt();
-        stack.push(Value.i32(v >>> c));
+        var c = (int) stack.pop();
+        var v = (int) stack.pop();
+        stack.push(v >>> c);
     }
 
     private static void I32_SHR_S(MStack stack) {
-        var c = stack.pop().asInt();
-        var v = stack.pop().asInt();
-        stack.push(Value.i32(v >> c));
+        var c = (int) stack.pop();
+        var v = (int) stack.pop();
+        stack.push(v >> c);
     }
 
     private static void I32_SHL(MStack stack) {
-        var c = stack.pop().asInt();
-        var v = stack.pop().asInt();
-        stack.push(Value.i32(v << c));
+        var c = (int) stack.pop();
+        var v = (int) stack.pop();
+        stack.push(v << c);
     }
 
     private static void I32_XOR(MStack stack) {
-        var a = stack.pop().asInt();
-        var b = stack.pop().asInt();
-        stack.push(Value.i32(a ^ b));
+        var a = (int) stack.pop();
+        var b = (int) stack.pop();
+        stack.push(a ^ b);
     }
 
     private static void I32_OR(MStack stack) {
-        var a = stack.pop().asInt();
-        var b = stack.pop().asInt();
-        stack.push(Value.i32(a | b));
+        var a = (int) stack.pop();
+        var b = (int) stack.pop();
+        stack.push(a | b);
     }
 
     private static void I32_AND(MStack stack) {
-        var a = stack.pop().asInt();
-        var b = stack.pop().asInt();
-        stack.push(Value.i32(a & b));
+        var a = (int) stack.pop();
+        var b = (int) stack.pop();
+        stack.push(a & b);
     }
 
     private static void I64_POPCNT(MStack stack) {
-        var tos = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_POPCNT(tos)));
+        var tos = stack.pop();
+        stack.push(OpcodeImpl.I64_POPCNT(tos));
     }
 
     private static void I64_CTZ(MStack stack) {
         var tos = stack.pop();
-        stack.push(Value.i64(OpcodeImpl.I64_CTZ(tos.asLong())));
+        stack.push(OpcodeImpl.I64_CTZ(tos));
     }
 
     private static void I64_CLZ(MStack stack) {
         var tos = stack.pop();
-        stack.push(Value.i64(OpcodeImpl.I64_CLZ(tos.asLong())));
+        stack.push(OpcodeImpl.I64_CLZ(tos));
     }
 
     private static void I64_ROTR(MStack stack) {
-        var c = stack.pop().asLong();
-        var v = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_ROTR(v, c)));
+        var c = stack.pop();
+        var v = stack.pop();
+        stack.push(OpcodeImpl.I64_ROTR(v, c));
     }
 
     private static void I64_ROTL(MStack stack) {
-        var c = stack.pop().asLong();
-        var v = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_ROTL(v, c)));
+        var c = stack.pop();
+        var v = stack.pop();
+        stack.push(OpcodeImpl.I64_ROTL(v, c));
     }
 
     private static void I64_REM_U(MStack stack) {
-        var b = stack.pop().asLong();
-        var a = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_REM_U(a, b)));
+        var b = stack.pop();
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_REM_U(a, b));
     }
 
     private static void I64_REM_S(MStack stack) {
-        var b = stack.pop().asLong();
-        var a = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_REM_S(a, b)));
+        var b = stack.pop();
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_REM_S(a, b));
     }
 
     private static void I64_SHR_U(MStack stack) {
-        var c = stack.pop().asLong();
-        var v = stack.pop().asLong();
-        stack.push(Value.i64(v >>> c));
+        var c = stack.pop();
+        var v = stack.pop();
+        stack.push(v >>> c);
     }
 
     private static void I64_SHR_S(MStack stack) {
-        var c = stack.pop().asLong();
-        var v = stack.pop().asLong();
-        stack.push(Value.i64(v >> c));
+        var c = stack.pop();
+        var v = stack.pop();
+        stack.push(v >> c);
     }
 
     private static void I64_SHL(MStack stack) {
-        var c = stack.pop().asLong();
-        var v = stack.pop().asLong();
-        stack.push(Value.i64(v << c));
+        var c = stack.pop();
+        var v = stack.pop();
+        stack.push(v << c);
     }
 
     private static void I64_XOR(MStack stack) {
-        var a = stack.pop().asLong();
-        var b = stack.pop().asLong();
-        stack.push(Value.i64(a ^ b));
+        var a = stack.pop();
+        var b = stack.pop();
+        stack.push(a ^ b);
     }
 
     private static void I64_OR(MStack stack) {
-        var a = stack.pop().asLong();
-        var b = stack.pop().asLong();
-        stack.push(Value.i64(a | b));
+        var a = stack.pop();
+        var b = stack.pop();
+        stack.push(a | b);
     }
 
     private static void I64_AND(MStack stack) {
-        var a = stack.pop().asLong();
-        var b = stack.pop().asLong();
-        stack.push(Value.i64(a & b));
+        var a = stack.pop();
+        var b = stack.pop();
+        stack.push(a & b);
     }
 
     private static void I32_REM_U(MStack stack) {
-        var b = stack.pop().asInt();
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_REM_U(a, b)));
+        var b = (int) stack.pop();
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_REM_U(a, b));
     }
 
     private static void I32_REM_S(MStack stack) {
-        var b = stack.pop().asInt();
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_REM_S(a, b)));
+        var b = (int) stack.pop();
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_REM_S(a, b));
     }
 
     private static void I64_DIV_U(MStack stack) {
-        var b = stack.pop().asLong();
-        var a = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_DIV_U(a, b)));
+        var b = stack.pop();
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_DIV_U(a, b));
     }
 
     private static void I64_DIV_S(MStack stack) {
-        var b = stack.pop().asLong();
-        var a = stack.pop().asLong();
-        stack.push(Value.i64(OpcodeImpl.I64_DIV_S(a, b)));
+        var b = stack.pop();
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_DIV_S(a, b));
     }
 
     private static void I64_GT_S(MStack stack) {
-        var b = stack.pop().asLong();
-        var a = stack.pop().asLong();
-        stack.push(Value.i32(OpcodeImpl.I64_GT_S(a, b)));
+        var b = stack.pop();
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_GT_S(a, b));
     }
 
     private static void I32_GT_U(MStack stack) {
-        var b = stack.pop().asInt();
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_GT_U(a, b)));
+        var b = (int) stack.pop();
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_GT_U(a, b));
     }
 
     private static void I32_GT_S(MStack stack) {
-        var b = stack.pop().asInt();
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_GT_S(a, b)));
+        var b = (int) stack.pop();
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_GT_S(a, b));
     }
 
     private static void I64_LT_U(MStack stack) {
-        var b = stack.pop().asLong();
-        var a = stack.pop().asLong();
-        stack.push(Value.i32(OpcodeImpl.I64_LT_U(a, b)));
+        var b = stack.pop();
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_LT_U(a, b));
     }
 
     private static void I64_LT_S(MStack stack) {
-        var b = stack.pop().asLong();
-        var a = stack.pop().asLong();
-        stack.push(Value.i32(OpcodeImpl.I64_LT_S(a, b)));
+        var b = stack.pop();
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_LT_S(a, b));
     }
 
     private static void I32_LT_U(MStack stack) {
-        var b = stack.pop().asInt();
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_LT_U(a, b)));
+        var b = (int) stack.pop();
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_LT_U(a, b));
     }
 
     private static void I32_LT_S(MStack stack) {
-        var b = stack.pop().asInt();
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_LT_S(a, b)));
+        var b = (int) stack.pop();
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_LT_S(a, b));
     }
 
     private static void I64_EQZ(MStack stack) {
-        var a = stack.pop().asLong();
-        stack.push(Value.i32(OpcodeImpl.I64_EQZ(a)));
+        var a = stack.pop();
+        stack.push(OpcodeImpl.I64_EQZ(a));
     }
 
     private static void I32_EQZ(MStack stack) {
-        var a = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_EQZ(a)));
+        var a = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_EQZ(a));
     }
 
     private static void I64_NE(MStack stack) {
-        var a = stack.pop().asLong();
-        var b = stack.pop().asLong();
-        stack.push(Value.i32(OpcodeImpl.I64_NE(a, b)));
+        var a = stack.pop();
+        var b = stack.pop();
+        stack.push(OpcodeImpl.I64_NE(a, b));
     }
 
     private static void I32_NE(MStack stack) {
-        var a = stack.pop().asInt();
-        var b = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_NE(a, b)));
+        var a = (int) stack.pop();
+        var b = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_NE(a, b));
     }
 
     private static void I64_EQ(MStack stack) {
-        var a = stack.pop().asLong();
-        var b = stack.pop().asLong();
-        stack.push(Value.i32(OpcodeImpl.I64_EQ(a, b)));
+        var a = stack.pop();
+        var b = stack.pop();
+        stack.push(OpcodeImpl.I64_EQ(a, b));
     }
 
     private static void I32_EQ(MStack stack) {
-        var a = stack.pop().asInt();
-        var b = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_EQ(a, b)));
+        var a = (int) stack.pop();
+        var b = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_EQ(a, b));
     }
 
     private static void MEMORY_SIZE(MStack stack, Instance instance) {
         var sz = instance.memory().pages();
-        stack.push(Value.i32(sz));
+        stack.push(sz);
     }
 
     private static void I64_STORE32(MStack stack, Instance instance, Operands operands) {
-        var value = stack.pop().asLong();
-        var ptr = (int) (operands.get(1) + stack.pop().asInt());
+        var value = stack.pop();
+        var ptr = (int) (operands.get(1) + (int) stack.pop());
         instance.memory().writeI32(ptr, (int) value);
     }
 
     private static void I64_STORE8(MStack stack, Instance instance, Operands operands) {
-        var value = stack.pop().asByte();
-        var ptr = (int) (operands.get(1) + stack.pop().asInt());
+        var value = (byte) stack.pop();
+        var ptr = (int) (operands.get(1) + (int) stack.pop());
         instance.memory().writeByte(ptr, value);
     }
 
-    private static void F64_PROMOTE_F32(MStack stack) {
-        var tos = stack.pop();
-        stack.push(Value.fromDouble(tos.asFloat()));
-    }
+    private static void F64_PROMOTE_F32(MStack stack) {}
 
-    private static void F64_REINTERPRET_I64(MStack stack) {
-        long tos = stack.pop().asLong();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_REINTERPRET_I64(tos)));
-    }
+    private static void F64_REINTERPRET_I64(MStack stack) {}
 
-    private static void I32_WRAP_I64(MStack stack) {
-        var tos = stack.pop();
-        stack.push(Value.i32(tos.asInt()));
-    }
+    private static void I32_WRAP_I64(MStack stack) {}
 
-    private static void I64_EXTEND_I32_S(MStack stack) {
-        var tos = stack.pop();
-        stack.push(Value.i64(tos.asInt()));
-    }
+    private static void I64_EXTEND_I32_S(MStack stack) {}
 
-    private static void I64_EXTEND_I32_U(MStack stack) {
-        int tos = stack.pop().asInt();
-        stack.push(Value.i64(OpcodeImpl.I64_EXTEND_I32_U(tos)));
-    }
+    private static void I64_EXTEND_I32_U(MStack stack) {}
 
     private static void I32_REINTERPRET_F32(MStack stack) {
-        float tos = stack.pop().asFloat();
-        stack.push(Value.i32(OpcodeImpl.I32_REINTERPRET_F32(tos)));
+        float tos = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.I32_REINTERPRET_F32(tos));
     }
 
     private static void I64_REINTERPRET_F64(MStack stack) {
-        double tos = stack.pop().asDouble();
-        stack.push(Value.i64(OpcodeImpl.I64_REINTERPRET_F64(tos)));
+        double tos = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.I64_REINTERPRET_F64(tos));
     }
 
     private static void F32_REINTERPRET_I32(MStack stack) {
-        int tos = stack.pop().asInt();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_REINTERPRET_I32(tos)));
+        int tos = (int) stack.pop();
+        stack.push(Value.floatToLong(OpcodeImpl.F32_REINTERPRET_I32(tos)));
     }
 
     private static void F32_DEMOTE_F64(MStack stack) {
-        var val = stack.pop().asDouble();
+        var val = Value.longToDouble(stack.pop());
 
-        stack.push(Value.fromFloat((float) val));
+        stack.push(Value.floatToLong((float) val));
     }
 
     private static void F32_CONVERT_I32_S(MStack stack) {
-        var tos = stack.pop().asInt();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_CONVERT_I32_S(tos)));
+        var tos = (int) stack.pop();
+        stack.push(Value.floatToLong(OpcodeImpl.F32_CONVERT_I32_S(tos)));
     }
 
     private static void I32_EXTEND_16_S(MStack stack) {
-        var tos = stack.pop().asInt();
-        stack.push(Value.i32(OpcodeImpl.I32_EXTEND_16_S(tos)));
+        var tos = (int) stack.pop();
+        stack.push(OpcodeImpl.I32_EXTEND_16_S(tos));
     }
 
     private static void I64_TRUNC_F64_S(MStack stack) {
-        double tos = stack.pop().asDouble();
-        stack.push(Value.i64(OpcodeImpl.I64_TRUNC_F64_S(tos)));
+        double tos = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.I64_TRUNC_F64_S(tos));
     }
 
     private static void F32_COPYSIGN(MStack stack) {
-        var b = stack.pop().asFloat();
-        var a = stack.pop().asFloat();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_COPYSIGN(a, b)));
+        var b = Value.longToFloat(stack.pop());
+        var a = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(OpcodeImpl.F32_COPYSIGN(a, b)));
     }
 
     private static void F32_ABS(MStack stack) {
-        var val = stack.pop().asFloat();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_ABS(val)));
+        var val = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(OpcodeImpl.F32_ABS(val)));
     }
 
     private static void F64_ABS(MStack stack) {
-        var val = stack.pop().asDouble();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_ABS(val)));
+        var val = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_ABS(val)));
     }
 
     private static void F32_NE(MStack stack) {
-        var b = stack.pop().asFloat();
-        var a = stack.pop().asFloat();
-        stack.push(Value.i32(OpcodeImpl.F32_NE(a, b)));
+        var b = Value.longToFloat(stack.pop());
+        var a = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.F32_NE(a, b));
     }
 
     private static void F64_NE(MStack stack) {
-        var b = stack.pop().asDouble();
-        var a = stack.pop().asDouble();
-        stack.push(Value.i32(OpcodeImpl.F64_NE(a, b)));
+        var b = Value.longToDouble(stack.pop());
+        var a = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.F64_NE(a, b));
     }
 
     private static void F32_LT(MStack stack) {
-        var b = stack.pop().asFloat();
-        var a = stack.pop().asFloat();
-        stack.push(Value.i32(OpcodeImpl.F32_LT(a, b)));
+        var b = Value.longToFloat(stack.pop());
+        var a = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.F32_LT(a, b));
     }
 
     private static void F64_LT(MStack stack) {
-        var b = stack.pop().asDouble();
-        var a = stack.pop().asDouble();
-        stack.push(Value.i32(OpcodeImpl.F64_LT(a, b)));
+        var b = Value.longToDouble(stack.pop());
+        var a = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.F64_LT(a, b));
     }
 
     private static void F32_LE(MStack stack) {
-        var b = stack.pop().asFloat();
-        var a = stack.pop().asFloat();
-        stack.push(Value.i32(OpcodeImpl.F32_LE(a, b)));
+        var b = Value.longToFloat(stack.pop());
+        var a = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.F32_LE(a, b));
     }
 
     private static void F64_LE(MStack stack) {
-        var b = stack.pop().asDouble();
-        var a = stack.pop().asDouble();
-        stack.push(Value.i32(OpcodeImpl.F64_LE(a, b)));
+        var b = Value.longToDouble(stack.pop());
+        var a = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.F64_LE(a, b));
     }
 
     private static void F32_GE(MStack stack) {
-        var b = stack.pop().asFloat();
-        var a = stack.pop().asFloat();
-        stack.push(Value.i32(OpcodeImpl.F32_GE(a, b)));
+        var b = Value.longToFloat(stack.pop());
+        var a = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.F32_GE(a, b));
     }
 
     private static void F64_GE(MStack stack) {
-        var b = stack.pop().asDouble();
-        var a = stack.pop().asDouble();
-        stack.push(Value.i32(OpcodeImpl.F64_GE(a, b)));
+        var b = Value.longToDouble(stack.pop());
+        var a = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.F64_GE(a, b));
     }
 
     private static void F32_GT(MStack stack) {
-        var b = stack.pop().asFloat();
-        var a = stack.pop().asFloat();
-        stack.push(Value.i32(OpcodeImpl.F32_GT(a, b)));
+        var b = Value.longToFloat(stack.pop());
+        var a = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.F32_GT(a, b));
     }
 
     private static void F64_GT(MStack stack) {
-        var b = stack.pop().asDouble();
-        var a = stack.pop().asDouble();
-        stack.push(Value.i32(OpcodeImpl.F64_GT(a, b)));
+        var b = Value.longToDouble(stack.pop());
+        var a = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.F64_GT(a, b));
     }
 
     private static void F32_CONVERT_I32_U(MStack stack) {
-        var tos = stack.pop().asInt();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_CONVERT_I32_U(tos)));
+        var tos = (int) stack.pop();
+        stack.push(Value.floatToLong(OpcodeImpl.F32_CONVERT_I32_U(tos)));
     }
 
     private static void F32_CONVERT_I64_S(MStack stack) {
-        var tos = stack.pop().asLong();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_CONVERT_I64_S(tos)));
+        var tos = stack.pop();
+        stack.push(Value.floatToLong(OpcodeImpl.F32_CONVERT_I64_S(tos)));
     }
 
     private static void REF_NULL(MStack stack, Operands operands) {
         var type = ValueType.forId((int) operands.get(0));
-        stack.push(new Value(type, (long) REF_NULL_VALUE));
+        stack.push(REF_NULL_VALUE);
     }
 
     private static void ELEM_DROP(Instance instance, Operands operands) {
@@ -1431,10 +1423,7 @@ class InterpreterMachine implements Machine {
 
     private static void REF_IS_NULL(MStack stack) {
         var val = stack.pop();
-        stack.push(
-                val.equals(Value.EXTREF_NULL) || val.equals(Value.FUNCREF_NULL)
-                        ? Value.TRUE
-                        : Value.FALSE);
+        stack.push(((val == REF_NULL_VALUE) ? Value.TRUE : Value.FALSE));
     }
 
     private static void DATA_DROP(Instance instance, Operands operands) {
@@ -1443,35 +1432,34 @@ class InterpreterMachine implements Machine {
     }
 
     private static void F64_CONVERT_I64_S(MStack stack) {
-        var tos = stack.pop().asLong();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_CONVERT_I64_S(tos)));
+        var tos = stack.pop();
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_CONVERT_I64_S(tos)));
     }
 
     private static void TABLE_GROW(MStack stack, Instance instance, Operands operands) {
         var tableidx = (int) operands.get(0);
         var table = instance.table(tableidx);
 
-        var size = stack.pop().asInt();
-        var valValue = stack.pop();
-        var val = valValue.asExtRef();
+        var size = (int) stack.pop();
+        var val = (int) stack.pop();
 
         var res = table.grow(size, val, instance);
-        stack.push(Value.i32(res));
+        stack.push(res);
     }
 
     private static void TABLE_SIZE(MStack stack, Instance instance, Operands operands) {
         var tableidx = (int) operands.get(0);
         var table = instance.table(tableidx);
 
-        stack.push(Value.i32(table.size()));
+        stack.push(table.size());
     }
 
     private static void TABLE_FILL(MStack stack, Instance instance, Operands operands) {
         var tableidx = (int) operands.get(0);
 
-        var size = stack.pop().asInt();
-        var val = stack.pop().asExtRef();
-        var offset = stack.pop().asInt();
+        var size = (int) stack.pop();
+        var val = (int) stack.pop();
+        var offset = (int) stack.pop();
 
         OpcodeImpl.TABLE_FILL(instance, tableidx, size, val, offset);
     }
@@ -1480,9 +1468,9 @@ class InterpreterMachine implements Machine {
         var tableidxSrc = (int) operands.get(1);
         var tableidxDst = (int) operands.get(0);
 
-        var size = stack.pop().asInt();
-        var s = stack.pop().asInt();
-        var d = stack.pop().asInt();
+        var size = (int) stack.pop();
+        var s = (int) stack.pop();
+        var d = (int) stack.pop();
 
         OpcodeImpl.TABLE_COPY(instance, tableidxSrc, tableidxDst, size, s, d);
     }
@@ -1494,9 +1482,9 @@ class InterpreterMachine implements Machine {
             throw new WASMRuntimeException(
                     "We don't support non zero index for memory: " + memidxSrc + " " + memidxDst);
         }
-        var size = stack.pop().asInt();
-        var offset = stack.pop().asInt();
-        var destination = stack.pop().asInt();
+        var size = (int) stack.pop();
+        var offset = (int) stack.pop();
+        var destination = (int) stack.pop();
         instance.memory().copy(destination, offset, size);
     }
 
@@ -1504,9 +1492,9 @@ class InterpreterMachine implements Machine {
         var tableidx = (int) operands.get(1);
         var elementidx = (int) operands.get(0);
 
-        var size = stack.pop().asInt();
-        var elemidx = stack.pop().asInt();
-        var offset = stack.pop().asInt();
+        var size = (int) stack.pop();
+        var elemidx = (int) stack.pop();
+        var offset = (int) stack.pop();
 
         OpcodeImpl.TABLE_INIT(instance, tableidx, elementidx, size, elemidx, offset);
     }
@@ -1517,101 +1505,101 @@ class InterpreterMachine implements Machine {
         if (memidx != 0) {
             throw new WASMRuntimeException("We don't support non zero index for memory: " + memidx);
         }
-        var size = stack.pop().asInt();
-        var offset = stack.pop().asInt();
-        var destination = stack.pop().asInt();
+        var size = (int) stack.pop();
+        var offset = (int) stack.pop();
+        var destination = (int) stack.pop();
         instance.memory().initPassiveSegment(segmentId, destination, offset, size);
     }
 
     private static void I64_TRUNC_F32_S(MStack stack) {
-        var tos = stack.pop().asFloat();
-        stack.push(Value.i64(OpcodeImpl.I64_TRUNC_F32_S(tos)));
+        var tos = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.I64_TRUNC_F32_S(tos));
     }
 
     private static void I32_TRUNC_F64_U(MStack stack) {
-        double tos = stack.pop().asDouble();
-        stack.push(Value.i32(OpcodeImpl.I32_TRUNC_F64_U(tos)));
+        double tos = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.I32_TRUNC_F64_U(tos));
     }
 
     private static void I32_TRUNC_F64_S(MStack stack) {
-        var tos = stack.pop().asDouble();
-        stack.push(Value.i32(OpcodeImpl.I32_TRUNC_F64_S(tos)));
+        var tos = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.I32_TRUNC_F64_S(tos));
     }
 
     private static void I64_TRUNC_SAT_F64_U(MStack stack) {
-        double tos = stack.pop().asDouble();
-        stack.push(Value.i64(OpcodeImpl.I64_TRUNC_SAT_F64_U(tos)));
+        double tos = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.I64_TRUNC_SAT_F64_U(tos));
     }
 
     private static void I64_TRUNC_SAT_F64_S(MStack stack) {
-        var tos = stack.pop().asDouble();
-        stack.push(Value.i64(OpcodeImpl.I64_TRUNC_SAT_F64_S(tos)));
+        var tos = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.I64_TRUNC_SAT_F64_S(tos));
     }
 
     private static void I64_TRUNC_SAT_F32_U(MStack stack) {
-        var tos = stack.pop().asFloat();
-        stack.push(Value.i64(OpcodeImpl.I64_TRUNC_SAT_F32_U(tos)));
+        var tos = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.I64_TRUNC_SAT_F32_U(tos));
     }
 
     private static void I64_TRUNC_SAT_F32_S(MStack stack) {
-        var tos = stack.pop().asFloat();
-        stack.push(Value.i64(OpcodeImpl.I64_TRUNC_SAT_F32_S(tos)));
+        var tos = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.I64_TRUNC_SAT_F32_S(tos));
     }
 
     private static void I64_TRUNC_F64_U(MStack stack) {
-        var tos = stack.pop().asDouble();
-        stack.push(Value.i64(OpcodeImpl.I64_TRUNC_F64_U(tos)));
+        var tos = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.I64_TRUNC_F64_U(tos));
     }
 
     private static void I64_TRUNC_F32_U(MStack stack) {
-        var tos = stack.pop().asFloat();
-        stack.push(Value.i64(OpcodeImpl.I64_TRUNC_F32_U(tos)));
+        var tos = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.I64_TRUNC_F32_U(tos));
     }
 
     private static void F32_CONVERT_I64_U(MStack stack) {
-        var tos = stack.pop().asLong();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_CONVERT_I64_U(tos)));
+        var tos = stack.pop();
+        stack.push(Value.floatToLong(OpcodeImpl.F32_CONVERT_I64_U(tos)));
     }
 
     private static void I32_TRUNC_F32_U(MStack stack) {
-        var tos = stack.pop().asFloat();
-        stack.push(Value.i32(OpcodeImpl.I32_TRUNC_F32_U(tos)));
+        var tos = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.I32_TRUNC_F32_U(tos));
     }
 
     private static void I32_TRUNC_SAT_F64_U(MStack stack) {
-        double tos = Double.longBitsToDouble(stack.pop().asLong());
-        stack.push(Value.i32(OpcodeImpl.I32_TRUNC_SAT_F64_U(tos)));
+        double tos = Double.longBitsToDouble(stack.pop());
+        stack.push(OpcodeImpl.I32_TRUNC_SAT_F64_U(tos));
     }
 
     private static void I32_TRUNC_SAT_F64_S(MStack stack) {
-        var tos = stack.pop().asDouble();
-        stack.push(Value.i32(OpcodeImpl.I32_TRUNC_SAT_F64_S(tos)));
+        var tos = Value.longToDouble(stack.pop());
+        stack.push(OpcodeImpl.I32_TRUNC_SAT_F64_S(tos));
     }
 
     private static void I32_TRUNC_SAT_F32_U(MStack stack) {
-        var tos = stack.pop().asFloat();
-        stack.push(Value.i32(OpcodeImpl.I32_TRUNC_SAT_F32_U(tos)));
+        var tos = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.I32_TRUNC_SAT_F32_U(tos));
     }
 
     private static void I32_TRUNC_SAT_F32_S(MStack stack) {
-        var tos = stack.pop().asFloat();
-        stack.push(Value.i32(OpcodeImpl.I32_TRUNC_SAT_F32_S(tos)));
+        var tos = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.I32_TRUNC_SAT_F32_S(tos));
     }
 
     private static void I32_TRUNC_F32_S(MStack stack) {
-        float tos = stack.pop().asFloat();
-        stack.push(Value.i32(OpcodeImpl.I32_TRUNC_F32_S(tos)));
+        float tos = Value.longToFloat(stack.pop());
+        stack.push(OpcodeImpl.I32_TRUNC_F32_S(tos));
     }
 
     private static void F64_COPYSIGN(MStack stack) {
-        var b = stack.pop().asDouble();
-        var a = stack.pop().asDouble();
-        stack.push(Value.fromDouble(OpcodeImpl.F64_COPYSIGN(a, b)));
+        var b = Value.longToDouble(stack.pop());
+        var a = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_COPYSIGN(a, b)));
     }
 
     private static void F32_TRUNC(MStack stack) {
-        var val = stack.pop().asFloat();
-        stack.push(Value.fromFloat(OpcodeImpl.F32_TRUNC(val)));
+        var val = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(OpcodeImpl.F32_TRUNC(val)));
     }
 
     private static void CALL(
@@ -1626,13 +1614,13 @@ class InterpreterMachine implements Machine {
     }
 
     private static void F64_NEG(MStack stack) {
-        var tos = stack.pop().asDouble();
-        stack.push(Value.fromDouble(-tos));
+        var tos = Value.longToDouble(stack.pop());
+        stack.push(Value.doubleToLong(-tos));
     }
 
     private static void F32_NEG(MStack stack) {
-        var tos = stack.pop().asFloat();
-        stack.push(Value.fromFloat(-tos));
+        var tos = Value.longToFloat(stack.pop());
+        stack.push(Value.floatToLong(-tos));
     }
 
     private static void MEMORY_FILL(MStack stack, Instance instance, Operands operands) {
@@ -1640,21 +1628,21 @@ class InterpreterMachine implements Machine {
         if (memidx != 0) {
             throw new WASMRuntimeException("We don't support multiple memories just yet");
         }
-        var size = stack.pop().asInt();
-        var val = stack.pop().asByte();
-        var offset = stack.pop().asInt();
+        var size = (int) stack.pop();
+        var val = (byte) stack.pop();
+        var offset = (int) stack.pop();
         var end = (size + offset);
         instance.memory().fill(val, offset, end);
     }
 
     private static void MEMORY_GROW(MStack stack, Instance instance) {
-        var size = stack.pop().asInt();
+        var size = (int) stack.pop();
         var nPages = instance.memory().grow(size);
-        stack.push(Value.i32(nPages));
+        stack.push(nPages);
     }
 
     private static int readMemPtr(MStack stack, Operands operands) {
-        int offset = stack.pop().asInt();
+        int offset = (int) stack.pop();
         if (operands.get(1) < 0 || operands.get(1) >= Integer.MAX_VALUE || offset < 0) {
             throw new WASMRuntimeException("out of bounds memory access");
         }
@@ -1662,137 +1650,138 @@ class InterpreterMachine implements Machine {
     }
 
     private static void F64_STORE(MStack stack, Instance instance, Operands operands) {
-        var value = stack.pop().asDouble();
+        var value = Value.longToDouble(stack.pop());
         var ptr = readMemPtr(stack, operands);
         instance.memory().writeF64(ptr, value);
     }
 
     private static void F32_STORE(MStack stack, Instance instance, Operands operands) {
-        var value = stack.pop().asFloat();
+        var value = Value.longToFloat(stack.pop());
         var ptr = readMemPtr(stack, operands);
         instance.memory().writeF32(ptr, value);
     }
 
     private static void I64_STORE(MStack stack, Instance instance, Operands operands) {
-        var value = stack.pop().asLong();
+        var value = stack.pop();
         var ptr = readMemPtr(stack, operands);
         instance.memory().writeLong(ptr, value);
     }
 
     private static void I64_STORE16(MStack stack, Instance instance, Operands operands) {
-        var value = stack.pop().asShort();
+        var value = (short) stack.pop();
         var ptr = readMemPtr(stack, operands);
         instance.memory().writeShort(ptr, value);
     }
 
     private static void I32_STORE(MStack stack, Instance instance, Operands operands) {
-        var value = stack.pop().asInt();
+        var value = (int) stack.pop();
         var ptr = readMemPtr(stack, operands);
         instance.memory().writeI32(ptr, value);
     }
 
     private static void I64_LOAD32_U(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
+        // TODO: make all the memory.readThings to return long
         var val = instance.memory().readU32(ptr);
-        stack.push(val);
+        stack.push(val.raw());
     }
 
     private static void I64_LOAD32_S(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI32(ptr);
         // TODO this is a bit hacky
-        stack.push(Value.i64(val.asInt()));
+        stack.push(val.raw());
     }
 
     private static void I64_LOAD16_U(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readU16(ptr);
         // TODO this is a bit hacky
-        stack.push(Value.i64(val.asInt()));
+        stack.push(val.raw());
     }
 
     private static void I32_LOAD16_U(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readU16(ptr);
-        stack.push(val);
+        stack.push(val.raw());
     }
 
     private static void I64_LOAD16_S(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI16(ptr);
         // TODO this is a bit hacky
-        stack.push(Value.i64(val.asInt()));
+        stack.push(val.raw());
     }
 
     private static void I32_LOAD16_S(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI16(ptr);
-        stack.push(val);
+        stack.push(val.raw());
     }
 
     private static void I64_LOAD8_U(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readU8(ptr);
         // TODO a bit hacky
-        stack.push(Value.i64(val.asInt()));
+        stack.push(val.raw());
     }
 
     private static void I32_LOAD8_U(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readU8(ptr);
-        stack.push(val);
+        stack.push(val.raw());
     }
 
     private static void I64_LOAD8_S(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI8(ptr);
         // TODO a bit hacky
-        stack.push(Value.i64(val.asInt()));
+        stack.push(val.raw());
     }
 
     private static void I32_LOAD8_S(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI8(ptr);
-        stack.push(val);
+        stack.push(val.raw());
     }
 
     private static void F64_LOAD(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readF64(ptr);
-        stack.push(val);
+        stack.push(val.raw());
     }
 
     private static void F32_LOAD(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readF32(ptr);
-        stack.push(val);
+        stack.push(val.raw());
     }
 
     private static void I64_LOAD(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI64(ptr);
-        stack.push(val);
+        stack.push(val.raw());
     }
 
     private static void I32_LOAD(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI32(ptr);
-        stack.push(val);
+        stack.push(val.raw());
     }
 
     private static void TABLE_SET(MStack stack, Instance instance, Operands operands) {
         var idx = (int) operands.get(0);
         var table = instance.table(idx);
 
-        var value = stack.pop().asExtRef();
-        var i = stack.pop().asInt();
+        var value = (int) stack.pop();
+        var i = (int) stack.pop();
         table.setRef(i, value, instance);
     }
 
     private static void TABLE_GET(MStack stack, Instance instance, Operands operands) {
         var idx = (int) operands.get(0);
-        var i = stack.pop().asInt();
-        stack.push(OpcodeImpl.TABLE_GET(instance, idx, i));
+        var i = (int) stack.pop();
+        stack.push(OpcodeImpl.TABLE_GET(instance, idx, i).raw());
     }
 
     private static void GLOBAL_SET(MStack stack, Instance instance, Operands operands) {
@@ -1805,11 +1794,11 @@ class InterpreterMachine implements Machine {
         int idx = (int) operands.get(0);
         var val = instance.readGlobal(idx);
 
-        stack.push(val);
+        stack.push(val.raw());
     }
 
     private static void SELECT(MStack stack) {
-        var pred = stack.pop().asInt();
+        var pred = (int) stack.pop();
         var b = stack.pop();
         var a = stack.pop();
         if (pred == 0) {
@@ -1820,7 +1809,7 @@ class InterpreterMachine implements Machine {
     }
 
     private static void SELECT_T(MStack stack) {
-        var pred = stack.pop().asInt();
+        var pred = (int) stack.pop();
         var b = stack.pop();
         var a = stack.pop();
         if (pred == 0) {
@@ -1836,7 +1825,7 @@ class InterpreterMachine implements Machine {
         var table = instance.table(tableIdx);
 
         var typeId = (int) operands.get(0);
-        int funcTableIdx = stack.pop().asInt();
+        int funcTableIdx = (int) stack.pop();
         int funcId = table.ref(funcTableIdx).asFuncRef();
         var tableInstance = table.instance(funcTableIdx);
         if (tableInstance != null) {
@@ -1892,7 +1881,7 @@ class InterpreterMachine implements Machine {
         var returnsSize = numberOfValuesToReturn(instance, instruction);
         frame.pushCtrl(instruction.opcode(), paramsSize, returnsSize, stack.size() - paramsSize);
 
-        frame.jumpTo(predValue.asInt() == 0 ? instruction.labelFalse() : instruction.labelTrue());
+        frame.jumpTo(predValue == 0 ? instruction.labelFalse() : instruction.labelTrue());
     }
 
     private static void ctrlJump(StackFrame frame, MStack stack, int n) {
@@ -1911,8 +1900,7 @@ class InterpreterMachine implements Machine {
     }
 
     private static void BR_TABLE(StackFrame frame, MStack stack, AnnotatedInstruction instruction) {
-        var predValue = stack.pop();
-        var pred = predValue.asInt();
+        var pred = (int) stack.pop();
 
         var defaultIdx = instruction.operandCount() - 1;
         if (pred < 0 || pred >= defaultIdx) {
@@ -1926,8 +1914,7 @@ class InterpreterMachine implements Machine {
     }
 
     private static void BR_IF(StackFrame frame, MStack stack, AnnotatedInstruction instruction) {
-        var predValue = stack.pop();
-        var pred = predValue.asInt();
+        var pred = (int) stack.pop();
 
         if (pred == 0) {
             frame.jumpTo(instruction.labelFalse());
@@ -1945,21 +1932,24 @@ class InterpreterMachine implements Machine {
         for (var i = params.size(); i > 0; i--) {
             var p = stack.pop();
             var t = params.get(i - 1);
-            if (p.type() != t) {
-                // Similar to what is happening in WaZero
-                // https://github.com/tetratelabs/wazero/blob/36676928d22ab92c34299eb0dca7608c92c94b22/internal/wasm/gofunc.go#L109
-                switch (t) {
-                    case I32:
-                    case I64:
-                    case F32:
-                    case F64:
-                        p = new Value(t, p.asLong());
-                        break;
-                    default:
-                        throw new RuntimeException("Type error when extracting args. Found: " + t);
-                }
-            }
-            args[i - 1] = p;
+            // TODO: re-enable the check and verify the boxing/unboxing
+            //            if (p.type() != t) {
+            //                // Similar to what is happening in WaZero
+            //                //
+            // https://github.com/tetratelabs/wazero/blob/36676928d22ab92c34299eb0dca7608c92c94b22/internal/wasm/gofunc.go#L109
+            //                switch (t) {
+            //                    case I32:
+            //                    case I64:
+            //                    case F32:
+            //                    case F64:
+            //                        p = new Value(t, p);
+            //                        break;
+            //                    default:
+            //                        throw new RuntimeException("Type error when extracting args.
+            // Found: " + t);
+            //                }
+            //            }
+            args[i - 1] = new Value(t, p);
         }
         return args;
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -70,7 +70,7 @@ class InterpreterMachine implements Machine {
             stackFrame.pushCtrl(OpCode.CALL, 0, type.returns().size(), stack.size());
             callStack.push(stackFrame);
 
-            // TODO: evaluate the boxing in this case ...
+            // TODO: evaluate if we can remove the boxing in this case ...
             var typedArgs = new Value[type.params().size()];
             for (int i = 0; i < type.params().size(); i++) {
                 typedArgs[i] = new Value(type.params().get(i), args[i]);

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -738,10 +738,10 @@ class InterpreterMachine implements Machine {
                     TABLE_GROW(stack, instance, operands);
                     break;
                 case REF_FUNC:
-                    stack.push((int) operands.get(0));
+                    stack.push(operands.get(0));
                     break;
                 case REF_NULL:
-                    REF_NULL(stack, operands);
+                    REF_NULL(stack);
                     break;
                 case REF_IS_NULL:
                     REF_IS_NULL(stack);
@@ -862,8 +862,8 @@ class InterpreterMachine implements Machine {
     }
 
     private static void I32_MUL(MStack stack) {
-        var a = (int) stack.pop();
-        var b = (int) stack.pop();
+        var a = stack.pop();
+        var b = stack.pop();
         stack.push(a * b);
     }
 
@@ -1288,13 +1288,13 @@ class InterpreterMachine implements Machine {
     }
 
     private static void I32_WRAP_I64(MStack stack) {
-        var tos = stack.pop();
-        stack.push((int) tos);
+        int tos = (int) stack.pop();
+        stack.push(tos);
     }
 
     private static void I64_EXTEND_I32_S(MStack stack) {
-        var tos = stack.pop();
-        stack.push((int) tos);
+        int tos = (int) stack.pop();
+        stack.push(tos);
     }
 
     private static void I64_EXTEND_I32_U(MStack stack) {
@@ -1424,8 +1424,7 @@ class InterpreterMachine implements Machine {
         stack.push(Value.floatToLong(OpcodeImpl.F32_CONVERT_I64_S(tos)));
     }
 
-    private static void REF_NULL(MStack stack, Operands operands) {
-        var type = ValueType.forId((int) operands.get(0));
+    private static void REF_NULL(MStack stack) {
         stack.push(REF_NULL_VALUE);
     }
 
@@ -1944,27 +1943,6 @@ class InterpreterMachine implements Machine {
         var args = new long[params.size()];
         for (var i = params.size(); i > 0; i--) {
             var p = stack.pop();
-            var t = params.get(i - 1);
-            // TODO: re-enable the check and verify the boxing/unboxing
-            // This section and checks can be moved in Instance.export!
-            //
-            //            if (p.type() != t) {
-            //                // Similar to what is happening in WaZero
-            //                //
-            // https://github.com/tetratelabs/wazero/blob/36676928d22ab92c34299eb0dca7608c92c94b22/internal/wasm/gofunc.go#L109
-            //                switch (t) {
-            //                    case I32:
-            //                    case I64:
-            //                    case F32:
-            //                    case F64:
-            //                        p = new Value(t, p);
-            //                        break;
-            //                    default:
-            //                        throw new RuntimeException("Type error when extracting args.
-            // Found: " + t);
-            //                }
-            //            }
-            // args[i - 1] = new Value(t, p);
             args[i - 1] = p;
         }
         return args;

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -1277,15 +1277,30 @@ class InterpreterMachine implements Machine {
         instance.memory().writeByte(ptr, value);
     }
 
-    private static void F64_PROMOTE_F32(MStack stack) {}
+    private static void F64_PROMOTE_F32(MStack stack) {
+        var tos = stack.pop();
+        stack.push(Double.doubleToRawLongBits(Float.intBitsToFloat((int) tos)));
+    }
 
-    private static void F64_REINTERPRET_I64(MStack stack) {}
+    private static void F64_REINTERPRET_I64(MStack stack) {
+        long tos = stack.pop();
+        stack.push(Value.doubleToLong(OpcodeImpl.F64_REINTERPRET_I64(tos)));
+    }
 
-    private static void I32_WRAP_I64(MStack stack) {}
+    private static void I32_WRAP_I64(MStack stack) {
+        var tos = stack.pop();
+        stack.push((int) tos);
+    }
 
-    private static void I64_EXTEND_I32_S(MStack stack) {}
+    private static void I64_EXTEND_I32_S(MStack stack) {
+        var tos = stack.pop();
+        stack.push((int) tos);
+    }
 
-    private static void I64_EXTEND_I32_U(MStack stack) {}
+    private static void I64_EXTEND_I32_U(MStack stack) {
+        var tos = stack.pop();
+        stack.push(OpcodeImpl.I64_EXTEND_I32_U((int) tos));
+    }
 
     private static void I32_REINTERPRET_F32(MStack stack) {
         float tos = Value.longToFloat(stack.pop());

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -70,17 +70,12 @@ class InterpreterMachine implements Machine {
             stackFrame.pushCtrl(OpCode.CALL, 0, type.returns().size(), stack.size());
             callStack.push(stackFrame);
 
-            // TODO: evaluate if we can remove the boxing in this case ...
-            var typedArgs = new Value[type.params().size()];
-            for (int i = 0; i < type.params().size(); i++) {
-                typedArgs[i] = new Value(type.params().get(i), args[i]);
-            }
-            var results = instance.callHostFunction(funcId, typedArgs);
+            var results = instance.callHostFunction(funcId, args);
             // a host function can return null or an array of ints
             // which we will push onto the stack
             if (results != null) {
                 for (var result : results) {
-                    stack.push(result.raw());
+                    stack.push(result);
                 }
             }
         }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -1683,66 +1683,66 @@ class InterpreterMachine implements Machine {
         var ptr = readMemPtr(stack, operands);
         // TODO: make all the memory.readThings to return long
         var val = instance.memory().readU32(ptr);
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void I64_LOAD32_S(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI32(ptr);
         // TODO this is a bit hacky
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void I64_LOAD16_U(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readU16(ptr);
         // TODO this is a bit hacky
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void I32_LOAD16_U(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readU16(ptr);
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void I64_LOAD16_S(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI16(ptr);
         // TODO this is a bit hacky
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void I32_LOAD16_S(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI16(ptr);
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void I64_LOAD8_U(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readU8(ptr);
         // TODO a bit hacky
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void I32_LOAD8_U(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readU8(ptr);
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void I64_LOAD8_S(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI8(ptr);
         // TODO a bit hacky
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void I32_LOAD8_S(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI8(ptr);
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void F64_LOAD(MStack stack, Instance instance, Operands operands) {
@@ -1754,19 +1754,19 @@ class InterpreterMachine implements Machine {
     private static void F32_LOAD(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readF32(ptr);
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void I64_LOAD(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI64(ptr);
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void I32_LOAD(MStack stack, Instance instance, Operands operands) {
         var ptr = readMemPtr(stack, operands);
         var val = instance.memory().readI32(ptr);
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void TABLE_SET(MStack stack, Instance instance, Operands operands) {
@@ -1781,7 +1781,7 @@ class InterpreterMachine implements Machine {
     private static void TABLE_GET(MStack stack, Instance instance, Operands operands) {
         var idx = (int) operands.get(0);
         var i = (int) stack.pop();
-        stack.push(OpcodeImpl.TABLE_GET(instance, idx, i).raw());
+        stack.push(OpcodeImpl.TABLE_GET(instance, idx, i));
     }
 
     private static void GLOBAL_SET(MStack stack, Instance instance, Operands operands) {
@@ -1794,7 +1794,7 @@ class InterpreterMachine implements Machine {
         int idx = (int) operands.get(0);
         var val = instance.readGlobal(idx);
 
-        stack.push(val.raw());
+        stack.push(val);
     }
 
     private static void SELECT(MStack stack) {
@@ -1826,7 +1826,7 @@ class InterpreterMachine implements Machine {
 
         var typeId = (int) operands.get(0);
         int funcTableIdx = (int) stack.pop();
-        int funcId = table.ref(funcTableIdx).asFuncRef();
+        int funcId = (int) table.ref(funcTableIdx);
         var tableInstance = table.instance(funcTableIdx);
         if (tableInstance != null) {
             instance = tableInstance;

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
@@ -1,6 +1,5 @@
 package com.dylibso.chicory.runtime;
 
-import com.dylibso.chicory.wasm.types.Value;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
@@ -10,33 +9,22 @@ import java.util.Deque;
  * We should replace with something more idiomatic and performant.
  */
 public class MStack {
-    private final Deque<Value> stack;
+    private final Deque<Long> stack;
 
     public MStack() {
         this.stack = new ArrayDeque<>();
     }
 
-    public void push(Value v) {
-        if (v == null) {
-            throw new RuntimeException("Can't push null value onto stack");
-        }
+    public void push(long v) {
         this.stack.push(v);
     }
 
-    public Value pop() {
-        var r = this.stack.pollFirst();
-        if (r == null) {
-            throw new RuntimeException("Stack underflow exception");
-        }
-        return r;
+    public long pop() {
+        return this.stack.pollFirst();
     }
 
-    public Value peek() {
-        var r = this.stack.peek();
-        if (r == null) {
-            throw new RuntimeException("Stack underflow exception");
-        }
-        return r;
+    public long peek() {
+        return this.stack.peek();
     }
 
     public int size() {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
@@ -9,6 +9,10 @@ import java.util.Deque;
  * We should replace with something more idiomatic and performant.
  */
 public class MStack {
+    // TODO:
+    // implement a Deque for long:
+    // inspiration from:
+    // https://github.com/real-logic/agrona/blob/6e15a5c18af85f0d715c8fec06ddcf1e389c8f72/agrona/src/main/java/org/agrona/collections/IntArrayQueue.java
     private final Deque<Long> stack;
 
     public MStack() {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MStack.java
@@ -1,42 +1,48 @@
 package com.dylibso.chicory.runtime;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-
 /**
  * A temporary class that gives us a little more control over the interface.
  * It allows us to assert non-nulls as well as throw stack under and overflow exceptions
  * We should replace with something more idiomatic and performant.
  */
 public class MStack {
-    // TODO:
-    // implement a Deque for long:
-    // inspiration from:
-    // https://github.com/real-logic/agrona/blob/6e15a5c18af85f0d715c8fec06ddcf1e389c8f72/agrona/src/main/java/org/agrona/collections/IntArrayQueue.java
-    private final Deque<Long> stack;
+    public static final int MIN_CAPACITY = 8;
+
+    private int count;
+    private long[] elements;
+
+    private void increaseCapacity() {
+        final int newCapacity = elements.length << 1;
+
+        final long[] array = new long[newCapacity];
+        System.arraycopy(elements, 0, array, 0, elements.length);
+
+        elements = array;
+    }
 
     public MStack() {
-        this.stack = new ArrayDeque<>();
+        this.elements = new long[MIN_CAPACITY];
     }
 
     public void push(long v) {
-        this.stack.push(v);
+        elements[count] = v;
+        count++;
+
+        if (count == elements.length) {
+            increaseCapacity();
+        }
     }
 
     public long pop() {
-        return this.stack.pollFirst();
+        count--;
+        return elements[count];
     }
 
     public long peek() {
-        return this.stack.peek();
+        return elements[count - 1];
     }
 
     public int size() {
-        return this.stack.size();
-    }
-
-    @Override
-    public String toString() {
-        return this.stack.toString();
+        return count;
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Machine.java
@@ -1,9 +1,8 @@
 package com.dylibso.chicory.runtime;
 
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
-import com.dylibso.chicory.wasm.types.Value;
 
 public interface Machine {
 
-    Value[] call(int funcId, Value[] args) throws ChicoryException;
+    long[] call(int funcId, long[] args) throws ChicoryException;
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
@@ -354,9 +354,9 @@ public final class Memory {
         }
     }
 
-    public Value readF64(int addr) {
+    public long readF64(int addr) {
         try {
-            return Value.f64(buffer.getLong(addr));
+            return buffer.getLong(addr);
         } catch (IndexOutOfBoundsException e) {
             throw new WASMRuntimeException("out of bounds memory access");
         }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
@@ -234,12 +234,12 @@ public final class Memory {
         }
     }
 
-    public Value readI32(int addr) {
-        return Value.i32(readInt(addr));
+    public long readI32(int addr) {
+        return readInt(addr);
     }
 
-    public Value readU32(int addr) {
-        return Value.i32(Integer.toUnsignedLong(readInt(addr)));
+    public long readU32(int addr) {
+        return Integer.toUnsignedLong(readInt(addr));
     }
 
     public void writeLong(int addr, long data) {
@@ -258,8 +258,8 @@ public final class Memory {
         }
     }
 
-    public Value readI64(int addr) {
-        return Value.i64(readLong(addr));
+    public long readI64(int addr) {
+        return readLong(addr);
     }
 
     public void writeShort(int addr, short data) {
@@ -278,13 +278,13 @@ public final class Memory {
         }
     }
 
-    public Value readI16(int addr) {
-        return Value.i32(readShort(addr));
+    public long readI16(int addr) {
+        return readShort(addr);
     }
 
-    public Value readU16(int addr) {
+    public long readU16(int addr) {
         try {
-            return Value.i32(buffer.getShort(addr) & 0xffff);
+            return buffer.getShort(addr) & 0xffff;
         } catch (IndexOutOfBoundsException e) {
             throw new WASMRuntimeException("out of bounds memory access");
         }
@@ -298,17 +298,17 @@ public final class Memory {
         }
     }
 
-    public Value readU8(int addr) {
+    public long readU8(int addr) {
         try {
-            return Value.i32(read(addr) & 0xFF);
+            return read(addr) & 0xFF;
         } catch (IndexOutOfBoundsException e) {
             throw new WASMRuntimeException("out of bounds memory access");
         }
     }
 
-    public Value readI8(int addr) {
+    public long readI8(int addr) {
         try {
-            return Value.i32(read(addr));
+            return read(addr);
         } catch (IndexOutOfBoundsException e) {
             throw new WASMRuntimeException("out of bounds memory access");
         }
@@ -322,9 +322,9 @@ public final class Memory {
         }
     }
 
-    public Value readF32(int addr) {
+    public long readF32(int addr) {
         try {
-            return Value.f32(buffer.getInt(addr));
+            return buffer.getInt(addr);
         } catch (IndexOutOfBoundsException e) {
             throw new WASMRuntimeException("out of bounds memory access");
         }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
@@ -11,7 +11,6 @@ import com.dylibso.chicory.wasm.types.ActiveDataSegment;
 import com.dylibso.chicory.wasm.types.DataSegment;
 import com.dylibso.chicory.wasm.types.MemoryLimits;
 import com.dylibso.chicory.wasm.types.PassiveDataSegment;
-import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
@@ -178,10 +177,6 @@ public final class Memory {
 
     public String readCString(int addr) {
         return readCString(addr, StandardCharsets.UTF_8);
-    }
-
-    public void write(int addr, Value data) {
-        write(addr, data.data());
     }
 
     public void write(int addr, byte[] data) {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
@@ -865,14 +865,15 @@ public final class OpcodeImpl {
         for (int i = offset; i < end; i++) {
             var elem = instance.element(elementidx);
             var val = computeConstantValue(instance, elem.initializers().get(elemidx++));
+            var rawValue = (int) val.raw();
             if (table.elementType() == ValueType.FuncRef) {
-                if (val.asFuncRef() > instance.functionCount()) {
+                if (rawValue > instance.functionCount()) {
                     throw new WASMRuntimeException("out of bounds table access");
                 }
-                table.setRef(i, val.asFuncRef(), instance);
+                table.setRef(i, rawValue, instance);
             } else {
                 assert table.elementType() == ValueType.ExternRef;
-                table.setRef(i, val.asExtRef(), instance);
+                table.setRef(i, rawValue, instance);
             }
         }
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
@@ -795,7 +795,7 @@ public final class OpcodeImpl {
 
     // ========= Tables =========
 
-    public static long TABLE_GET(Instance instance, int tableIndex, int index) {
+    public static int TABLE_GET(Instance instance, int tableIndex, int index) {
         TableInstance table = instance.table(tableIndex);
         if (index < 0 || index >= table.limits().max() || index >= table.size()) {
             throw new WASMRuntimeException("out of bounds table access");

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
@@ -830,11 +830,11 @@ public final class OpcodeImpl {
             if (d <= s) {
                 var val = src.ref(s++);
                 var inst = src.instance(d);
-                dest.setRef(d++, val, inst);
+                dest.setRef(d++, (int) val, inst);
             } else {
                 var val = src.ref(s + i);
                 var inst = src.instance(d + i);
-                dest.setRef(d + i, val, inst);
+                dest.setRef(d + i, (int) val, inst);
             }
         }
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
@@ -7,7 +7,6 @@ import static com.dylibso.chicory.runtime.ConstantEvaluators.computeConstantValu
 import com.dylibso.chicory.runtime.exceptions.WASMRuntimeException;
 import com.dylibso.chicory.wasm.types.OpCode;
 import com.dylibso.chicory.wasm.types.PassiveElement;
-import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 
 /**
@@ -796,7 +795,7 @@ public final class OpcodeImpl {
 
     // ========= Tables =========
 
-    public static Value TABLE_GET(Instance instance, int tableIndex, int index) {
+    public static long TABLE_GET(Instance instance, int tableIndex, int index) {
         TableInstance table = instance.table(tableIndex);
         if (index < 0 || index >= table.limits().max() || index >= table.size()) {
             throw new WASMRuntimeException("out of bounds table access");
@@ -831,11 +830,11 @@ public final class OpcodeImpl {
             if (d <= s) {
                 var val = src.ref(s++);
                 var inst = src.instance(d);
-                dest.setRef(d++, val.asFuncRef(), inst);
+                dest.setRef(d++, val, inst);
             } else {
                 var val = src.ref(s + i);
                 var inst = src.instance(d + i);
-                dest.setRef(d + i, val.asFuncRef(), inst);
+                dest.setRef(d + i, val, inst);
             }
         }
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/StackFrame.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/StackFrame.java
@@ -25,12 +25,12 @@ public class StackFrame {
 
     private final int funcId;
     private int pc;
-    private final Value[] locals;
+    private final long[] locals;
     private final Instance instance;
 
     private final List<CtrlFrame> ctrlStack = new ArrayList<>();
 
-    public StackFrame(Instance instance, int funcId, Value[] args, List<ValueType> localTypes) {
+    public StackFrame(Instance instance, int funcId, long[] args, List<ValueType> localTypes) {
         this(Collections.emptyList(), instance, funcId, args, localTypes);
     }
 
@@ -38,7 +38,7 @@ public class StackFrame {
             List<AnnotatedInstruction> code,
             Instance instance,
             int funcId,
-            Value[] args,
+            long[] args,
             List<ValueType> localTypes) {
         this.code = code;
         this.instance = instance;
@@ -55,11 +55,11 @@ public class StackFrame {
         }
     }
 
-    void setLocal(int i, Value v) {
+    void setLocal(int i, long v) {
         this.locals[i] = v;
     }
 
-    Value local(int i) {
+    long local(int i) {
         return locals[i];
     }
 
@@ -132,7 +132,7 @@ public class StackFrame {
 
     public static void doControlTransfer(CtrlFrame ctrlFrame, MStack stack) {
         var endResults = ctrlFrame.startValues + ctrlFrame.endValues; // unwind stack
-        Value[] returns = new Value[endResults];
+        long[] returns = new long[endResults];
         for (int i = 0; i < returns.length; i++) {
             if (stack.size() > 0) {
                 returns[i] = stack.pop();
@@ -144,10 +144,8 @@ public class StackFrame {
         }
 
         for (int i = 0; i < returns.length; i++) {
-            Value value = returns[returns.length - 1 - i];
-            if (value != null) {
-                stack.push(value);
-            }
+            long value = returns[returns.length - 1 - i];
+            stack.push(value);
         }
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/TableInstance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/TableInstance.java
@@ -14,12 +14,12 @@ public class TableInstance {
 
     private final Table table;
     private Instance[] instances;
-    private int[] refs;
+    private long[] refs;
 
     public TableInstance(Table table) {
         this.table = table;
         this.instances = new Instance[(int) table.limits().min()];
-        refs = new int[(int) table.limits().min()];
+        refs = new long[(int) table.limits().min()];
         Arrays.fill(refs, REF_NULL_VALUE);
     }
 
@@ -50,11 +50,12 @@ public class TableInstance {
         return oldSize;
     }
 
+    // TODO: this should return a long instead
     public Value ref(int index) {
         if (index < 0 || index >= this.refs.length) {
             throw new ChicoryException("undefined element");
         }
-        int res = this.refs[index];
+        long res = this.refs[index];
         if (this.elementType() == ValueType.FuncRef) {
             return Value.funcRef(res);
         } else {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/TableInstance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/TableInstance.java
@@ -56,7 +56,7 @@ public class TableInstance {
         return this.refs[index];
     }
 
-    public void setRef(int index, long value, Instance instance) {
+    public void setRef(int index, int value, Instance instance) {
         if (index < 0 || index >= this.refs.length || index >= this.instances.length) {
             throw new UninstantiableException("out of bounds table access");
         }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/TableInstance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/TableInstance.java
@@ -6,7 +6,6 @@ import com.dylibso.chicory.wasm.exceptions.ChicoryException;
 import com.dylibso.chicory.wasm.exceptions.UninstantiableException;
 import com.dylibso.chicory.wasm.types.Limits;
 import com.dylibso.chicory.wasm.types.Table;
-import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.Arrays;
 
@@ -50,20 +49,14 @@ public class TableInstance {
         return oldSize;
     }
 
-    // TODO: this should return a long instead
-    public Value ref(int index) {
+    public long ref(int index) {
         if (index < 0 || index >= this.refs.length) {
             throw new ChicoryException("undefined element");
         }
-        long res = this.refs[index];
-        if (this.elementType() == ValueType.FuncRef) {
-            return Value.funcRef(res);
-        } else {
-            return Value.externRef(res);
-        }
+        return this.refs[index];
     }
 
-    public void setRef(int index, int value, Instance instance) {
+    public void setRef(int index, long value, Instance instance) {
         if (index < 0 || index >= this.refs.length || index >= this.instances.length) {
             throw new UninstantiableException("out of bounds table access");
         }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/TableInstance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/TableInstance.java
@@ -13,12 +13,12 @@ public class TableInstance {
 
     private final Table table;
     private Instance[] instances;
-    private long[] refs;
+    private int[] refs;
 
     public TableInstance(Table table) {
         this.table = table;
         this.instances = new Instance[(int) table.limits().min()];
-        refs = new long[(int) table.limits().min()];
+        refs = new int[(int) table.limits().min()];
         Arrays.fill(refs, REF_NULL_VALUE);
     }
 
@@ -49,7 +49,7 @@ public class TableInstance {
         return oldSize;
     }
 
-    public long ref(int index) {
+    public int ref(int index) {
         if (index < 0 || index >= this.refs.length) {
             throw new ChicoryException("undefined element");
         }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/WasmFunctionHandle.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/WasmFunctionHandle.java
@@ -1,11 +1,9 @@
 package com.dylibso.chicory.runtime;
 
-import com.dylibso.chicory.wasm.types.Value;
-
 /**
  * Represents a Java function that can be called from Wasm.
  */
 @FunctionalInterface
 public interface WasmFunctionHandle {
-    Value[] apply(Instance instance, Value... args);
+    long[] apply(Instance instance, long... args);
 }

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/InterruptionTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/InterruptionTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.dylibso.chicory.wasm.Parser;
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
-import com.dylibso.chicory.wasm.types.Value;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ public class InterruptionTest {
                                                 .getResourceAsStream("compiled/power.c.wasm")))
                         .build();
         var function = instance.export("run");
-        assertInterruption(() -> function.apply(Value.i32(100)));
+        assertInterruption(() -> function.apply(100));
     }
 
     private static void assertInterruption(Runnable function) throws InterruptedException {

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
@@ -367,7 +367,7 @@ public class JavaTestGen {
         var args =
                 (cmd.action().args() != null)
                         ? Arrays.stream(cmd.action().args())
-                                .map(WasmValue::toWasmValue)
+                                .map(WasmValue::toArgsValue)
                                 .collect(Collectors.joining(", "))
                         : "";
 
@@ -393,19 +393,9 @@ public class JavaTestGen {
 
             for (int i = 0; i < cmd.expected().length; i++) {
                 var expected = cmd.expected()[i];
-                var returnVar = expected.toJavaValue();
-                var typeConversion = expected.extractType();
-                var deltaParam = expected.delta();
-                exprs.add(
-                        new NameExpr(
-                                "assertEquals("
-                                        + returnVar
-                                        + ", results["
-                                        + i
-                                        + "]"
-                                        + typeConversion
-                                        + deltaParam
-                                        + ")"));
+                var expectedVar = expected.toExpectedValue();
+                var resultVar = expected.toResultValue("results[" + i + "]");
+                exprs.add(new NameExpr("assertEquals(" + expectedVar + ", " + resultVar + ")"));
             }
 
             return exprs;
@@ -421,7 +411,7 @@ public class JavaTestGen {
         if (cmd.action().type() == INVOKE) {
             var args =
                     Arrays.stream(cmd.action().args())
-                            .map(WasmValue::toWasmValue)
+                            .map(WasmValue::toArgsValue)
                             .collect(Collectors.joining(", "));
             invocationMethod = ".apply(" + args + ")";
         } else {

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/WasmValue.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/wast/WasmValue.java
@@ -18,7 +18,28 @@ public class WasmValue {
         return value;
     }
 
-    public String toJavaValue() {
+    public String toResultValue(String result) {
+        switch (type) {
+            case I64:
+                return result;
+            case I32:
+                return "(int) " + result;
+            case F32:
+                return "Float.intBitsToFloat((int) " + result + "), 0.0";
+            case F64:
+                return "Double.longBitsToDouble(" + result + "), 0.0";
+            case EXTERN_REF:
+            case FUNC_REF:
+                if (result.equals("null")) {
+                    return "Value.REF_NULL_VALUE";
+                }
+                return result;
+            default:
+                throw new IllegalArgumentException("Type not recognized " + type);
+        }
+    }
+
+    public String toExpectedValue() {
         switch (type) {
             case I32:
                 return "Integer.parseUnsignedInt(\"" + value + "\")";
@@ -53,13 +74,9 @@ public class WasmValue {
                     return "null";
                 }
             case EXTERN_REF:
-                if (value.toString().equals("null")) {
-                    return "Value.EXTREF_NULL";
-                }
-                return value;
             case FUNC_REF:
-                if (value.toString().equals("null")) {
-                    return "Value.FUNCREF_NULL";
+                if (value.equals("null")) {
+                    return "Value.REF_NULL_VALUE";
                 }
                 return value;
             default:
@@ -67,61 +84,42 @@ public class WasmValue {
         }
     }
 
-    public String toWasmValue() {
+    public String toArgsValue() {
         switch (type) {
             case I32:
-                return "Value.i32(" + toJavaValue() + ")";
-            case I64:
-                return "Value.i64(" + toJavaValue() + ")";
             case F32:
-                return "Value.f32(Integer.parseUnsignedInt(\"" + value + "\"))";
-            case F64:
-                return "Value.f64(Long.parseUnsignedLong(\"" + value + "\"))";
-            case EXTERN_REF:
-                if (value.toString().equals("null")) {
-                    return "Value.EXTREF_NULL";
+                if (value != null) {
+                    switch (value) {
+                        case "nan:canonical":
+                        case "nan:arithmetic":
+                            return "(int) Float.NaN";
+                        default:
+                            return "Integer.parseUnsignedInt(\"" + value + "\")";
+                    }
+                } else {
+                    return "null";
                 }
-                return "Value.externRef(" + value + ")";
+            case I64:
+            case F64:
+                if (value != null) {
+                    switch (value) {
+                        case "nan:canonical":
+                        case "nan:arithmetic":
+                            return "(long) Double.NaN";
+                        default:
+                            return "Long.parseUnsignedLong(\"" + value + "\")";
+                    }
+                } else {
+                    return "null";
+                }
+            case EXTERN_REF:
             case FUNC_REF:
                 if (value.toString().equals("null")) {
-                    return "Value.FUNCREF_NULL";
+                    return "Value.REF_NULL_VALUE";
                 }
-                return "Value.funcRef(" + value + ")";
+                return value;
             default:
                 throw new IllegalArgumentException("Type not recognized " + type);
-        }
-    }
-
-    public String extractType() {
-        if (value == null || value.equals("null")) {
-            return "";
-        } else {
-            switch (type) {
-                case I32:
-                    return ".asInt()";
-                case I64:
-                    return ".asLong()";
-                case F32:
-                    return ".asFloat()";
-                case F64:
-                    return ".asDouble()";
-                case EXTERN_REF:
-                    return ".asExtRef()";
-                case FUNC_REF:
-                    return ".asFuncRef()";
-                default:
-                    throw new IllegalArgumentException("Type not recognized " + type);
-            }
-        }
-    }
-
-    public String delta() {
-        switch (type) {
-            case F32:
-            case F64:
-                return ", 0.0";
-            default:
-                return "";
         }
     }
 }

--- a/wabt/src/test/java/com/dylibso/chicory/wabt/Wat2WasmTest.java
+++ b/wabt/src/test/java/com/dylibso/chicory/wabt/Wat2WasmTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasi.WasiExitException;
 import com.dylibso.chicory.wasm.Parser;
-import com.dylibso.chicory.wasm.types.Value;
 import java.io.File;
 import org.junit.jupiter.api.Test;
 
@@ -37,10 +36,8 @@ public class Wat2WasmTest {
 
         var addFunction = moduleInstance.export("add");
         var results =
-                addFunction.apply(
-                        Value.i32(Integer.parseUnsignedInt("1")),
-                        Value.i32(Integer.parseUnsignedInt("41")));
-        assertEquals(Integer.parseUnsignedInt("42"), results[0].asInt());
+                addFunction.apply(Integer.parseUnsignedInt("1"), Integer.parseUnsignedInt("41"));
+        assertEquals(Integer.parseUnsignedInt("42"), results[0]);
     }
 
     @Test

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
@@ -475,8 +475,8 @@ public final class WasiPreview1 implements Closeable {
         int totalRead = 0;
         for (var i = 0; i < iovsLen; i++) {
             int base = iovs + (i * 8);
-            int iovBase = memory.readI32(base).asInt();
-            var iovLen = memory.readI32(base + 4).asInt();
+            int iovBase = (int) memory.readI32(base);
+            var iovLen = (int) memory.readI32(base + 4);
             try {
                 byte[] data = new byte[iovLen];
                 int read = reader.read(data);
@@ -676,8 +676,8 @@ public final class WasiPreview1 implements Closeable {
         var totalWritten = 0;
         for (var i = 0; i < iovsLen; i++) {
             var base = iovs + (i * 8);
-            var iovBase = memory.readI32(base).asInt();
-            var iovLen = memory.readI32(base + 4).asInt();
+            var iovBase = (int) memory.readI32(base);
+            var iovLen = (int) memory.readI32(base + 4);
             var data = memory.readBytes(iovBase, iovLen);
             try {
                 int written = writer.write(data);

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
@@ -475,8 +475,8 @@ public final class WasiPreview1 implements Closeable {
         int totalRead = 0;
         for (var i = 0; i < iovsLen; i++) {
             int base = iovs + (i * 8);
-            int iovBase = (int) memory.readI32(base);
-            var iovLen = (int) memory.readI32(base + 4);
+            int iovBase = memory.readInt(base);
+            var iovLen = memory.readInt(base + 4);
             try {
                 byte[] data = new byte[iovLen];
                 int read = reader.read(data);
@@ -676,8 +676,8 @@ public final class WasiPreview1 implements Closeable {
         var totalWritten = 0;
         for (var i = 0; i < iovsLen; i++) {
             var base = iovs + (i * 8);
-            var iovBase = (int) memory.readI32(base);
-            var iovLen = (int) memory.readI32(base + 4);
+            var iovBase = memory.readInt(base);
+            var iovLen = memory.readInt(base + 4);
             var data = memory.readBytes(iovBase, iovLen);
             try {
                 int written = writer.write(data);

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.Random;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class WasiPreview1Test {
@@ -67,6 +68,8 @@ public class WasiPreview1Test {
     }
 
     @Test
+    // TODO: re-enable me
+    @Disabled
     public void shouldRunWasiDemoJavyModule() {
         // check with: echo "{ \"n\": 2, \"bar\": \"baz\"}" | wasmtime
         // wasi/src/test/resources/compiled/javy-demo.js.wasm

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
@@ -18,7 +18,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.Random;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class WasiPreview1Test {
@@ -67,8 +66,6 @@ public class WasiPreview1Test {
     }
 
     @Test
-    // TODO: re-enable me
-    @Disabled
     public void shouldRunWasiDemoJavyModule() {
         // check with: echo "{ \"n\": 2, \"bar\": \"baz\"}" | wasmtime
         // wasi/src/test/resources/compiled/javy-demo.js.wasm

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
@@ -14,7 +14,6 @@ import com.dylibso.chicory.runtime.Store;
 import com.dylibso.chicory.wasm.Module;
 import com.dylibso.chicory.wasm.Parser;
 import com.dylibso.chicory.wasm.types.MemoryLimits;
-import com.dylibso.chicory.wasm.types.Value;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.List;
@@ -169,9 +168,9 @@ public class WasiPreview1Test {
         var module = loadModule("compiled/sum.go.tiny.wasm");
         var instance = Instance.builder(module).withExternalValues(imports).build();
         var sum = instance.export("add");
-        var result = sum.apply(Value.i32(20), Value.i32(22))[0];
+        var result = sum.apply(20, 22)[0];
 
-        assertEquals(result.asInt(), 42);
+        assertEquals(result, 42);
     }
 
     @Test

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
@@ -107,18 +107,17 @@ public class WasiPreview1Test {
         var ptr =
                 quickjs.export("canonical_abi_realloc")
                         .apply(
-                                Value.i32(0), // original_ptr
-                                Value.i32(0), // original_size
-                                Value.i32(1), // alignment
-                                Value.i32(jsCode.length) // new size
+                                0, // original_ptr
+                                0, // original_size
+                                1, // alignment
+                                jsCode.length // new size
                                 )[0];
 
-        quickjs.memory().write(ptr.asInt(), jsCode);
-        var aggregatedCodePtr =
-                quickjs.export("compile_src").apply(ptr, Value.i64(jsCode.length))[0];
+        quickjs.memory().write((int) ptr, jsCode);
+        var aggregatedCodePtr = quickjs.export("compile_src").apply(ptr, jsCode.length)[0];
 
-        var codePtr = quickjs.memory().readI32(aggregatedCodePtr.asInt()); // 32 bit
-        var codeLength = quickjs.memory().readU32(aggregatedCodePtr.asInt() + 4);
+        var codePtr = quickjs.memory().readI32((int) aggregatedCodePtr); // 32 bit
+        var codeLength = quickjs.memory().readU32((int) aggregatedCodePtr + 4);
 
         quickjs.export("eval_bytecode").apply(codePtr, codeLength);
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -8,11 +8,11 @@ import java.util.Objects;
 
 public class Value {
 
-    public static final Value TRUE = Value.i32(1);
+    public static final long TRUE = 1L;
 
-    public static final Value FALSE = Value.i32(0);
+    public static final long FALSE = 0L;
 
-    public static final int REF_NULL_VALUE = -1;
+    public static final long REF_NULL_VALUE = -1L;
     public static final Value EXTREF_NULL = Value.externRef(REF_NULL_VALUE);
     public static final Value FUNCREF_NULL = Value.funcRef(REF_NULL_VALUE);
 
@@ -26,8 +26,16 @@ public class Value {
         return Value.f32(Float.floatToRawIntBits(data));
     }
 
+    public static long floatToLong(float data) {
+        return Float.floatToRawIntBits(data);
+    }
+
     public static Value fromDouble(double data) {
         return Value.f64(Double.doubleToRawLongBits(data));
+    }
+
+    public static long doubleToLong(double data) {
+        return Double.doubleToRawLongBits(data);
     }
 
     public static Value i32(int data) {
@@ -50,11 +58,11 @@ public class Value {
         return new Value(ValueType.F64, data);
     }
 
-    public static Value externRef(int data) {
+    public static Value externRef(long data) {
         return new Value(ValueType.ExternRef, data);
     }
 
-    public static Value funcRef(int data) {
+    public static Value funcRef(long data) {
         return new Value(ValueType.FuncRef, data);
     }
 
@@ -86,20 +94,16 @@ public class Value {
      * @param valueType must be a valid zeroable type.
      * @return a zero.
      */
-    public static Value zero(ValueType valueType) {
+    public static long zero(ValueType valueType) {
         switch (valueType) {
             case I32:
-                return Value.i32(0);
             case F32:
-                return Value.f32(0);
             case I64:
-                return Value.i64(0);
             case F64:
-                return Value.f64(0);
+                return 0L;
             case FuncRef:
-                return Value.FUNCREF_NULL;
             case ExternRef:
-                return Value.EXTREF_NULL;
+                return REF_NULL_VALUE;
             default:
                 throw new IllegalArgumentException(
                         "Can't create a zero value for type " + valueType);
@@ -148,6 +152,10 @@ public class Value {
         }
     }
 
+    public long raw() {
+        return data;
+    }
+
     // TODO memoize these
     public byte asByte() {
         switch (type) {
@@ -185,8 +193,16 @@ public class Value {
         return Float.intBitsToFloat(asInt());
     }
 
+    public static float longToFloat(long data) {
+        return Float.intBitsToFloat((int) data);
+    }
+
     public double asDouble() {
         return Double.longBitsToDouble(asLong());
+    }
+
+    public static double longToDouble(long data) {
+        return Double.longBitsToDouble(data);
     }
 
     public ValueType type() {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -16,7 +16,7 @@ public class Value {
     public static final Value EXTREF_NULL = Value.externRef(REF_NULL_VALUE);
     public static final Value FUNCREF_NULL = Value.funcRef(REF_NULL_VALUE);
 
-    public static final Value[] EMPTY_VALUES = new Value[0];
+    public static final long[] EMPTY_VALUES = new long[0];
 
     private final ValueType type;
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -12,7 +12,7 @@ public class Value {
 
     public static final long FALSE = 0L;
 
-    public static final long REF_NULL_VALUE = -1L;
+    public static final int REF_NULL_VALUE = -1;
     public static final Value EXTREF_NULL = Value.externRef(REF_NULL_VALUE);
     public static final Value FUNCREF_NULL = Value.funcRef(REF_NULL_VALUE);
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -22,6 +22,7 @@ public class Value {
 
     private final long data;
 
+    // TODO: before the PR is ready review the type conversions everywhere
     public static Value fromFloat(float data) {
         return Value.f32(Float.floatToRawIntBits(data));
     }

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/types/ValueTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/types/ValueTest.java
@@ -1,10 +1,8 @@
 package com.dylibso.chicory.wasm.types;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -28,23 +26,17 @@ public class ValueTest {
         var f32Ref = 0.12345678f;
         var f32 = Value.f32(1039980265L);
         assertEquals(f32Ref, f32.asFloat(), 0.0);
-        assertArrayEquals(f32.data(), Value.fromFloat(f32Ref).data());
+        assertEquals(f32.raw(), Value.fromFloat(f32Ref).raw());
         var f64Ref = 0.123456789012345d;
         var f64 = Value.f64(4593560419847042606L);
         assertEquals(f64Ref, f64.asDouble(), 0.0);
-        assertArrayEquals(f64.data(), Value.fromDouble(f64Ref).data());
+        assertEquals(f64.raw(), Value.fromDouble(f64Ref).raw());
     }
 
     @Test
     public void validConstruction() {
-
         new Value(ValueType.I32, 42);
         assertTrue(true);
-    }
-
-    @Test
-    public void invalidConstruction() {
-        assertThrows(IllegalArgumentException.class, () -> new Value(ValueType.I64, 42));
     }
 
     @Test


### PR DESCRIPTION
Supersede #447 this is a complete implementation, already passing all the tests up to the interpreter, can be tested with something like:

```
 mvn clean install -pl runtime-tests -am
```

I started, but got a bit confused about the changes necessary in "aot", @electrum or @danielperano I would love some help in finalizing this PR :pray: and learning a bit more how `asm` works ...

This is a prerequisite to avoid arrays construction [here](https://github.com/dylibso/chicory/pull/528/files#diff-f9f476fefd928e6770830c090018da2b95a054834c70bf472460d568fd1a9d2bR184), the plan is to open up the underlying array so that we can perform operations just using the offset :crossed_fingers: 