### PR TITLE
Remove function-annotations from the BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -16,11 +16,6 @@
     <dependencies>
       <dependency>
         <groupId>com.dylibso.chicory</groupId>
-        <artifactId>function-annotations</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.dylibso.chicory</groupId>
         <artifactId>log</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
We need to work a bit more on the annotation processing story, I noticed that we have this in the BOM and I think that we should leave it out to avoid setting wrong expectations when we release the next version.