### PR TITLE
Global review of the project (part 2)

### DIFF
--- a/aot-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
+++ b/aot-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
@@ -10,9 +10,9 @@ import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.runtime.TableInstance;
 import com.dylibso.chicory.runtime.WasmFunctionHandle;
-import com.dylibso.chicory.wasm.types.Limits;
 import com.dylibso.chicory.wasm.types.MemoryLimits;
 import com.dylibso.chicory.wasm.types.Table;
+import com.dylibso.chicory.wasm.types.TableLimits;
 import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
@@ -71,7 +71,8 @@ public final class Spectest {
                     new ImportTable(
                             "spectest",
                             "table",
-                            new TableInstance(new Table(ValueType.FuncRef, new Limits(10, 20))))
+                            new TableInstance(
+                                    new Table(ValueType.FuncRef, new TableLimits(10, 20))))
                 });
     }
 }

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
@@ -10,9 +10,9 @@ import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.runtime.TableInstance;
 import com.dylibso.chicory.runtime.WasmFunctionHandle;
-import com.dylibso.chicory.wasm.types.Limits;
 import com.dylibso.chicory.wasm.types.MemoryLimits;
 import com.dylibso.chicory.wasm.types.Table;
+import com.dylibso.chicory.wasm.types.TableLimits;
 import com.dylibso.chicory.wasm.types.Value;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
@@ -71,7 +71,8 @@ public final class Spectest {
                     new ImportTable(
                             "spectest",
                             "table",
-                            new TableInstance(new Table(ValueType.FuncRef, new Limits(10, 20))))
+                            new TableInstance(
+                                    new Table(ValueType.FuncRef, new TableLimits(10, 20))))
                 });
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ImportTable.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ImportTable.java
@@ -1,7 +1,7 @@
 package com.dylibso.chicory.runtime;
 
-import com.dylibso.chicory.wasm.types.Limits;
 import com.dylibso.chicory.wasm.types.Table;
+import com.dylibso.chicory.wasm.types.TableLimits;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.Map;
 
@@ -28,7 +28,8 @@ public class ImportTable implements ImportValue {
         }
 
         this.table =
