### PR TITLE
Rename `ExternalValues` to `ImportValues`; order of params in `ImportFunction`,`HostFunction`.

### DIFF
--- a/aot-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
+++ b/aot-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
@@ -26,35 +26,35 @@ public final class Spectest {
     public static ImportValues toImportValues() {
         return new ImportValues(
                 new HostFunction[] {
-                    new HostFunction("spectest", "print", noop, List.of(), List.of()),
+                    new HostFunction("spectest", "print", List.of(), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_i32", noop, List.of(ValueType.I32), List.of()),
+                            "spectest", "print_i32", List.of(ValueType.I32), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_i32_1", noop, List.of(ValueType.I32), List.of()),
+                            "spectest", "print_i32_1", List.of(ValueType.I32), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_i32_2", noop, List.of(ValueType.I32), List.of()),
+                            "spectest", "print_i32_2", List.of(ValueType.I32), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_f32", noop, List.of(ValueType.F32), List.of()),
+                            "spectest", "print_f32", List.of(ValueType.F32), List.of(), noop),
                     new HostFunction(
                             "spectest",
                             "print_i32_f32",
-                            noop,
                             List.of(ValueType.I32, ValueType.F32),
-                            List.of()),
+                            List.of(),
+                            noop),
                     new HostFunction(
-                            "spectest", "print_i64", noop, List.of(ValueType.I64), List.of()),
+                            "spectest", "print_i64", List.of(ValueType.I64), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_i64_1", noop, List.of(ValueType.I64), List.of()),
+                            "spectest", "print_i64_1", List.of(ValueType.I64), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_i64_2", noop, List.of(ValueType.I64), List.of()),
+                            "spectest", "print_i64_2", List.of(ValueType.I64), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_f64", noop, List.of(ValueType.F64), List.of()),
+                            "spectest", "print_f64", List.of(ValueType.F64), List.of(), noop),
                     new HostFunction(
                             "spectest",
                             "print_f64_f64",
-                            noop,
                             List.of(ValueType.F64, ValueType.F64),
-                            List.of())
+                            List.of(),
+                            noop)
                 },
                 new ImportGlobal[] {
                     new ImportGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),

--- a/aot-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
+++ b/aot-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
@@ -1,11 +1,11 @@
 package com.dylibso.chicory.testing;
 
-import com.dylibso.chicory.runtime.ExternalGlobal;
-import com.dylibso.chicory.runtime.ExternalMemory;
-import com.dylibso.chicory.runtime.ExternalTable;
-import com.dylibso.chicory.runtime.ExternalValues;
 import com.dylibso.chicory.runtime.GlobalInstance;
 import com.dylibso.chicory.runtime.HostFunction;
