### PR TITLE
computeConstantValue to return the raw long

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Memory.java
@@ -5,13 +5,11 @@ import static java.lang.Math.min;
 
 import com.dylibso.chicory.runtime.exceptions.WASMRuntimeException;
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
-import com.dylibso.chicory.wasm.exceptions.InvalidException;
 import com.dylibso.chicory.wasm.exceptions.UninstantiableException;
 import com.dylibso.chicory.wasm.types.ActiveDataSegment;
 import com.dylibso.chicory.wasm.types.DataSegment;
 import com.dylibso.chicory.wasm.types.MemoryLimits;
 import com.dylibso.chicory.wasm.types.PassiveDataSegment;
-import com.dylibso.chicory.wasm.types.ValueType;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -106,25 +104,10 @@ public final class Memory {
         for (var s : dataSegments) {
             if (s instanceof ActiveDataSegment) {
                 var segment = (ActiveDataSegment) s;
-                if (segment.index() != 0) {
-                    throw new InvalidException("unknown memory " + segment.index());
-                }
                 var offsetExpr = segment.offsetInstructions();
-                if (offsetExpr.size() > 1) {
-                    throw new InvalidException(
-                            "type mismatch, constant expression required, expected only one"
-                                    + " initialization instruction");
-                }
                 var data = segment.data();
-                var offsetValue = computeConstantValue(instance, offsetExpr);
-                if (offsetValue.type() != ValueType.I32) {
-                    throw new InvalidException(
-                            "type mismatch, expected I32 but found "
-                                    + offsetValue.type()
-                                    + " in offset memory initialization");
-                }
-                var offset = offsetValue.asInt();
-                write(offset, data);
+                var offset = computeConstantValue(instance, offsetExpr);
+                write((int) offset, data);
             } else if (s instanceof PassiveDataSegment) {
                 // Passive segment should be skipped
             } else {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/OpcodeImpl.java
@@ -856,16 +856,15 @@ public final class OpcodeImpl {
 
         for (int i = offset; i < end; i++) {
             var elem = instance.element(elementidx);
-            var val = computeConstantValue(instance, elem.initializers().get(elemidx++));
-            var rawValue = (int) val.raw();
+            var val = (int) computeConstantValue(instance, elem.initializers().get(elemidx++));
             if (table.elementType() == ValueType.FuncRef) {
-                if (rawValue > instance.functionCount()) {
+                if (val > instance.functionCount()) {
                     throw new WASMRuntimeException("out of bounds table access");
                 }
-                table.setRef(i, rawValue, instance);
+                table.setRef(i, val, instance);
             } else {
                 assert table.elementType() == ValueType.ExternRef;
-                table.setRef(i, rawValue, instance);
+                table.setRef(i, val, instance);
             }
         }
     }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Validator.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Validator.java
@@ -344,6 +344,9 @@ final class Validator {
         for (var ds : module.dataSection().dataSegments()) {
             if (ds instanceof ActiveDataSegment) {
                 var ads = (ActiveDataSegment) ds;
+                if (ads.index() != 0) {
+                    throw new InvalidException("unknown memory " + ads.index());
+                }
                 validateConstantExpression(ads.offsetInstructions(), ValueType.I32);
             }
         }
@@ -449,6 +452,9 @@ final class Validator {
             if (constInstrCount > 1) {
                 throw new InvalidException("type mismatch, multiple constant expressions found");
             }
+        }
+        if (constInstrCount <= 0) {
+            throw new InvalidException("type mismatch, no constant expressions found");
         }
     }
 


### PR DESCRIPTION
This is a first step in the right direction, we still have `computeConstantType` around, but is used only during `initialization` not in runtime.

We should move all the logic of the checks down to the validator, eventually.