### PR TITLE
Rename `moduleName()` -> `module()`, `fieldName()` -> `name()` 

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalFunction.java
@@ -6,19 +6,19 @@ import java.util.List;
 public class ExternalFunction implements ExternalValue {
     private final WasmFunctionHandle handle;
     private final String moduleName;
-    private final String fieldName;
+    private final String symbolName;
     private final List<ValueType> paramTypes;
     private final List<ValueType> returnTypes;
 
     public ExternalFunction(
             String moduleName,
-            String fieldName,
+            String symbolName,
             WasmFunctionHandle handle,
             List<ValueType> paramTypes,
             List<ValueType> returnTypes) {
         this.handle = handle;
         this.moduleName = moduleName;
-        this.fieldName = fieldName;
+        this.symbolName = symbolName;
         this.paramTypes = paramTypes;
         this.returnTypes = returnTypes;
     }
@@ -33,8 +33,8 @@ public class ExternalFunction implements ExternalValue {
     }
 
     @Override
-    public String fieldName() {
-        return fieldName;
+    public String symbolName() {
+        return symbolName;
     }
 
     @Override

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalFunction.java
@@ -5,20 +5,20 @@ import java.util.List;
 
 public class ExternalFunction implements ExternalValue {
     private final WasmFunctionHandle handle;
-    private final String moduleName;
-    private final String symbolName;
+    private final String module;
+    private final String name;
     private final List<ValueType> paramTypes;
     private final List<ValueType> returnTypes;
 
     public ExternalFunction(
-            String moduleName,
-            String symbolName,
+            String module,
+            String name,
             WasmFunctionHandle handle,
             List<ValueType> paramTypes,
             List<ValueType> returnTypes) {
         this.handle = handle;
-        this.moduleName = moduleName;
-        this.symbolName = symbolName;
+        this.module = module;
+        this.name = name;
         this.paramTypes = paramTypes;
         this.returnTypes = returnTypes;
     }
@@ -28,13 +28,13 @@ public class ExternalFunction implements ExternalValue {
     }
 
     @Override
-    public String moduleName() {
-        return moduleName;
+    public String module() {
+        return module;
     }
 
     @Override
-    public String symbolName() {
-        return symbolName;
+    public String name() {
+        return name;
     }
 
     @Override

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalGlobal.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalGlobal.java
@@ -2,13 +2,13 @@ package com.dylibso.chicory.runtime;
 
 public class ExternalGlobal implements ExternalValue {
     private final GlobalInstance instance;
-    private final String moduleName;
-    private final String symbolName;
+    private final String module;
+    private final String name;
 
-    public ExternalGlobal(String moduleName, String symbolName, GlobalInstance instance) {
+    public ExternalGlobal(String module, String name, GlobalInstance instance) {
         this.instance = instance;
-        this.moduleName = moduleName;
-        this.symbolName = symbolName;
+        this.module = module;
+        this.name = name;
     }
 
     public GlobalInstance instance() {
@@ -16,13 +16,13 @@ public class ExternalGlobal implements ExternalValue {
     }
 
     @Override
-    public String moduleName() {
-        return moduleName;
+    public String module() {
+        return module;
     }
 
     @Override
-    public String symbolName() {
-        return symbolName;
+    public String name() {
+        return name;
     }
 
     @Override

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalGlobal.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalGlobal.java
@@ -3,12 +3,12 @@ package com.dylibso.chicory.runtime;
 public class ExternalGlobal implements ExternalValue {
     private final GlobalInstance instance;
     private final String moduleName;
-    private final String fieldName;
+    private final String symbolName;
 
-    public ExternalGlobal(String moduleName, String fieldName, GlobalInstance instance) {
+    public ExternalGlobal(String moduleName, String symbolName, GlobalInstance instance) {
         this.instance = instance;
         this.moduleName = moduleName;
-        this.fieldName = fieldName;
+        this.symbolName = symbolName;
     }
 
     public GlobalInstance instance() {
@@ -21,8 +21,8 @@ public class ExternalGlobal implements ExternalValue {
     }
 
     @Override
-    public String fieldName() {
-        return fieldName;
+    public String symbolName() {
+        return symbolName;
     }
 
     @Override

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalMemory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalMemory.java
@@ -1,24 +1,24 @@
 package com.dylibso.chicory.runtime;
 
 public class ExternalMemory implements ExternalValue {
-    private final String moduleName;
-    private final String symbolName;
+    private final String module;
+    private final String name;
     private final Memory memory;
 
-    public ExternalMemory(String moduleName, String symbolName, Memory memory) {
-        this.moduleName = moduleName;
-        this.symbolName = symbolName;
+    public ExternalMemory(String module, String name, Memory memory) {
+        this.module = module;
+        this.name = name;
         this.memory = memory;
     }
 
     @Override
-    public String moduleName() {
-        return moduleName;
+    public String module() {
+        return module;
     }
 
     @Override
-    public String symbolName() {
-        return symbolName;
+    public String name() {
+        return name;
     }
 
     @Override

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalMemory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalMemory.java
@@ -2,12 +2,12 @@ package com.dylibso.chicory.runtime;
 
 public class ExternalMemory implements ExternalValue {
     private final String moduleName;
-    private final String fieldName;
+    private final String symbolName;
     private final Memory memory;
 
-    public ExternalMemory(String moduleName, String fieldName, Memory memory) {
+    public ExternalMemory(String moduleName, String symbolName, Memory memory) {
         this.moduleName = moduleName;
-        this.fieldName = fieldName;
+        this.symbolName = symbolName;
         this.memory = memory;
     }
 
@@ -17,8 +17,8 @@ public class ExternalMemory implements ExternalValue {
     }
 
     @Override
-    public String fieldName() {
-        return fieldName;
+    public String symbolName() {
+        return symbolName;
     }
 
     @Override

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalTable.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalTable.java
@@ -6,19 +6,19 @@ import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.Map;
 
 public class ExternalTable implements ExternalValue {
-    private final String moduleName;
-    private final String symbolName;
+    private final String module;
+    private final String name;
     private final TableInstance table;
 
-    public ExternalTable(String moduleName, String symbolName, TableInstance table) {
-        this.moduleName = moduleName;
-        this.symbolName = symbolName;
+    public ExternalTable(String module, String name, TableInstance table) {
+        this.module = module;
+        this.name = name;
         this.table = table;
     }
 
-    public ExternalTable(String moduleName, String symbolName, Map<Integer, Integer> funcRefs) {
-        this.moduleName = moduleName;
-        this.symbolName = symbolName;
+    public ExternalTable(String module, String name, Map<Integer, Integer> funcRefs) {
+        this.module = module;
+        this.name = name;
 
         long maxFuncRef = 0;
         for (var k : funcRefs.keySet()) {
@@ -33,13 +33,13 @@ public class ExternalTable implements ExternalValue {
     }
 
     @Override
-    public String moduleName() {
-        return moduleName;
+    public String module() {
+        return module;
     }
 
     @Override
-    public String symbolName() {
-        return symbolName;
+    public String name() {
+        return name;
     }
 
     @Override

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalTable.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalTable.java
@@ -7,18 +7,18 @@ import java.util.Map;
 
 public class ExternalTable implements ExternalValue {
     private final String moduleName;
-    private final String fieldName;
+    private final String symbolName;
     private final TableInstance table;
 
-    public ExternalTable(String moduleName, String fieldName, TableInstance table) {
+    public ExternalTable(String moduleName, String symbolName, TableInstance table) {
         this.moduleName = moduleName;
-        this.fieldName = fieldName;
+        this.symbolName = symbolName;
         this.table = table;
     }
 
-    public ExternalTable(String moduleName, String fieldName, Map<Integer, Integer> funcRefs) {
+    public ExternalTable(String moduleName, String symbolName, Map<Integer, Integer> funcRefs) {
         this.moduleName = moduleName;
-        this.fieldName = fieldName;
+        this.symbolName = symbolName;
 
         long maxFuncRef = 0;
         for (var k : funcRefs.keySet()) {
@@ -38,8 +38,8 @@ public class ExternalTable implements ExternalValue {
     }
 
     @Override
-    public String fieldName() {
-        return fieldName;
+    public String symbolName() {
+        return symbolName;
     }
 
     @Override

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalValue.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalValue.java
@@ -15,9 +15,9 @@ public interface ExternalValue {
         TABLE
     }
 
-    String moduleName();
+    String module();
 
-    String symbolName();
+    String name();
 
     ExternalValue.Type type();
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalValue.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ExternalValue.java
@@ -17,7 +17,7 @@ public interface ExternalValue {
 
     String moduleName();
 
-    String fieldName();
+    String symbolName();
 
     ExternalValue.Type type();
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
@@ -9,10 +9,10 @@ import java.util.List;
 public class HostFunction extends ExternalFunction {
     public HostFunction(
             String moduleName,
-            String fieldName,
+            String symbolName,
             WasmFunctionHandle handle,
             List<ValueType> paramTypes,
             List<ValueType> returnTypes) {
-        super(moduleName, fieldName, handle, paramTypes, returnTypes);
+        super(moduleName, symbolName, handle, paramTypes, returnTypes);
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -402,7 +402,7 @@ public class Instance {
                         "incompatible import type for host function "
                                 + f.moduleName()
                                 + "."
-                                + f.fieldName());
+                                + f.symbolName());
             }
             for (int i = 0; i < expectedType.params().size(); i++) {
                 var expected = expectedType.params().get(i);
@@ -412,7 +412,7 @@ public class Instance {
                             "incompatible import type for host function "
                                     + f.moduleName()
                                     + "."
-                                    + f.fieldName());
+                                    + f.symbolName());
                 }
             }
             for (int i = 0; i < expectedType.returns().size(); i++) {
@@ -423,7 +423,7 @@ public class Instance {
                             "incompatible import type for host function "
                                     + f.moduleName()
                                     + "."
-                                    + f.fieldName());
+                                    + f.symbolName());
                 }
             }
         }
@@ -451,7 +451,7 @@ public class Instance {
                                 + " on table: "
                                 + t.moduleName()
                                 + "."
-                                + t.fieldName());
+                                + t.symbolName());
             }
         }
 
@@ -480,14 +480,14 @@ public class Instance {
                                 + " on memory: "
                                 + m.moduleName()
                                 + "."
-                                + m.fieldName());
+                                + m.symbolName());
             }
         }
 
         private void validateNegativeImportType(
                 String moduleName, String name, ExternalValue[] external) {
             for (var fh : external) {
-                if (fh.moduleName().equals(moduleName) && fh.fieldName().equals(name)) {
+                if (fh.moduleName().equals(moduleName) && fh.symbolName().equals(name)) {
                     throw new UnlinkableException("incompatible import type");
                 }
             }
@@ -565,7 +565,7 @@ public class Instance {
                 Function<ExternalValue, Boolean> checkName =
                         (ExternalValue fh) ->
                                 i.moduleName().equals(fh.moduleName())
-                                        && i.name().equals(fh.fieldName());
+                                        && i.name().equals(fh.symbolName());
                 switch (i.importType()) {
                     case FUNCTION:
                         cnt = externalValues.functionCount();

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -400,9 +400,9 @@ public class Instance {
                     || expectedType.returns().size() != f.returnTypes().size()) {
                 throw new UnlinkableException(
                         "incompatible import type for host function "
-                                + f.moduleName()
+                                + f.module()
                                 + "."
-                                + f.symbolName());
+                                + f.name());
             }
             for (int i = 0; i < expectedType.params().size(); i++) {
                 var expected = expectedType.params().get(i);
@@ -410,9 +410,9 @@ public class Instance {
                 if (expected != got) {
                     throw new UnlinkableException(
                             "incompatible import type for host function "
-                                    + f.moduleName()
+                                    + f.module()
                                     + "."
-                                    + f.symbolName());
+                                    + f.name());
                 }
             }
             for (int i = 0; i < expectedType.returns().size(); i++) {
@@ -421,9 +421,9 @@ public class Instance {
                 if (expected != got) {
                     throw new UnlinkableException(
                             "incompatible import type for host function "
-                                    + f.moduleName()
+                                    + f.module()
                                     + "."
-                                    + f.symbolName());
+                                    + f.name());
                 }
             }
         }
@@ -449,9 +449,9 @@ public class Instance {
                                 + ", current: "
                                 + t.table().limits()
                                 + " on table: "
-                                + t.moduleName()
+                                + t.module()
                                 + "."
-                                + t.symbolName());
+                                + t.name());
             }
         }
 
@@ -478,16 +478,16 @@ public class Instance {
                                 + ", host: "
                                 + m.memory().limits()
                                 + " on memory: "
-                                + m.moduleName()
+                                + m.module()
                                 + "."
-                                + m.symbolName());
+                                + m.name());
             }
         }
 
         private void validateNegativeImportType(
                 String moduleName, String name, ExternalValue[] external) {
             for (var fh : external) {
-                if (fh.moduleName().equals(moduleName) && fh.symbolName().equals(name)) {
+                if (fh.module().equals(moduleName) && fh.name().equals(name)) {
                     throw new UnlinkableException("incompatible import type");
                 }
             }
@@ -558,14 +558,12 @@ public class Instance {
             int cnt;
             for (var impIdx = 0; impIdx < imports.length; impIdx++) {
                 var i = imports[impIdx];
-                var name = i.moduleName() + "." + i.name();
+                var name = i.module() + "." + i.name();
                 var found = false;
-                validateNegativeImportType(
-                        i.moduleName(), i.name(), i.importType(), externalValues);
+                validateNegativeImportType(i.module(), i.name(), i.importType(), externalValues);
                 Function<ExternalValue, Boolean> checkName =
                         (ExternalValue fh) ->
-                                i.moduleName().equals(fh.moduleName())
-                                        && i.name().equals(fh.symbolName());
+                                i.module().equals(fh.module()) && i.name().equals(fh.name());
                 switch (i.importType()) {
                     case FUNCTION:
                         cnt = externalValues.functionCount();

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
@@ -23,7 +23,7 @@ public class Store {
      */
     public Store addFunction(ExternalFunction... function) {
         for (var f : function) {
-            functions.put(new QualifiedName(f.moduleName(), f.symbolName()), f);
+            functions.put(new QualifiedName(f.module(), f.name()), f);
         }
         return this;
     }
@@ -33,7 +33,7 @@ public class Store {
      */
     public Store addGlobal(ExternalGlobal... global) {
         for (var g : global) {
-            globals.put(new QualifiedName(g.moduleName(), g.symbolName()), g);
+            globals.put(new QualifiedName(g.module(), g.name()), g);
         }
         return this;
     }
@@ -43,7 +43,7 @@ public class Store {
      */
     public Store addMemory(ExternalMemory... memory) {
         for (var m : memory) {
-            memories.put(new QualifiedName(m.moduleName(), m.symbolName()), m);
+            memories.put(new QualifiedName(m.module(), m.name()), m);
         }
         return this;
     }
@@ -53,7 +53,7 @@ public class Store {
      */
     public Store addTable(ExternalTable... table) {
         for (var t : table) {
-            tables.put(new QualifiedName(t.moduleName(), t.symbolName()), t);
+            tables.put(new QualifiedName(t.module(), t.name()), t);
         }
         return this;
     }
@@ -138,12 +138,12 @@ public class Store {
      * QualifiedName is internally used to use pairs (moduleName, name) as keys in the store.
      */
     static class QualifiedName {
-        private final String moduleName;
-        private final String symbolName;
+        private final String module;
+        private final String name;
 
-        public QualifiedName(String moduleName, String symbolName) {
-            this.moduleName = moduleName;
-            this.symbolName = symbolName;
+        public QualifiedName(String module, String name) {
+            this.module = module;
+            this.name = name;
         }
 
         @Override
@@ -155,13 +155,13 @@ public class Store {
                 return false;
             }
             QualifiedName qualifiedName = (QualifiedName) o;
-            return Objects.equals(moduleName, qualifiedName.moduleName)
-                    && Objects.equals(symbolName, qualifiedName.symbolName);
+            return Objects.equals(module, qualifiedName.module)
+                    && Objects.equals(name, qualifiedName.name);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(moduleName, symbolName);
+            return Objects.hash(module, name);
         }
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
@@ -23,7 +23,7 @@ public class Store {
      */
     public Store addFunction(ExternalFunction... function) {
         for (var f : function) {
-            functions.put(new QualifiedName(f.moduleName(), f.fieldName()), f);
+            functions.put(new QualifiedName(f.moduleName(), f.symbolName()), f);
         }
         return this;
     }
@@ -33,7 +33,7 @@ public class Store {
      */
     public Store addGlobal(ExternalGlobal... global) {
         for (var g : global) {
-            globals.put(new QualifiedName(g.moduleName(), g.fieldName()), g);
+            globals.put(new QualifiedName(g.moduleName(), g.symbolName()), g);
         }
         return this;
     }
@@ -43,7 +43,7 @@ public class Store {
      */
     public Store addMemory(ExternalMemory... memory) {
         for (var m : memory) {
-            memories.put(new QualifiedName(m.moduleName(), m.fieldName()), m);
+            memories.put(new QualifiedName(m.moduleName(), m.symbolName()), m);
         }
         return this;
     }
@@ -53,7 +53,7 @@ public class Store {
      */
     public Store addTable(ExternalTable... table) {
         for (var t : table) {
-            tables.put(new QualifiedName(t.moduleName(), t.fieldName()), t);
+            tables.put(new QualifiedName(t.moduleName(), t.symbolName()), t);
         }
         return this;
     }
@@ -139,11 +139,11 @@ public class Store {
      */
     static class QualifiedName {
         private final String moduleName;
-        private final String fieldName;
+        private final String symbolName;
 
-        public QualifiedName(String moduleName, String fieldName) {
+        public QualifiedName(String moduleName, String symbolName) {
             this.moduleName = moduleName;
-            this.fieldName = fieldName;
+            this.symbolName = symbolName;
         }
 
         @Override
@@ -156,12 +156,12 @@ public class Store {
             }
             QualifiedName qualifiedName = (QualifiedName) o;
             return Objects.equals(moduleName, qualifiedName.moduleName)
-                    && Objects.equals(fieldName, qualifiedName.fieldName);
+                    && Objects.equals(symbolName, qualifiedName.symbolName);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(moduleName, fieldName);
+            return Objects.hash(moduleName, symbolName);
         }
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Import.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Import.java
@@ -11,19 +11,19 @@ import java.util.Objects;
  * reference.
  */
 public abstract class Import {
-    private final String moduleName;
+    private final String module;
     private final String name;
 
-    Import(String moduleName, String name) {
-        this.moduleName = requireNonNull(moduleName, "moduleName");
+    Import(String module, String name) {
+        this.module = requireNonNull(module, "moduleName");
         this.name = requireNonNull(name, "name");
     }
 
     /**
      * @return the module name to import from
      */
-    public String moduleName() {
-        return moduleName;
+    public String module() {
+        return module;
     }
 
     /**
@@ -44,16 +44,16 @@ public abstract class Import {
     }
 
     public boolean equals(Import other) {
-        return other != null && moduleName.equals(other.moduleName) && name.equals(other.name);
+        return other != null && module.equals(other.module) && name.equals(other.name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(moduleName, name);
+        return Objects.hash(module, name);
     }
 
     public StringBuilder toString(StringBuilder b) {
-        return b.append('<').append(moduleName).append('.').append(name).append('>');
+        return b.append('<').append(module).append('.').append(name).append('>');
     }
 
     @Override

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
@@ -45,7 +45,7 @@ public class ParserTest {
             var importSection = module.importSection();
             assertEquals(1, importSection.importCount());
             assertEquals(ExternalType.FUNCTION, importSection.getImport(0).importType());
-            assertEquals("env", importSection.getImport(0).moduleName());
+            assertEquals("env", importSection.getImport(0).module());
             assertEquals("gotit", importSection.getImport(0).name());
 
             // check data section


### PR DESCRIPTION
Follow up to #527.

Using `fieldName` might cause confusion now (a "field" in a module to me sounds like a "global" value, not a function) and in the future; e.g. [fields](https://webassembly.github.io/gc/core/syntax/types.html#syntax-fieldtype) are the fields in a `Structure` (see WasmGC);

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