-                new TableInstance(new Table(ValueType.FuncRef, new Limits(maxFuncRef, maxFuncRef)));
+                new TableInstance(
+                        new Table(ValueType.FuncRef, new TableLimits(maxFuncRef, maxFuncRef)));
         this.table.reset();
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -692,7 +692,7 @@ public class Instance {
             if (module.memorySection().isPresent()) {
                 var memories = module.memorySection().get();
                 if (memories.memoryCount() > 0) {
-                    memory = new Memory(memories.getMemory(0).memoryLimits());
+                    memory = new Memory(memories.getMemory(0).limits());
                 }
             } else {
                 if (mappedHostImports != null && mappedHostImports.memoryCount() > 0) {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/TableInstance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/TableInstance.java
@@ -4,8 +4,8 @@ import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
 
 import com.dylibso.chicory.wasm.exceptions.ChicoryException;
 import com.dylibso.chicory.wasm.exceptions.UninstantiableException;
-import com.dylibso.chicory.wasm.types.Limits;
 import com.dylibso.chicory.wasm.types.Table;
+import com.dylibso.chicory.wasm.types.TableLimits;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.Arrays;
 
@@ -30,7 +30,7 @@ public class TableInstance {
         return table.elementType();
     }
 
-    public Limits limits() {
+    public TableLimits limits() {
         return table.limits();
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -38,7 +38,6 @@ import com.dylibso.chicory.wasm.types.GlobalImport;
 import com.dylibso.chicory.wasm.types.GlobalSection;
 import com.dylibso.chicory.wasm.types.ImportSection;
 import com.dylibso.chicory.wasm.types.Instruction;
-import com.dylibso.chicory.wasm.types.Limits;
 import com.dylibso.chicory.wasm.types.Memory;
 import com.dylibso.chicory.wasm.types.MemoryImport;
 import com.dylibso.chicory.wasm.types.MemoryLimits;
@@ -53,6 +52,7 @@ import com.dylibso.chicory.wasm.types.SectionId;
 import com.dylibso.chicory.wasm.types.StartSection;
 import com.dylibso.chicory.wasm.types.Table;
 import com.dylibso.chicory.wasm.types.TableImport;
+import com.dylibso.chicory.wasm.types.TableLimits;
 import com.dylibso.chicory.wasm.types.TableSection;
 import com.dylibso.chicory.wasm.types.TypeSection;
 import com.dylibso.chicory.wasm.types.UnknownCustomSection;
@@ -444,8 +444,8 @@ public final class Parser {
                         var min = (int) readVarUInt32(buffer);
                         var limits =
                                 limitType > 0
-                                        ? new Limits(min, readVarUInt32(buffer))
-                                        : new Limits(min);
+                                        ? new TableLimits(min, readVarUInt32(buffer))
+                                        : new TableLimits(min);
 
                         importSection.addImport(
                                 new TableImport(moduleName, importName, tableType, limits));
@@ -510,7 +510,10 @@ public final class Parser {
                 throw new MalformedException("integer representation too long, integer too large");
             }
             var min = readVarUInt32(buffer);
-            var limits = limitType > 0 ? new Limits(min, readVarUInt32(buffer)) : new Limits(min);
+            var limits =
+                    limitType > 0
+                            ? new TableLimits(min, readVarUInt32(buffer))
+                            : new TableLimits(min);
             tableSection.addTable(new Table(tableType, limits));
         }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/AnnotatedInstruction.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/AnnotatedInstruction.java
@@ -1,10 +1,12 @@
 package com.dylibso.chicory.wasm.types;
 
 import com.dylibso.chicory.wasm.exceptions.InvalidException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/*
+ * An instruction with additional metadata for control flow.
+ */
 public final class AnnotatedInstruction extends Instruction {
     public static final int UNDEFINED_LABEL = -1;
 
@@ -177,7 +179,7 @@ public final class AnnotatedInstruction extends Instruction {
                     depth,
                     labelTrue.orElse(UNDEFINED_LABEL),
                     labelFalse.orElse(UNDEFINED_LABEL),
-                    labelTable.orElse(new ArrayList<>()),
+                    labelTable.orElse(List.of()),
                     scope.orElse(null));
         }
     }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Memory.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Memory.java
@@ -9,21 +9,21 @@ import java.util.Objects;
  * reference.
  */
 public final class Memory {
-    private final MemoryLimits memoryLimits;
+    private final MemoryLimits limits;
 
     /**
      * Construct a new instance.
      *
-     * @param memoryLimits the memory limits (must not be {@code null})
+     * @param limits the memory limits (must not be {@code null})
      */
-    public Memory(MemoryLimits memoryLimits) {
-        this.memoryLimits = Objects.requireNonNull(memoryLimits, "memoryLimits");
+    public Memory(MemoryLimits limits) {
+        this.limits = Objects.requireNonNull(limits, "memoryLimits");
     }
 
     /**
      * @return the defined memory limits
      */
-    public MemoryLimits memoryLimits() {
-        return memoryLimits;
+    public MemoryLimits limits() {
+        return limits;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Table.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Table.java
@@ -4,9 +4,9 @@ import java.util.Objects;
 
 public class Table {
     private final ValueType elementType;
-    private final Limits limits;
+    private final TableLimits limits;
 
-    public Table(ValueType elementType, Limits limits) {
+    public Table(ValueType elementType, TableLimits limits) {
         this.elementType = Objects.requireNonNull(elementType, "elementType");
         if (!elementType.isReference()) {
             throw new IllegalArgumentException("Table element type must be a reference type");
@@ -18,7 +18,7 @@ public class Table {
         return elementType;
     }
 
-    public Limits limits() {
+    public TableLimits limits() {
         return limits;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableImport.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableImport.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  */
 public final class TableImport extends Import {
     private final ValueType entryType;
-    private final Limits limits;
+    private final TableLimits limits;
 
     /**
      * Construct a new instance.
@@ -17,7 +17,7 @@ public final class TableImport extends Import {
      * @param entryType the table entry type (must not be {@code null})
      * @param limits the table limits (must not be {@code null})
      */
-    public TableImport(String moduleName, String name, ValueType entryType, Limits limits) {
+    public TableImport(String moduleName, String name, ValueType entryType, TableLimits limits) {
         super(moduleName, name);
         this.entryType = Objects.requireNonNull(entryType, "entryType");
         this.limits = Objects.requireNonNull(limits, "limits");
@@ -33,7 +33,7 @@ public final class TableImport extends Import {
     /**
      * @return the table size limits
      */
-    public Limits limits() {
+    public TableLimits limits() {
         return limits;
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableLimits.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableLimits.java
@@ -1,20 +1,22 @@
 package com.dylibso.chicory.wasm.types;
 
+import static com.dylibso.chicory.wasm.WasmLimits.MAX_TABLE_ENTRIES;
+
 import com.dylibso.chicory.wasm.exceptions.InvalidException;
 
-public class Limits {
-    public static final long LIMIT_MAX = 0x1_0000_0000L;
+public class TableLimits {
+    public static final long LIMIT_MAX = MAX_TABLE_ENTRIES;
 
-    private static final Limits UNBOUNDED = new Limits(0);
+    private static final TableLimits UNBOUNDED = new TableLimits(0);
 
     private final long min;
     private final long max;
 
-    public Limits(long min) {
+    public TableLimits(long min) {
         this(min, LIMIT_MAX);
     }
 
-    public Limits(long min, long max) {
+    public TableLimits(long min, long max) {
         if (min > max) {
             throw new InvalidException("size minimum must not be greater than maximum");
         }
@@ -32,10 +34,10 @@ public class Limits {
 
     @Override
     public boolean equals(Object obj) {
-        return obj instanceof Limits && equals((Limits) obj);
+        return obj instanceof TableLimits && equals((TableLimits) obj);
     }
 
-    public boolean equals(Limits other) {
+    public boolean equals(TableLimits other) {
         return this == other || other != null && min == other.min && max == other.max;
     }
 
@@ -59,7 +61,7 @@ public class Limits {
         return b.append(']');
     }
 
-    public static Limits unbounded() {
+    public static TableLimits unbounded() {
         return UNBOUNDED;
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -9,8 +9,6 @@ public class Value {
     public static final long TRUE = 1L;
     public static final long FALSE = 0L;
     public static final int REF_NULL_VALUE = -1;
-    public static final Value EXTREF_NULL = Value.externRef(REF_NULL_VALUE);
-    public static final Value FUNCREF_NULL = Value.funcRef(REF_NULL_VALUE);
     public static final long[] EMPTY_VALUES = new long[0];
 
     private final ValueType type;

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ValueType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ValueType.java
@@ -29,22 +29,6 @@ public enum ValueType {
     }
 
     /**
-     * @return {@code true} if the type can be stored in memory, and thus has a size, or {@code false} otherwise
-     */
-    public boolean hasSize() {
-        switch (this) {
-            case F64:
-            case F32:
-            case I64:
-            case I32:
-            case V128:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    /**
      * @return the size of this type in memory
      *
      * @throws IllegalStateException if the type cannot be stored in memory

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
@@ -73,8 +73,8 @@ public class ParserTest {
             // check memory section
             var memorySection = module.memorySection();
             assertEquals(1, memorySection.get().memoryCount());
-            assertEquals(1, memorySection.get().getMemory(0).memoryLimits().initialPages());
-            assertEquals(65536, memorySection.get().getMemory(0).memoryLimits().maximumPages());
+            assertEquals(1, memorySection.get().getMemory(0).limits().initialPages());
+            assertEquals(65536, memorySection.get().getMemory(0).limits().maximumPages());
 
             var codeSection = module.codeSection();
             assertEquals(1, codeSection.functionBodyCount());


### PR DESCRIPTION
follow up to #600.
- Rename `Limits` to `TableLimits` for consistency with `MemoryLimits`
- Rename `Memory#memoryLimits()` to `Memory#limits()`  for consistency with `Table#limits()`
- Delete unused `ValueType#hasSize()` essentially dual of `ValueType#isReference()`