+import com.dylibso.chicory.runtime.ImportGlobal;
+import com.dylibso.chicory.runtime.ImportMemory;
+import com.dylibso.chicory.runtime.ImportTable;
+import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.runtime.TableInstance;
@@ -23,8 +23,8 @@ public final class Spectest {
 
     private Spectest() {}
 
-    public static ExternalValues toExternalValues() {
-        return new ExternalValues(
+    public static ImportValues toImportValues() {
+        return new ImportValues(
                 new HostFunction[] {
                     new HostFunction("spectest", "print", noop, List.of(), List.of()),
                     new HostFunction(
@@ -56,21 +56,19 @@ public final class Spectest {
                             List.of(ValueType.F64, ValueType.F64),
                             List.of())
                 },
-                new ExternalGlobal[] {
-                    new ExternalGlobal(
-                            "spectest", "global_i32", new GlobalInstance(Value.i32(666))),
-                    new ExternalGlobal(
-                            "spectest", "global_i64", new GlobalInstance(Value.i64(666))),
-                    new ExternalGlobal(
+                new ImportGlobal[] {
+                    new ImportGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),
+                    new ImportGlobal("spectest", "global_i64", new GlobalInstance(Value.i64(666))),
+                    new ImportGlobal(
                             "spectest", "global_f32", new GlobalInstance(Value.fromFloat(666.6f))),
-                    new ExternalGlobal(
+                    new ImportGlobal(
                             "spectest", "global_f64", new GlobalInstance(Value.fromDouble(666.6))),
                 },
-                new ExternalMemory[] {
-                    new ExternalMemory("spectest", "memory", new Memory(new MemoryLimits(1, 2)))
+                new ImportMemory[] {
+                    new ImportMemory("spectest", "memory", new Memory(new MemoryLimits(1, 2)))
                 },
-                new ExternalTable[] {
-                    new ExternalTable(
+                new ImportTable[] {
+                    new ImportTable(
                             "spectest",
                             "table",
                             new TableInstance(new Table(ValueType.FuncRef, new Limits(10, 20))))

--- a/aot-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/aot-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -1,7 +1,7 @@
 package com.dylibso.chicory.testing;
 
 import com.dylibso.chicory.aot.AotMachine;
-import com.dylibso.chicory.runtime.ExternalValues;
+import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Store;
 import com.dylibso.chicory.wabt.Wat2Wasm;
@@ -62,9 +62,9 @@ public class TestModule {
     }
 
     public Instance instantiate(Store s) {
-        ExternalValues externalValues = s.toExternalValues();
+        ImportValues importValues = s.toImportValues();
         return Instance.builder(module)
-                .withExternalValues(externalValues)
+                .withImportValues(importValues)
                 .withMachineFactory(AotMachine::new)
                 .build();
     }

--- a/cli/src/main/java/com/dylibso/chicory/cli/Cli.java
+++ b/cli/src/main/java/com/dylibso/chicory/cli/Cli.java
@@ -1,7 +1,7 @@
 package com.dylibso.chicory.cli;
 
 import com.dylibso.chicory.log.SystemLogger;
-import com.dylibso.chicory.runtime.ExternalValues;
+import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasi.WasiOptions;
 import com.dylibso.chicory.wasi.WasiPreview1;
@@ -59,17 +59,17 @@ public class Cli implements Runnable {
         var module = Parser.parse(file);
         var imports =
                 wasi
-                        ? new ExternalValues(
+                        ? new ImportValues(
                                 new WasiPreview1(
                                                 logger,
                                                 WasiOptions.builder().inheritSystem().build())
                                         .toHostFunctions())
-                        : new ExternalValues();
+                        : new ImportValues();
         var instance =
                 Instance.builder(module)
                         .withInitialize(true)
                         .withStart(false)
-                        .withExternalValues(imports)
+                        .withImportValues(imports)
                         .build();
 
         if (functionName != null) {

--- a/docs/docs/usage/host-functions.md
+++ b/docs/docs/usage/host-functions.md
@@ -53,15 +53,15 @@ import com.dylibso.chicory.wasm.types.ValueType;
 var func = new HostFunction(
     "console",
     "log",
+    List.of(ValueType.I32, ValueType.I32),
+    List.of(),
     (Instance instance, long... args) -> { // decompiled is: console_log(13, 0);
         var len = (int) args[0];
         var offset = (int) args[1];
         var message = instance.memory().readString(offset, len);
         println(message);
         return null;
-    },
-    List.of(ValueType.I32, ValueType.I32),
-    List.of());
+    });
 ```
 
 Again we're dealing with pointers here. The module calls `console.log` with the length of the string

--- a/docs/docs/usage/host-functions.md
+++ b/docs/docs/usage/host-functions.md
@@ -78,9 +78,9 @@ Now we just need to pass this host function in during our instantiation phase:
 
 ```java
 import com.dylibso.chicory.wasm.Parser;
-import com.dylibso.chicory.runtime.ExternalValues;
-var hostFunctions = new ExternalValues(new HostFunction[] {func});
-var instance = Instance.builder(Parser.parse(new File("./logger.wasm"))).withExternalValues(hostFunctions).build();
+import com.dylibso.chicory.runtime.ImportValues;
+var hostFunctions = new ImportValues(new HostFunction[] {func});
+var instance = Instance.builder(Parser.parse(new File("./logger.wasm"))).withImportValues(hostFunctions).build();
 var logIt = instance.export("logIt");
 logIt.apply();
 // should print "Hello, World!" 10 times

--- a/docs/docs/usage/linking.md
+++ b/docs/docs/usage/linking.md
@@ -28,15 +28,15 @@ import com.dylibso.chicory.wasm.types.ValueType;
 var func = new HostFunction(
     "console",
     "log",
+    List.of(ValueType.I32, ValueType.I32),
+    List.of(),
     (Instance instance, long... args) -> { // decompiled is: console_log(13, 0);
         var len = (int) args[0];
         var offset = (int) args[1];
         var message = instance.memory().readString(offset, len);
         println(message);
         return null;
-    },
-    List.of(ValueType.I32, ValueType.I32),
-    List.of());
+    });
 var hostFunctions = new ImportValues(new HostFunction[] {func});
 var instance = Instance.builder(Parser.parse(new File("./logger.wasm"))).withImportValues(hostFunctions).build();
 ```

--- a/docs/docs/usage/linking.md
+++ b/docs/docs/usage/linking.md
@@ -22,7 +22,7 @@ TODO: should we make this more explicit?
 import com.dylibso.chicory.wasm.Parser;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.HostFunction;
-import com.dylibso.chicory.runtime.ExternalValues;
+import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.wasm.types.ValueType;
 
 var func = new HostFunction(
@@ -37,8 +37,8 @@ var func = new HostFunction(
     },
     List.of(ValueType.I32, ValueType.I32),
     List.of());
-var hostFunctions = new ExternalValues(new HostFunction[] {func});
-var instance = Instance.builder(Parser.parse(new File("./logger.wasm"))).withExternalValues(hostFunctions).build();
+var hostFunctions = new ImportValues(new HostFunction[] {func});
+var instance = Instance.builder(Parser.parse(new File("./logger.wasm"))).withImportValues(hostFunctions).build();
 ```
 -->
 
@@ -68,9 +68,9 @@ var logger2 = store.instantiate("logger2", Parser.parse(new File("./logger.wasm"
 This is equivalent to:
 
 ```java
-var external = store.toExternalValues();
+var external = store.toImportValues();
 var m = Parser.parse(new File("./logger.wasm"));
-var instance = Instance.builder(m).withExternalValues(external).build();
+var instance = Instance.builder(m).withImportValues(external).build();
 store.register("logger2", instance);
 ```
 

--- a/host-module/it/src/it/with-imports/src/test/java/chicory/test/WithImportsTest.java
+++ b/host-module/it/src/it/with-imports/src/test/java/chicory/test/WithImportsTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.dylibso.chicory.hostmodule.annotations.HostModule;
 import com.dylibso.chicory.hostmodule.annotations.WasmExport;
-import com.dylibso.chicory.runtime.ExternalValues;
+import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasm.Parser;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -24,8 +24,8 @@ class WithImportsTest {
                                     Parser.parse(
                                             WithImportsTest.class.getResourceAsStream(
                                                     "/compiled/host-function.wat.wasm")))
-                            .withExternalValues(
-                                    new ExternalValues(
+                            .withImportValues(
+                                    new ImportValues(
                                             TestModule_ModuleFactory.toHostFunctions(this)))
                             .build();
         }

--- a/host-module/processor/src/main/java/com/dylibso/chicory/hostmodule/processor/HostModuleProcessor.java
+++ b/host-module/processor/src/main/java/com/dylibso/chicory/hostmodule/processor/HostModuleProcessor.java
@@ -279,9 +279,9 @@ public final class HostModuleProcessor extends AbstractProcessor {
                         .setType("HostFunction")
                         .addArgument(new StringLiteralExpr(moduleName))
                         .addArgument(new StringLiteralExpr(name))
-                        .addArgument(handle)
                         .addArgument(new MethodCallExpr(new NameExpr("List"), "of", paramTypes))
-                        .addArgument(new MethodCallExpr(new NameExpr("List"), "of", returnType));
+                        .addArgument(new MethodCallExpr(new NameExpr("List"), "of", returnType))
+                        .addArgument(handle);
         // TODO: update javaparser and replace with multiline formatting
         function.setLineComment("");
         return function;

--- a/host-module/processor/src/test/resources/BasicMathGenerated.java
+++ b/host-module/processor/src/test/resources/BasicMathGenerated.java
@@ -15,33 +15,33 @@ public final class BasicMath_ModuleFactory {
 
     public static HostFunction[] toHostFunctions(BasicMath functions) {
         return new HostFunction[] { //
-                new HostFunction("math",
-                        "add",
-                        (Instance instance, long... args) -> {
-                            long result = functions.add((int) args[0],
-                                    (int) args[1]);
-                            return new long[] { result };
-                        },
-                        List.of(ValueType.I32,
-                                ValueType.I32),
-                        List.of(ValueType.I64)), //
-                new HostFunction("math",
-                        "square",
-                        (Instance instance, long... args) -> {
-                            double result = functions.pow2(Value.longToFloat(args[0]));
-                            return new long[] { Value.doubleToLong(result) };
-                        },
-                        List.of(ValueType.F32),
-                        List.of(ValueType.F64)), //
-                new HostFunction("math",
-                        "floor_div",
-                        (Instance instance, long... args) -> {
-                            int result = functions.floorDiv((int) args[0],
-                                    (int) args[1]);
-                            return new long[] { (long) result };
-                        },
-                        List.of(ValueType.I32,
-                                ValueType.I32),
-                        List.of(ValueType.I32)) };
+        new HostFunction("math",
+                         "add",
+                         List.of(ValueType.I32,
+                                 ValueType.I32),
+                         List.of(ValueType.I64),
+                         (Instance instance, long... args) -> {
+                             long result = functions.add((int) args[0],
+                                                         (int) args[1]);
+                             return new long[] { result };
+                         }), //
+        new HostFunction("math",
+                         "square",
+                         List.of(ValueType.F32),
+                         List.of(ValueType.F64),
+                         (Instance instance, long... args) -> {
+                             double result = functions.pow2(Value.longToFloat(args[0]));
+                             return new long[] { Value.doubleToLong(result) };
+                         }), //
+        new HostFunction("math",
+                         "floor_div",
+                         List.of(ValueType.I32,
+                                 ValueType.I32),
+                         List.of(ValueType.I32),
+                         (Instance instance, long... args) -> {
+                             int result = functions.floorDiv((int) args[0],
+                                                             (int) args[1]);
+                             return new long[] { (long) result };
+                         }) };
     }
 }

--- a/host-module/processor/src/test/resources/NestedGenerated.java
+++ b/host-module/processor/src/test/resources/NestedGenerated.java
@@ -16,24 +16,24 @@ public final class Nested_ModuleFactory {
 
     public static HostFunction[] toHostFunctions(Nested functions) {
         return new HostFunction[] { //
-                new HostFunction("nested",
-                        "print",
-                        (Instance instance, long... args) -> {
-                            functions.print(instance.memory(),
-                                    (int) args[0],
-                                    (int) args[1]);
-                            return null;
-                        },
-                        List.of(ValueType.I32,
-                                ValueType.I32),
-                        List.of()), //
-                new HostFunction("nested",
-                        "exit",
-                        (Instance instance, long... args) -> {
-                            functions.exit();
-                            return null;
-                        },
-                        List.of(),
-                        List.of()) };
+        new HostFunction("nested",
+                         "print",
+                         List.of(ValueType.I32,
+                                 ValueType.I32),
+                         List.of(),
+                         (Instance instance, long... args) -> {
+                             functions.print(instance.memory(),
+                                             (int) args[0],
+                                             (int) args[1]);
+                             return null;
+                         }), //
+        new HostFunction("nested",
+                         "exit",
+                         List.of(),
+                         List.of(),
+                         (Instance instance, long... args) -> {
+                             functions.exit();
+                             return null;
+                         }) };
     }
 }

--- a/host-module/processor/src/test/resources/NoPackageGenerated.java
+++ b/host-module/processor/src/test/resources/NoPackageGenerated.java
@@ -13,24 +13,24 @@ public final class NoPackage_ModuleFactory {
 
     public static HostFunction[] toHostFunctions(NoPackage functions) {
         return new HostFunction[] { //
-                new HostFunction("nopackage",
-                        "print",
-                        (Instance instance, long... args) -> {
-                            functions.print(instance.memory(),
-                                    (int) args[0],
-                                    (int) args[1]);
-                            return null;
-                        },
-                        List.of(ValueType.I32,
-                                ValueType.I32),
-                        List.of()), //
-                new HostFunction("nopackage",
-                        "exit",
-                        (Instance instance, long... args) -> {
-                            functions.exit();
-                            return null;
-                        },
-                        List.of(),
-                        List.of()) };
+        new HostFunction("nopackage",
+                         "print",
+                         List.of(ValueType.I32,
+                                 ValueType.I32),
+                         List.of(),
+                         (Instance instance, long... args) -> {
+                             functions.print(instance.memory(),
+                                             (int) args[0],
+                                             (int) args[1]);
+                             return null;
+                         }), //
+        new HostFunction("nopackage",
+                         "exit",
+                         List.of(),
+                         List.of(),
+                         (Instance instance, long... args) -> {
+                             functions.exit();
+                             return null;
+                         }) };
     }
 }

--- a/host-module/processor/src/test/resources/SimpleGenerated.java
+++ b/host-module/processor/src/test/resources/SimpleGenerated.java
@@ -15,42 +15,42 @@ public final class Simple_ModuleFactory {
 
     public static HostFunction[] toHostFunctions(Simple functions) {
         return new HostFunction[] { //
-                new HostFunction("simple",
-                        "print",
-                        (Instance instance, long... args) -> {
-                            functions.print(instance.memory().readString((int) args[0],
-                                    (int) args[1]));
-                            return null;
-                        },
-                        List.of(ValueType.I32,
-                                ValueType.I32),
-                        List.of()), //
-                new HostFunction("simple",
-                        "printx",
-                        (Instance instance, long... args) -> {
-                            functions.printx(instance.memory().readCString((int) args[0]));
-                            return null;
-                        },
-                        List.of(ValueType.I32),
-                        List.of()), //
-                new HostFunction("simple",
-                        "random_get",
-                        (Instance instance, long... args) -> {
-                            functions.randomGet(instance.memory(),
-                                    (int) args[0],
-                                    (int) args[1]);
-                            return null;
-                        },
-                        List.of(ValueType.I32,
-                                ValueType.I32),
-                        List.of()), //
-                new HostFunction("simple",
-                        "exit",
-                        (Instance instance, long... args) -> {
-                            functions.exit();
-                            return null;
-                        },
-                        List.of(),
-                        List.of()) };
+        new HostFunction("simple",
+                         "print",
+                         List.of(ValueType.I32,
+                                 ValueType.I32),
+                         List.of(),
+                         (Instance instance, long... args) -> {
+                             functions.print(instance.memory().readString((int) args[0],
+                                                                          (int) args[1]));
+                             return null;
+                         }), //
+        new HostFunction("simple",
+                         "printx",
+                         List.of(ValueType.I32),
+                         List.of(),
+                         (Instance instance, long... args) -> {
+                             functions.printx(instance.memory().readCString((int) args[0]));
+                             return null;
+                         }), //
+        new HostFunction("simple",
+                         "random_get",
+                         List.of(ValueType.I32,
+                                 ValueType.I32),
+                         List.of(),
+                         (Instance instance, long... args) -> {
+                             functions.randomGet(instance.memory(),
+                                                 (int) args[0],
+                                                 (int) args[1]);
+                             return null;
+                         }), //
+        new HostFunction("simple",
+                         "exit",
+                         List.of(),
+                         List.of(),
+                         (Instance instance, long... args) -> {
+                             functions.exit();
+                             return null;
+                         }) };
     }
 }

--- a/machine-tests/src/test/java/com/dylibso/chicory/testing/MachinesTest.java
+++ b/machine-tests/src/test/java/com/dylibso/chicory/testing/MachinesTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.dylibso.chicory.aot.AotMachine;
 import com.dylibso.chicory.log.SystemLogger;
-import com.dylibso.chicory.runtime.ExternalValues;
+import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Store;
 import com.dylibso.chicory.testing.gen.DynamicHelloJSMachineFactory;
@@ -76,13 +76,13 @@ public final class MachinesTest {
         var quickjs =
                 quickJsInstanceBuilder()
                         .withMachineFactory(QuickJSMachineFactory::create)
-                        .withExternalValues(new ExternalValues(wasi.toHostFunctions()))
+                        .withImportValues(new ImportValues(wasi.toHostFunctions()))
                         .build();
 
         var store = new Store().register("javy_quickjs_provider_v1", quickjs);
 
         // the module is going to use the interpreter instead
-        moduleInstanceBuilder().withExternalValues(store.toExternalValues()).build();
+        moduleInstanceBuilder().withImportValues(store.toImportValues()).build();
 
         // stderr?
         assertEquals(expectedOutput, stderr.toString(UTF_8));
@@ -90,7 +90,7 @@ public final class MachinesTest {
         // and now runtime AOT
         moduleInstanceBuilder()
                 .withMachineFactory(AotMachine::new)
-                .withExternalValues(store.toExternalValues())
+                .withImportValues(store.toImportValues())
                 .build();
 
         assertEquals(expectedOutput + expectedOutput, stderr.toString(UTF_8));
@@ -106,7 +106,7 @@ public final class MachinesTest {
         // using the pre-compiled version of QuickJS
         var quickjs =
                 quickJsInstanceBuilder()
-                        .withExternalValues(new ExternalValues(wasi.toHostFunctions()))
+                        .withImportValues(new ImportValues(wasi.toHostFunctions()))
                         .build();
 
         var store = new Store().register("javy_quickjs_provider_v1", quickjs);
@@ -114,7 +114,7 @@ public final class MachinesTest {
         // the module is going to use the pre compiled aot
         moduleInstanceBuilder()
                 .withMachineFactory(DynamicHelloJSMachineFactory::create)
-                .withExternalValues(store.toExternalValues())
+                .withImportValues(store.toImportValues())
                 .build();
 
         // stderr?
@@ -123,7 +123,7 @@ public final class MachinesTest {
         // and now runtime AOT
         moduleInstanceBuilder()
                 .withMachineFactory(AotMachine::new)
-                .withExternalValues(store.toExternalValues())
+                .withImportValues(store.toImportValues())
                 .build();
 
         assertEquals(expectedOutput + expectedOutput, stderr.toString(UTF_8));
@@ -140,7 +140,7 @@ public final class MachinesTest {
         var quickjs =
                 quickJsInstanceBuilder()
                         .withMachineFactory(AotMachine::new)
-                        .withExternalValues(new ExternalValues(wasi.toHostFunctions()))
+                        .withImportValues(new ImportValues(wasi.toHostFunctions()))
                         .build();
 
         var store = new Store().register("javy_quickjs_provider_v1", quickjs);
@@ -148,14 +148,14 @@ public final class MachinesTest {
         // the module is going to use the pre compiled aot
         moduleInstanceBuilder()
                 .withMachineFactory(DynamicHelloJSMachineFactory::create)
-                .withExternalValues(store.toExternalValues())
+                .withImportValues(store.toImportValues())
                 .build();
 
         // stderr?
         assertEquals(expectedOutput, stderr.toString(UTF_8));
 
         // and now the interpreter
-        moduleInstanceBuilder().withExternalValues(store.toExternalValues()).build();
+        moduleInstanceBuilder().withImportValues(store.toImportValues()).build();
 
         assertEquals(expectedOutput + expectedOutput, stderr.toString(UTF_8));
     }
@@ -184,7 +184,7 @@ public final class MachinesTest {
                             .build();
             var logger = new SystemLogger();
             try (var wasi = WasiPreview1.builder().withLogger(logger).withOpts(wasiOpts).build()) {
-                ExternalValues imports = new ExternalValues(wasi.toHostFunctions());
+                ImportValues imports = new ImportValues(wasi.toHostFunctions());
                 var wat2WasmModule = Parser.parse(new File("../wabt/src/main/resources/wat2wasm"));
                 var startFunctionIndex = new AtomicInteger();
                 for (int i = 0; i < wat2WasmModule.exportSection().exportCount(); i++) {
@@ -206,7 +206,7 @@ public final class MachinesTest {
                                         return machine.call(funcId, args);
                                     };
                                 })
-                        .withExternalValues(imports)
+                        .withImportValues(imports)
                         .build();
             }
 

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
@@ -26,35 +26,35 @@ public final class Spectest {
     public static ImportValues toImportValues() {
         return new ImportValues(
                 new HostFunction[] {
-                    new HostFunction("spectest", "print", noop, List.of(), List.of()),
+                    new HostFunction("spectest", "print", List.of(), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_i32", noop, List.of(ValueType.I32), List.of()),
+                            "spectest", "print_i32", List.of(ValueType.I32), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_i32_1", noop, List.of(ValueType.I32), List.of()),
+                            "spectest", "print_i32_1", List.of(ValueType.I32), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_i32_2", noop, List.of(ValueType.I32), List.of()),
+                            "spectest", "print_i32_2", List.of(ValueType.I32), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_f32", noop, List.of(ValueType.F32), List.of()),
+                            "spectest", "print_f32", List.of(ValueType.F32), List.of(), noop),
                     new HostFunction(
                             "spectest",
                             "print_i32_f32",
-                            noop,
                             List.of(ValueType.I32, ValueType.F32),
-                            List.of()),
+                            List.of(),
+                            noop),
                     new HostFunction(
-                            "spectest", "print_i64", noop, List.of(ValueType.I64), List.of()),
+                            "spectest", "print_i64", List.of(ValueType.I64), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_i64_1", noop, List.of(ValueType.I64), List.of()),
+                            "spectest", "print_i64_1", List.of(ValueType.I64), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_i64_2", noop, List.of(ValueType.I64), List.of()),
+                            "spectest", "print_i64_2", List.of(ValueType.I64), List.of(), noop),
                     new HostFunction(
-                            "spectest", "print_f64", noop, List.of(ValueType.F64), List.of()),
+                            "spectest", "print_f64", List.of(ValueType.F64), List.of(), noop),
                     new HostFunction(
                             "spectest",
                             "print_f64_f64",
-                            noop,
                             List.of(ValueType.F64, ValueType.F64),
-                            List.of())
+                            List.of(),
+                            noop)
                 },
                 new ImportGlobal[] {
                     new ImportGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
@@ -1,11 +1,11 @@
 package com.dylibso.chicory.testing;
 
-import com.dylibso.chicory.runtime.ExternalGlobal;
-import com.dylibso.chicory.runtime.ExternalMemory;
-import com.dylibso.chicory.runtime.ExternalTable;
-import com.dylibso.chicory.runtime.ExternalValues;
 import com.dylibso.chicory.runtime.GlobalInstance;
 import com.dylibso.chicory.runtime.HostFunction;
+import com.dylibso.chicory.runtime.ImportGlobal;
+import com.dylibso.chicory.runtime.ImportMemory;
+import com.dylibso.chicory.runtime.ImportTable;
+import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.runtime.TableInstance;
@@ -23,8 +23,8 @@ public final class Spectest {
 
     private Spectest() {}
 
-    public static ExternalValues toExternalValues() {
-        return new ExternalValues(
+    public static ImportValues toImportValues() {
+        return new ImportValues(
                 new HostFunction[] {
                     new HostFunction("spectest", "print", noop, List.of(), List.of()),
                     new HostFunction(
@@ -56,21 +56,19 @@ public final class Spectest {
                             List.of(ValueType.F64, ValueType.F64),
                             List.of())
                 },
-                new ExternalGlobal[] {
-                    new ExternalGlobal(
-                            "spectest", "global_i32", new GlobalInstance(Value.i32(666))),
-                    new ExternalGlobal(
-                            "spectest", "global_i64", new GlobalInstance(Value.i64(666))),
-                    new ExternalGlobal(
+                new ImportGlobal[] {
+                    new ImportGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),
+                    new ImportGlobal("spectest", "global_i64", new GlobalInstance(Value.i64(666))),
+                    new ImportGlobal(
                             "spectest", "global_f32", new GlobalInstance(Value.fromFloat(666.6f))),
-                    new ExternalGlobal(
+                    new ImportGlobal(
                             "spectest", "global_f64", new GlobalInstance(Value.fromDouble(666.6))),
                 },
-                new ExternalMemory[] {
-                    new ExternalMemory("spectest", "memory", new Memory(new MemoryLimits(1, 2)))
+                new ImportMemory[] {
+                    new ImportMemory("spectest", "memory", new Memory(new MemoryLimits(1, 2)))
                 },
-                new ExternalTable[] {
-                    new ExternalTable(
+                new ImportTable[] {
+                    new ImportTable(
                             "spectest",
                             "table",
                             new TableInstance(new Table(ValueType.FuncRef, new Limits(10, 20))))

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -1,6 +1,6 @@
 package com.dylibso.chicory.testing;
 
-import com.dylibso.chicory.runtime.ExternalValues;
+import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Store;
 import com.dylibso.chicory.wabt.Wat2Wasm;
@@ -61,7 +61,7 @@ public class TestModule {
     }
 
     public Instance instantiate(Store s) {
-        ExternalValues externalValues = s.toExternalValues();
-        return Instance.builder(module).withExternalValues(externalValues).build();
+        ImportValues importValues = s.toImportValues();
+        return Instance.builder(module).withImportValues(importValues).build();
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
@@ -6,7 +6,7 @@ import java.util.List;
 /**
  * A HostFunction is an ExternalFunction that has been defined by the host.
  */
-public class HostFunction extends ExternalFunction {
+public class HostFunction extends ImportFunction {
     public HostFunction(
             String moduleName,
             String symbolName,

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
@@ -10,9 +10,9 @@ public class HostFunction extends ImportFunction {
     public HostFunction(
             String moduleName,
             String symbolName,
-            WasmFunctionHandle handle,
             List<ValueType> paramTypes,
-            List<ValueType> returnTypes) {
+            List<ValueType> returnTypes,
+            WasmFunctionHandle handle) {
         super(moduleName, symbolName, paramTypes, returnTypes, handle);
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
@@ -13,6 +13,6 @@ public class HostFunction extends ImportFunction {
             WasmFunctionHandle handle,
             List<ValueType> paramTypes,
             List<ValueType> returnTypes) {
-        super(moduleName, symbolName, handle, paramTypes, returnTypes);
+        super(moduleName, symbolName, paramTypes, returnTypes, handle);
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ImportFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ImportFunction.java
@@ -4,23 +4,23 @@ import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
 public class ImportFunction implements ImportValue {
-    private final WasmFunctionHandle handle;
     private final String module;
     private final String name;
     private final List<ValueType> paramTypes;
     private final List<ValueType> returnTypes;
+    private final WasmFunctionHandle handle;
 
     public ImportFunction(
             String module,
             String name,
-            WasmFunctionHandle handle,
             List<ValueType> paramTypes,
-            List<ValueType> returnTypes) {
-        this.handle = handle;
+            List<ValueType> returnTypes,
+            WasmFunctionHandle handle) {
         this.module = module;
         this.name = name;
         this.paramTypes = paramTypes;
         this.returnTypes = returnTypes;
+        this.handle = handle;
     }
 
     public WasmFunctionHandle handle() {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ImportFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ImportFunction.java
@@ -3,14 +3,14 @@ package com.dylibso.chicory.runtime;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
 
-public class ExternalFunction implements ExternalValue {
+public class ImportFunction implements ImportValue {
     private final WasmFunctionHandle handle;
     private final String module;
     private final String name;
     private final List<ValueType> paramTypes;
     private final List<ValueType> returnTypes;
 
-    public ExternalFunction(
+    public ImportFunction(
             String module,
             String name,
             WasmFunctionHandle handle,

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ImportGlobal.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ImportGlobal.java
@@ -1,11 +1,11 @@
 package com.dylibso.chicory.runtime;
 
-public class ExternalGlobal implements ExternalValue {
+public class ImportGlobal implements ImportValue {
     private final GlobalInstance instance;
     private final String module;
     private final String name;
 
-    public ExternalGlobal(String module, String name, GlobalInstance instance) {
+    public ImportGlobal(String module, String name, GlobalInstance instance) {
         this.instance = instance;
         this.module = module;
         this.name = name;
@@ -26,7 +26,7 @@ public class ExternalGlobal implements ExternalValue {
     }
 
     @Override
-    public ExternalValue.Type type() {
+    public ImportValue.Type type() {
         return Type.GLOBAL;
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ImportMemory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ImportMemory.java
@@ -1,11 +1,11 @@
 package com.dylibso.chicory.runtime;
 
-public class ExternalMemory implements ExternalValue {
+public class ImportMemory implements ImportValue {
     private final String module;
     private final String name;
     private final Memory memory;
 
-    public ExternalMemory(String module, String name, Memory memory) {
+    public ImportMemory(String module, String name, Memory memory) {
         this.module = module;
         this.name = name;
         this.memory = memory;
@@ -22,7 +22,7 @@ public class ExternalMemory implements ExternalValue {
     }
 
     @Override
-    public ExternalValue.Type type() {
+    public ImportValue.Type type() {
         return Type.MEMORY;
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ImportTable.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ImportTable.java
@@ -5,18 +5,18 @@ import com.dylibso.chicory.wasm.types.Table;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.Map;
 
-public class ExternalTable implements ExternalValue {
+public class ImportTable implements ImportValue {
     private final String module;
     private final String name;
     private final TableInstance table;
 
-    public ExternalTable(String module, String name, TableInstance table) {
+    public ImportTable(String module, String name, TableInstance table) {
         this.module = module;
         this.name = name;
         this.table = table;
     }
 
-    public ExternalTable(String module, String name, Map<Integer, Integer> funcRefs) {
+    public ImportTable(String module, String name, Map<Integer, Integer> funcRefs) {
         this.module = module;
         this.name = name;
 
@@ -43,7 +43,7 @@ public class ExternalTable implements ExternalValue {
     }
 
     @Override
-    public ExternalValue.Type type() {
+    public ImportValue.Type type() {
         return Type.TABLE;
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ImportValue.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ImportValue.java
@@ -1,13 +1,15 @@
 package com.dylibso.chicory.runtime;
 
 /**
- * An <i>external value</i> is the runtime representation of an entity that can be imported or exported.
+ * An <i>external value</i> is the runtime representation of an entity that can be imported.
  * It is an address denoting either a function instance, table instance, memory instance,
  * or global instances in the shared store.
  *
- * See <a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval">External Values</a>.
+ * See also <a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval">External Values</a>.
+ *
+ * @see ExportFunction
  */
-public interface ExternalValue {
+public interface ImportValue {
     enum Type {
         FUNCTION,
         GLOBAL,
@@ -19,5 +21,5 @@ public interface ExternalValue {
 
     String name();
 
-    ExternalValue.Type type();
+    ImportValue.Type type();
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ImportValues.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ImportValues.java
@@ -4,82 +4,82 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class ExternalValues {
-    private static final ExternalFunction[] NO_EXTERNAL_FUNCTIONS = new ExternalFunction[0];
-    private static final ExternalGlobal[] NO_EXTERNAL_GLOBALS = new ExternalGlobal[0];
-    private static final ExternalMemory[] NO_EXTERNAL_MEMORIES = new ExternalMemory[0];
-    private static final ExternalTable[] NO_EXTERNAL_TABLES = new ExternalTable[0];
+public class ImportValues {
+    private static final ImportFunction[] NO_EXTERNAL_FUNCTIONS = new ImportFunction[0];
+    private static final ImportGlobal[] NO_EXTERNAL_GLOBALS = new ImportGlobal[0];
+    private static final ImportMemory[] NO_EXTERNAL_MEMORIES = new ImportMemory[0];
+    private static final ImportTable[] NO_EXTERNAL_TABLES = new ImportTable[0];
 
-    private final ExternalFunction[] functions;
-    private final ExternalGlobal[] globals;
-    private final ExternalMemory[] memories;
-    private final ExternalTable[] tables;
+    private final ImportFunction[] functions;
+    private final ImportGlobal[] globals;
+    private final ImportMemory[] memories;
+    private final ImportTable[] tables;
 
-    public ExternalValues() {
+    public ImportValues() {
         this.functions = NO_EXTERNAL_FUNCTIONS;
         this.globals = NO_EXTERNAL_GLOBALS;
         this.memories = NO_EXTERNAL_MEMORIES;
         this.tables = NO_EXTERNAL_TABLES;
     }
 
-    public ExternalValues(HostFunction[] functions) {
+    public ImportValues(HostFunction[] functions) {
         this.functions = functions.clone();
         this.globals = NO_EXTERNAL_GLOBALS;
         this.memories = NO_EXTERNAL_MEMORIES;
         this.tables = NO_EXTERNAL_TABLES;
     }
 
-    public ExternalValues(ExternalGlobal[] globals) {
+    public ImportValues(ImportGlobal[] globals) {
         this.functions = NO_EXTERNAL_FUNCTIONS;
         this.globals = globals.clone();
         this.memories = NO_EXTERNAL_MEMORIES;
         this.tables = NO_EXTERNAL_TABLES;
     }
 
-    public ExternalValues(ExternalMemory[] memories) {
+    public ImportValues(ImportMemory[] memories) {
         this.functions = NO_EXTERNAL_FUNCTIONS;
         this.globals = NO_EXTERNAL_GLOBALS;
         this.memories = memories.clone();
         this.tables = NO_EXTERNAL_TABLES;
     }
 
-    public ExternalValues(ExternalMemory memory) {
+    public ImportValues(ImportMemory memory) {
         this.functions = NO_EXTERNAL_FUNCTIONS;
         this.globals = NO_EXTERNAL_GLOBALS;
-        this.memories = new ExternalMemory[] {memory};
+        this.memories = new ImportMemory[] {memory};
         this.tables = NO_EXTERNAL_TABLES;
     }
 
-    public ExternalValues(ExternalTable[] tables) {
+    public ImportValues(ImportTable[] tables) {
         this.functions = NO_EXTERNAL_FUNCTIONS;
         this.globals = NO_EXTERNAL_GLOBALS;
         this.memories = NO_EXTERNAL_MEMORIES;
         this.tables = tables.clone();
     }
 
-    public ExternalValues(
-            ExternalFunction[] functions,
-            ExternalGlobal[] globals,
-            ExternalMemory memory,
-            ExternalTable[] tables) {
+    public ImportValues(
+            ImportFunction[] functions,
+            ImportGlobal[] globals,
+            ImportMemory memory,
+            ImportTable[] tables) {
         this.functions = functions.clone();
         this.globals = globals.clone();
-        this.memories = new ExternalMemory[] {memory};
+        this.memories = new ImportMemory[] {memory};
         this.tables = tables.clone();
     }
 
-    public ExternalValues(
-            ExternalFunction[] functions,
-            ExternalGlobal[] globals,
-            ExternalMemory[] memories,
-            ExternalTable[] tables) {
+    public ImportValues(
+            ImportFunction[] functions,
+            ImportGlobal[] globals,
+            ImportMemory[] memories,
+            ImportTable[] tables) {
         this.functions = functions.clone();
         this.globals = globals.clone();
         this.memories = memories.clone();
         this.tables = tables.clone();
     }
 
-    public ExternalFunction[] functions() {
+    public ImportFunction[] functions() {
         return functions.clone();
     }
 
@@ -87,11 +87,11 @@ public class ExternalValues {
         return functions.length;
     }
 
-    public ExternalFunction function(int idx) {
+    public ImportFunction function(int idx) {
         return functions[idx];
     }
 
-    public ExternalGlobal[] globals() {
+    public ImportGlobal[] globals() {
         return globals;
     }
 
@@ -99,11 +99,11 @@ public class ExternalValues {
         return globals.length;
     }
 
-    public ExternalGlobal global(int idx) {
+    public ImportGlobal global(int idx) {
         return globals[idx];
     }
 
-    public ExternalMemory[] memories() {
+    public ImportMemory[] memories() {
         return memories;
     }
 
@@ -111,11 +111,11 @@ public class ExternalValues {
         return memories.length;
     }
 
-    public ExternalMemory memory(int idx) {
+    public ImportMemory memory(int idx) {
         return memories[idx];
     }
 
-    public ExternalTable[] tables() {
+    public ImportTable[] tables() {
         return tables;
     }
 
@@ -123,7 +123,7 @@ public class ExternalValues {
         return tables.length;
     }
 
-    public ExternalTable table(int idx) {
+    public ImportTable table(int idx) {
         return tables[idx];
     }
 
@@ -131,24 +131,24 @@ public class ExternalValues {
         return new Builder();
     }
 
-    public static ExternalValues empty() {
+    public static ImportValues empty() {
         return new Builder().build();
     }
 
     public static final class Builder {
-        private List<ExternalFunction> functions;
-        private List<ExternalGlobal> globals;
-        private List<ExternalMemory> memories;
-        private List<ExternalTable> tables;
+        private List<ImportFunction> functions;
+        private List<ImportGlobal> globals;
+        private List<ImportMemory> memories;
+        private List<ImportTable> tables;
 
         Builder() {}
 
-        public Builder withFunctions(List<ExternalFunction> functions) {
+        public Builder withFunctions(List<ImportFunction> functions) {
             this.functions = functions;
             return this;
         }
 
-        public Builder addFunction(ExternalFunction... function) {
+        public Builder addFunction(ImportFunction... function) {
             if (this.functions == null) {
                 this.functions = new ArrayList<>();
             }
@@ -156,12 +156,12 @@ public class ExternalValues {
             return this;
         }
 
-        public Builder withGlobals(List<ExternalGlobal> globals) {
+        public Builder withGlobals(List<ImportGlobal> globals) {
             this.globals = globals;
             return this;
         }
 
-        public Builder addGlobal(ExternalGlobal... global) {
+        public Builder addGlobal(ImportGlobal... global) {
             if (this.globals == null) {
                 this.globals = new ArrayList<>();
             }
@@ -169,12 +169,12 @@ public class ExternalValues {
             return this;
         }
 
-        public Builder withMemories(List<ExternalMemory> memories) {
+        public Builder withMemories(List<ImportMemory> memories) {
             this.memories = memories;
             return this;
         }
 
-        public Builder addMemory(ExternalMemory... memory) {
+        public Builder addMemory(ImportMemory... memory) {
             if (this.memories == null) {
                 this.memories = new ArrayList<>();
             }
@@ -182,12 +182,12 @@ public class ExternalValues {
             return this;
         }
 
-        public Builder withTables(List<ExternalTable> tables) {
+        public Builder withTables(List<ImportTable> tables) {
             this.tables = tables;
             return this;
         }
 
-        public Builder addTable(ExternalTable... table) {
+        public Builder addTable(ImportTable... table) {
             if (this.tables == null) {
                 this.tables = new ArrayList<>();
             }
@@ -195,22 +195,22 @@ public class ExternalValues {
             return this;
         }
 
-        public ExternalValues build() {
-            final ExternalValues externalValues =
-                    new ExternalValues(
+        public ImportValues build() {
+            final ImportValues importValues =
+                    new ImportValues(
                             functions == null
                                     ? new HostFunction[0]
                                     : functions.toArray(new HostFunction[0]),
                             globals == null
-                                    ? new ExternalGlobal[0]
-                                    : globals.toArray(new ExternalGlobal[0]),
+                                    ? new ImportGlobal[0]
+                                    : globals.toArray(new ImportGlobal[0]),
                             memories == null
-                                    ? new ExternalMemory[0]
-                                    : memories.toArray(new ExternalMemory[0]),
+                                    ? new ImportMemory[0]
+                                    : memories.toArray(new ImportMemory[0]),
                             tables == null
-                                    ? new ExternalTable[0]
-                                    : tables.toArray(new ExternalTable[0]));
-            return externalValues;
+                                    ? new ImportTable[0]
+                                    : tables.toArray(new ImportTable[0]));
+            return importValues;
         }
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
@@ -101,9 +101,9 @@ public class Store {
                             new ImportFunction(
                                     name,
                                     exportName,
-                                    (inst, args) -> f.apply(args),
                                     ftype.params(),
-                                    ftype.returns()));
+                                    ftype.returns(),
+                                    (inst, args) -> f.apply(args)));
                     break;
 
                 case TABLE:

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
@@ -11,17 +11,17 @@ import java.util.Objects;
  * The runtime storage for all function, global, memory, table instances.
  */
 public class Store {
-    final LinkedHashMap<QualifiedName, ExternalFunction> functions = new LinkedHashMap<>();
-    final LinkedHashMap<QualifiedName, ExternalGlobal> globals = new LinkedHashMap<>();
-    final LinkedHashMap<QualifiedName, ExternalMemory> memories = new LinkedHashMap<>();
-    final LinkedHashMap<QualifiedName, ExternalTable> tables = new LinkedHashMap<>();
+    final LinkedHashMap<QualifiedName, ImportFunction> functions = new LinkedHashMap<>();
+    final LinkedHashMap<QualifiedName, ImportGlobal> globals = new LinkedHashMap<>();
+    final LinkedHashMap<QualifiedName, ImportMemory> memories = new LinkedHashMap<>();
+    final LinkedHashMap<QualifiedName, ImportTable> tables = new LinkedHashMap<>();
 
     public Store() {}
 
     /**
      * Add a function to the store.
      */
-    public Store addFunction(ExternalFunction... function) {
+    public Store addFunction(ImportFunction... function) {
         for (var f : function) {
             functions.put(new QualifiedName(f.module(), f.name()), f);
         }
@@ -31,7 +31,7 @@ public class Store {
     /**
      * Add a global to the store.
      */
-    public Store addGlobal(ExternalGlobal... global) {
+    public Store addGlobal(ImportGlobal... global) {
         for (var g : global) {
             globals.put(new QualifiedName(g.module(), g.name()), g);
         }
@@ -41,7 +41,7 @@ public class Store {
     /**
      * Add a memory to the store.
      */
-    public Store addMemory(ExternalMemory... memory) {
+    public Store addMemory(ImportMemory... memory) {
         for (var m : memory) {
             memories.put(new QualifiedName(m.module(), m.name()), m);
         }
@@ -51,7 +51,7 @@ public class Store {
     /**
      * Add a table to the store.
      */
-    public Store addTable(ExternalTable... table) {
+    public Store addTable(ImportTable... table) {
         for (var t : table) {
             tables.put(new QualifiedName(t.module(), t.name()), t);
         }
@@ -59,24 +59,24 @@ public class Store {
     }
 
     /**
-     * Add the contents of a {@link ExternalValues} instance to the store.
+     * Add the contents of a {@link ImportValues} instance to the store.
      */
-    public Store addExternalValues(ExternalValues externalValues) {
-        return this.addGlobal(externalValues.globals())
-                .addFunction(externalValues.functions())
-                .addMemory(externalValues.memories())
-                .addTable(externalValues.tables());
+    public Store addImportValues(ImportValues importValues) {
+        return this.addGlobal(importValues.globals())
+                .addFunction(importValues.functions())
+                .addMemory(importValues.memories())
+                .addTable(importValues.tables());
     }
 
     /**
-     * Convert the contents of a store to a {@link ExternalValues} instance.
+     * Convert the contents of a store to a {@link ImportValues} instance.
      */
-    public ExternalValues toExternalValues() {
-        return new ExternalValues(
-                functions.values().toArray(new ExternalFunction[0]),
-                globals.values().toArray(new ExternalGlobal[0]),
-                memories.values().toArray(new ExternalMemory[0]),
-                tables.values().toArray(new ExternalTable[0]));
+    public ImportValues toImportValues() {
+        return new ImportValues(
+                functions.values().toArray(new ImportFunction[0]),
+                globals.values().toArray(new ImportGlobal[0]),
+                memories.values().toArray(new ImportMemory[0]),
+                tables.values().toArray(new ImportTable[0]));
     }
 
     /**
@@ -98,7 +98,7 @@ public class Store {
                     ExportFunction f = instance.export(exportName);
                     FunctionType ftype = instance.exportType(exportName);
                     this.addFunction(
-                            new ExternalFunction(
+                            new ImportFunction(
                                     name,
                                     exportName,
                                     (inst, args) -> f.apply(args),
@@ -108,16 +108,16 @@ public class Store {
 
                 case TABLE:
                     this.addTable(
-                            new ExternalTable(name, exportName, instance.table(export.index())));
+                            new ImportTable(name, exportName, instance.table(export.index())));
                     break;
 
                 case MEMORY:
-                    this.addMemory(new ExternalMemory(name, exportName, instance.memory()));
+                    this.addMemory(new ImportMemory(name, exportName, instance.memory()));
                     break;
 
                 case GLOBAL:
                     GlobalInstance g = instance.global(export.index());
-                    this.addGlobal(new ExternalGlobal(name, exportName, g));
+                    this.addGlobal(new ImportGlobal(name, exportName, g));
                     break;
             }
         }
@@ -128,8 +128,8 @@ public class Store {
      * A shorthand for instantiating a module and registering it in the store.
      */
     public Instance instantiate(String name, Module m) {
-        ExternalValues externalValues = this.toExternalValues();
-        Instance instance = Instance.builder(m).withExternalValues(externalValues).build();
+        ImportValues importValues = this.toImportValues();
+        Instance instance = Instance.builder(m).withImportValues(importValues).build();
         register(name, instance);
         return instance;
     }

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/ImportValuesTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/ImportValuesTest.java
@@ -8,13 +8,13 @@ import java.util.Collections;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-class ExternalValuesTest {
+class ImportValuesTest {
 
     @Nested
     class Builder {
         @Test
         void empty() {
-            final ExternalValues result = ExternalValues.builder().build();
+            final ImportValues result = ImportValues.builder().build();
             assertEquals(0, result.functionCount());
             assertEquals(0, result.globalCount());
             assertEquals(0, result.memoryCount());
@@ -26,8 +26,8 @@ class ExternalValuesTest {
 
             @Test
             void withFunctions() {
-                final ExternalValues result =
-                        ExternalValues.builder()
+                final ImportValues result =
+                        ImportValues.builder()
                                 .withFunctions(
                                         Arrays.asList(
                                                 new HostFunction("module_1", "", null, null, null),
@@ -38,8 +38,8 @@ class ExternalValuesTest {
 
             @Test
             void addFunction() {
-                final ExternalValues result =
-                        ExternalValues.builder()
+                final ImportValues result =
+                        ImportValues.builder()
                                 .addFunction(new HostFunction("module_1", "", null, null, null))
                                 .addFunction(new HostFunction("module_2", "", null, null, null))
                                 .build();
@@ -52,15 +52,15 @@ class ExternalValuesTest {
 
             @Test
             void withGlobals() {
-                final ExternalValues result =
-                        ExternalValues.builder()
+                final ImportValues result =
+                        ImportValues.builder()
                                 .withGlobals(
                                         Arrays.asList(
-                                                new ExternalGlobal(
+                                                new ImportGlobal(
                                                         "spectest",
                                                         "global_i32",
                                                         new GlobalInstance(Value.i32(666))),
-                                                new ExternalGlobal(
+                                                new ImportGlobal(
                                                         "spectest",
                                                         "global_i64",
                                                         new GlobalInstance(Value.i64(666)))))
@@ -70,15 +70,15 @@ class ExternalValuesTest {
 
             @Test
             void addGlobal() {
-                final ExternalValues result =
-                        ExternalValues.builder()
+                final ImportValues result =
+                        ImportValues.builder()
                                 .addGlobal(
-                                        new ExternalGlobal(
+                                        new ImportGlobal(
                                                 "spectest",
                                                 "global_i32",
                                                 new GlobalInstance(Value.i32(666))))
                                 .addGlobal(
-                                        new ExternalGlobal(
+                                        new ImportGlobal(
                                                 "spectest",
                                                 "global_i64",
                                                 new GlobalInstance(Value.i64(666))))
@@ -92,22 +92,22 @@ class ExternalValuesTest {
 
             @Test
             void withMemories() {
-                final ExternalValues result =
-                        ExternalValues.builder()
+                final ImportValues result =
+                        ImportValues.builder()
                                 .withMemories(
                                         Arrays.asList(
-                                                new ExternalMemory("spectest", "memory", null),
-                                                new ExternalMemory("spectest", "memory_2", null)))
+                                                new ImportMemory("spectest", "memory", null),
+                                                new ImportMemory("spectest", "memory_2", null)))
                                 .build();
                 assertEquals(2, result.memoryCount());
             }
 
             @Test
             void addMemory() {
-                final ExternalValues result =
-                        ExternalValues.builder()
-                                .addMemory(new ExternalMemory("spectest", "memory", null))
-                                .addMemory(new ExternalMemory("spectest", "memory_2", null))
+                final ImportValues result =
+                        ImportValues.builder()
+                                .addMemory(new ImportMemory("spectest", "memory", null))
+                                .addMemory(new ImportMemory("spectest", "memory_2", null))
                                 .build();
                 assertEquals(2, result.memoryCount());
             }
@@ -118,15 +118,15 @@ class ExternalValuesTest {
 
             @Test
             void withTables() {
-                final ExternalValues result =
-                        ExternalValues.builder()
+                final ImportValues result =
+                        ImportValues.builder()
                                 .withTables(
                                         Arrays.asList(
-                                                new ExternalTable(
+                                                new ImportTable(
                                                         "spectest",
                                                         "table",
                                                         Collections.emptyMap()),
-                                                new ExternalTable(
+                                                new ImportTable(
                                                         "spectest",
                                                         "table_2",
                                                         Collections.emptyMap())))
@@ -136,13 +136,13 @@ class ExternalValuesTest {
 
             @Test
             void addMemory() {
-                final ExternalValues result =
-                        ExternalValues.builder()
+                final ImportValues result =
+                        ImportValues.builder()
                                 .addTable(
-                                        new ExternalTable(
+                                        new ImportTable(
                                                 "spectest", "table", Collections.emptyMap()))
                                 .addTable(
-                                        new ExternalTable(
+                                        new ImportTable(
                                                 "spectest", "table_2", Collections.emptyMap()))
                                 .build();
                 assertEquals(2, result.tableCount());

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
@@ -101,7 +101,7 @@ public class ModuleTest {
         var funcs = new HostFunction[] {func};
         var instance =
                 Instance.builder(loadModule("compiled/host-function.wat.wasm"))
-                        .withExternalValues(new ExternalValues(funcs))
+                        .withImportValues(new ImportValues(funcs))
                         .build();
         var logIt = instance.export("logIt");
         logIt.apply();
@@ -151,7 +151,7 @@ public class ModuleTest {
                         List.of());
         var funcs = new HostFunction[] {func};
         Instance.builder(loadModule("compiled/start.wat.wasm"))
-                .withExternalValues(new ExternalValues(funcs))
+                .withImportValues(new ImportValues(funcs))
                 .build();
 
         assertTrue(count.get() > 0);
@@ -285,17 +285,17 @@ public class ModuleTest {
                         },
                         List.of(ValueType.I32, ValueType.F64),
                         List.of());
-        var memory = new ExternalMemory("env", "memory", new Memory(new MemoryLimits(1)));
+        var memory = new ImportMemory("env", "memory", new Memory(new MemoryLimits(1)));
 
         var hostImports =
-                new ExternalValues(
+                new ImportValues(
                         new HostFunction[] {cbrtFunc, logFunc},
-                        new ExternalGlobal[0],
+                        new ImportGlobal[0],
                         memory,
-                        new ExternalTable[0]);
+                        new ImportTable[0]);
         var instance =
                 Instance.builder(loadModule("compiled/mixed-imports.wat.wasm"))
-                        .withExternalValues(hostImports)
+                        .withImportValues(hostImports)
                         .build();
 
         var run = instance.export("main");

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
@@ -84,6 +84,8 @@ public class ModuleTest {
                 new HostFunction(
                         "console",
                         "log",
+                        List.of(ValueType.I32, ValueType.I32),
+                        List.of(),
                         (Instance instance, long... args) -> { // decompiled is: console_log(13, 0);
                             Memory memory = instance.memory();
                             int len = (int) args[0];
@@ -95,9 +97,7 @@ public class ModuleTest {
                             }
 
                             return null;
-                        },
-                        List.of(ValueType.I32, ValueType.I32),
-                        List.of());
+                        });
         var funcs = new HostFunction[] {func};
         var instance =
                 Instance.builder(loadModule("compiled/host-function.wat.wasm"))
@@ -138,6 +138,8 @@ public class ModuleTest {
                 new HostFunction(
                         "env",
                         "gotit",
+                        List.of(ValueType.I32),
+                        List.of(),
                         (Instance instance, long... args) -> {
                             var val = args[0];
 
@@ -146,9 +148,7 @@ public class ModuleTest {
                             }
 
                             return null;
-                        },
-                        List.of(ValueType.I32),
-                        List.of());
+                        });
         var funcs = new HostFunction[] {func};
         Instance.builder(loadModule("compiled/start.wat.wasm"))
                 .withImportValues(new ImportValues(funcs))
@@ -265,26 +265,26 @@ public class ModuleTest {
                 new HostFunction(
                         "env",
                         "cbrt",
+                        List.of(ValueType.I32),
+                        List.of(ValueType.F64),
                         (Instance instance, long... args) -> {
                             var x = args[0];
                             var cbrt = Math.cbrt((double) x);
                             return new long[] {Double.doubleToRawLongBits(cbrt)};
-                        },
-                        List.of(ValueType.I32),
-                        List.of(ValueType.F64));
+                        });
         var logResult = new AtomicReference<String>(null);
         var logFunc =
                 new HostFunction(
                         "env",
                         "log",
+                        List.of(ValueType.I32, ValueType.F64),
+                        List.of(),
                         (Instance instance, long... args) -> {
                             var logLevel = args[0];
                             var value = (int) Double.longBitsToDouble(args[1]);
                             logResult.set(logLevel + ": " + value);
                             return null;
-                        },
-                        List.of(ValueType.I32, ValueType.F64),
-                        List.of());
+                        });
         var memory = new ImportMemory("env", "memory", new Memory(new MemoryLimits(1)));
 
         var hostImports =

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/JavaTestGen.java
@@ -132,7 +132,7 @@ public class JavaTestGen {
         testClass.addFieldWithInitializer(
                 "Store",
                 "store",
-                new NameExpr("new Store().addExternalValues(Spectest.toExternalValues())"));
+                new NameExpr("new Store().addImportValues(Spectest.toImportValues())"));
 
         String currentWasmFile = null;
         for (var cmd : wast.commands()) {

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
@@ -5,7 +5,7 @@ import static java.nio.file.Files.createDirectories;
 
 import com.dylibso.chicory.log.Logger;
 import com.dylibso.chicory.log.SystemLogger;
-import com.dylibso.chicory.runtime.ExternalValues;
+import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasi.WasiOptions;
 import com.dylibso.chicory.wasi.WasiPreview1;
@@ -86,10 +86,10 @@ public final class Wast2Json {
                                 .withLogger(logger)
                                 .withOpts(wasiOpts.build())
                                 .build()) {
-                    ExternalValues imports = new ExternalValues(wasi.toHostFunctions());
+                    ImportValues imports = new ImportValues(wasi.toHostFunctions());
 
                     Instance.builder(MODULE)
-                            .withExternalValues(imports)
+                            .withImportValues(imports)
                             .withMachineFactory(Wast2JsonModuleMachineFactory::create)
                             .build();
                 }

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
@@ -4,7 +4,7 @@ import static java.nio.file.Files.copy;
 
 import com.dylibso.chicory.log.Logger;
 import com.dylibso.chicory.log.SystemLogger;
-import com.dylibso.chicory.runtime.ExternalValues;
+import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasi.WasiOptions;
 import com.dylibso.chicory.wasi.WasiPreview1;
@@ -71,10 +71,10 @@ public final class Wat2Wasm {
 
                 try (var wasi =
                         WasiPreview1.builder().withLogger(logger).withOpts(wasiOpts).build()) {
-                    ExternalValues imports = new ExternalValues(wasi.toHostFunctions());
+                    ImportValues imports = new ImportValues(wasi.toHostFunctions());
                     Instance.builder(MODULE)
                             .withMachineFactory(Wat2WasmModuleMachineFactory::create)
-                            .withExternalValues(imports)
+                            .withImportValues(imports)
                             .build();
                 }
 

--- a/wasi/README.md
+++ b/wasi/README.md
@@ -151,8 +151,7 @@ import com.dylibso.chicory.log.SystemLogger;
 import com.dylibso.chicory.wasi.WasiOptions;
 import com.dylibso.chicory.wasi.WasiPreview1;
 import com.dylibso.chicory.wasm.Parser;
-import com.dylibso.chicory.runtime.ExternalValues;
-import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.runtime.ImportValues;
 
 import java.io.File;
 
@@ -162,10 +161,10 @@ var options = WasiOptions.builder().build();
 // create our instance of wasip1
 var wasi = new WasiPreview1(logger, WasiOptions.builder().build());
 // turn those into host functions. Here we could add any other custom definitions we have
-var hostFunctions = new ExternalValues(wasi.toHostFunctions());
+var hostFunctions = new ImportValues(wasi.toHostFunctions());
 // create the module and connect the external values
 // this will execute the module if it's a WASI command-pattern module
-Instance.builder(Parser.parse(new File("hello-wasi.wasm"))).withExternalValues(hostFunctions).build();
+Instance.builder(Parser.parse(new File("hello-wasi.wasm"))).withImportValues(hostFunctions).build();
 ```
 
 > **Note**: Take note that we don't explicitly execute the module. The module will run when you instantiate it. This
@@ -200,11 +199,11 @@ var fakeStderr = new ByteArrayOutputStream();
 var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).withStderr(fakeStderr).withStdin(fakeStdin).build();
 
 var wasi = new WasiPreview1(logger, wasiOpts);
-var hostFunctions = new ExternalValues(wasi.toHostFunctions());
+var hostFunctions = new ImportValues(wasi.toHostFunctions());
 
 // greet-wasi is a rust program that greets the string passed in stdin
 // instantiating will execute the module if it's a WASI command-pattern module
-Instance.builder(Parser.parse(new File("greet-wasi.wasm"))).withExternalValues(hostFunctions).build();
+Instance.builder(Parser.parse(new File("greet-wasi.wasm"))).withImportValues(hostFunctions).build();
 
 // check that we output the greeting
 assert(fakeStdout.toString().equals("Hello, Andrea!"));

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.dylibso.chicory.log.Logger;
 import com.dylibso.chicory.log.SystemLogger;
-import com.dylibso.chicory.runtime.ExternalValues;
+import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.runtime.Store;
@@ -33,9 +33,9 @@ public class WasiPreview1Test {
         var fakeStdout = new MockPrintStream();
         var wasi =
                 new WasiPreview1(this.logger, WasiOptions.builder().withStdout(fakeStdout).build());
-        var imports = new ExternalValues(wasi.toHostFunctions());
+        var imports = new ImportValues(wasi.toHostFunctions());
         Instance.builder(loadModule("compiled/hello-wasi.wat.wasm"))
-                .withExternalValues(imports)
+                .withImportValues(imports)
                 .build();
         assertEquals(fakeStdout.output().strip(), "hello world");
     }
@@ -46,9 +46,9 @@ public class WasiPreview1Test {
         var expected = "Hello, World!";
         var stdout = new MockPrintStream();
         var wasi = new WasiPreview1(this.logger, WasiOptions.builder().withStdout(stdout).build());
-        var imports = new ExternalValues(wasi.toHostFunctions());
+        var imports = new ImportValues(wasi.toHostFunctions());
         Instance.builder(loadModule("compiled/hello-wasi.rs.wasm"))
-                .withExternalValues(imports)
+                .withImportValues(imports)
                 .build(); // run _start and prints Hello, World!
         assertEquals(expected, stdout.output().strip());
     }
@@ -60,9 +60,9 @@ public class WasiPreview1Test {
         var fakeStdout = new MockPrintStream();
         var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).withStdin(fakeStdin).build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
-        var imports = new ExternalValues(wasi.toHostFunctions());
+        var imports = new ImportValues(wasi.toHostFunctions());
         Instance.builder(loadModule("compiled/greet-wasi.rs.wasm"))
-                .withExternalValues(imports)
+                .withImportValues(imports)
                 .build();
         assertEquals(fakeStdout.output().strip(), "Hello, Benjamin!");
     }
@@ -75,9 +75,9 @@ public class WasiPreview1Test {
         var fakeStdout = new MockPrintStream();
         var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).withStdin(fakeStdin).build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
-        var imports = new ExternalValues(wasi.toHostFunctions());
+        var imports = new ImportValues(wasi.toHostFunctions());
         Instance.builder(loadModule("compiled/javy-demo.js.javy.wasm"))
-                .withExternalValues(imports)
+                .withImportValues(imports)
                 .build();
 
         assertEquals(fakeStdout.output(), "{\"foo\":3,\"newBar\":\"baz!\"}");
@@ -100,7 +100,7 @@ public class WasiPreview1Test {
         var wasi = new WasiPreview1(logger, wasiOpts);
         var quickjs =
                 Instance.builder(loadModule("compiled/quickjs-provider.javy-dynamic.wasm"))
-                        .withExternalValues(new ExternalValues(wasi.toHostFunctions()))
+                        .withImportValues(new ImportValues(wasi.toHostFunctions()))
                         .build();
 
         var greetingMsg = "Hello QuickJS!";
@@ -144,14 +144,14 @@ public class WasiPreview1Test {
         var wasi = new WasiPreview1(logger, wasiOpts);
         var quickjs =
                 Instance.builder(loadModule("compiled/quickjs-provider.javy-dynamic.wasm"))
-                        .withExternalValues(new ExternalValues(wasi.toHostFunctions()))
+                        .withImportValues(new ImportValues(wasi.toHostFunctions()))
                         .build();
 
         var store = new Store();
         store.register("javy_quickjs_provider_v1", quickjs);
 
         Instance.builder(loadModule("compiled/hello-world.js.javy-dynamic.wasm"))
-                .withExternalValues(store.toExternalValues())
+                .withImportValues(store.toImportValues())
                 .build();
 
         // stderr?
@@ -162,9 +162,9 @@ public class WasiPreview1Test {
     public void shouldRunTinyGoModule() {
         var wasiOpts = WasiOptions.builder().build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
-        var imports = new ExternalValues(wasi.toHostFunctions());
+        var imports = new ImportValues(wasi.toHostFunctions());
         var module = loadModule("compiled/sum.go.tiny.wasm");
-        var instance = Instance.builder(module).withExternalValues(imports).build();
+        var instance = Instance.builder(module).withImportValues(imports).build();
         var sum = instance.export("add");
         var result = sum.apply(20, 22)[0];
 
@@ -176,12 +176,12 @@ public class WasiPreview1Test {
         var fakeStdout = new MockPrintStream();
         var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
-        var imports = new ExternalValues(wasi.toHostFunctions());
+        var imports = new ImportValues(wasi.toHostFunctions());
         var module = loadModule("compiled/main.go.wasm");
         var exit =
                 assertThrows(
                         WasiExitException.class,
-                        () -> Instance.builder(module).withExternalValues(imports).build());
+                        () -> Instance.builder(module).withImportValues(imports).build());
         assertEquals(0, exit.exitCode());
         assertEquals("Hello, WebAssembly!\n", fakeStdout.output());
     }
@@ -198,10 +198,10 @@ public class WasiPreview1Test {
                         .withArguments(List.of(""))
                         .build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
-        var imports = new ExternalValues(wasi.toHostFunctions());
+        var imports = new ImportValues(wasi.toHostFunctions());
 
         var module = loadModule("compiled/basic.dotnet.wasm");
-        Instance.builder(module).withExternalValues(imports).build();
+        Instance.builder(module).withImportValues(imports).build();
 
         assertEquals("Hello, Wasi Console!\n", fakeStdout.output());
     }

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiTestRunner.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiTestRunner.java
@@ -4,7 +4,7 @@ import static com.dylibso.chicory.wasi.Files.copyDirectory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.dylibso.chicory.log.SystemLogger;
-import com.dylibso.chicory.runtime.ExternalValues;
+import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasm.Parser;
 import com.google.common.jimfs.Configuration;
@@ -85,7 +85,7 @@ public final class WasiTestRunner {
     private static int execute(File test, WasiOptions wasiOptions) {
         try (var wasi = new WasiPreview1(LOGGER, wasiOptions)) {
             Instance.builder(Parser.parse(test))
-                    .withExternalValues(new ExternalValues(wasi.toHostFunctions()))
+                    .withImportValues(new ImportValues(wasi.toHostFunctions()))
                     .build();
         } catch (WasiExitException e) {
             return e.exitCode();


### PR DESCRIPTION
Follow up to https://github.com/dylibso/chicory/pull/527

Hopefully last big rename (related to this, at least) before the RC 😅 

After chatting with @andreaTP, we agreed that `ExternalValues`, from the perspective of an end user, was confusing naming ("external to what?"). We came up with `ImportedValues`. 

To be honest, my original objection with `HostImports` was about them being `Host`, not `Imports" :) 

- In all our usages, these values are _indeed_ used _by an instance_. 
- They represent a _named value_ assigned to an _import_ (i.e. a  named pair `<module,name>`). 
- The name is generic, it does not imply that value belongs to a Host-thing, nor a Wasm-thing, thus it can be used in both cases.
- There is a specular opposite, at least for functions (`ExportFunction`)

we do "lose" the parallel with the spec, but this is less of an issue, because we only use these `ImportValues` as, duh, values imported by `Instance`s. We never return `ImportValue` from an `export*()`-kind API, so everything should work

### Order of Parameters for External/HostFunction

In this PR I am also changing, again, the order of the parameters for `ImportFunction` because the old constructor "broke" the signature into two pieces, i.e. the handle was _between_ the names and the types:

- module, name, **handle**, paramTypes, returnTypes

vs:

- module, name, paramTypes, returnTypes, **handle**

which I think is clearer. This change is in the last 2 commits, for easier review.