### PR TITLE
CString annotation uses a single argument

### DIFF
--- a/function-processor/src/main/java/com/dylibso/chicory/function/processor/FunctionProcessor.java
+++ b/function-processor/src/main/java/com/dylibso/chicory/function/processor/FunctionProcessor.java
@@ -179,7 +179,6 @@ public final class FunctionProcessor extends AbstractProcessor {
                                                 new MethodCallExpr(lenExpr, "asInt"))));
                     } else if (annotatedWith(parameter, CString.class)) {
                         paramTypes.add(valueType("I32"));
-                        paramTypes.add(valueType("I32"));
                         arguments.add(
                                 new MethodCallExpr(
                                         new MethodCallExpr(new NameExpr("instance"), "memory"),

--- a/function-processor/src/test/resources/SimpleGenerated.java
+++ b/function-processor/src/test/resources/SimpleGenerated.java
@@ -32,7 +32,7 @@ public final class Simple_ModuleFactory {
                     },
                     "simple",
                     "printx",
-                    List.of(ValueType.I32, ValueType.I32),
+                    List.of(ValueType.I32),
                     List.of()
             ),
             new HostFunction(


### PR DESCRIPTION
This is a trivia, but it will spare a couple of lines in the following PRs