### PR TITLE
[chore] Remove callHostFunc from public API of Instance

### DIFF
--- a/aot/src/main/java/com/dylibso/chicory/aot/AotCompiler.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotCompiler.java
@@ -3,9 +3,9 @@ package com.dylibso.chicory.aot;
 import static com.dylibso.chicory.aot.AotEmitterMap.EMITTERS;
 import static com.dylibso.chicory.aot.AotMethodInliner.aotMethodsRemapper;
 import static com.dylibso.chicory.aot.AotMethodInliner.createAotMethodsClass;
+import static com.dylibso.chicory.aot.AotMethodRefs.CALL_HOST_FUNCTION;
 import static com.dylibso.chicory.aot.AotMethodRefs.CALL_INDIRECT;
 import static com.dylibso.chicory.aot.AotMethodRefs.CHECK_INTERRUPTION;
-import static com.dylibso.chicory.aot.AotMethodRefs.INSTANCE_CALL_HOST_FUNCTION;
 import static com.dylibso.chicory.aot.AotMethodRefs.INSTANCE_MEMORY;
 import static com.dylibso.chicory.aot.AotMethodRefs.INSTANCE_TABLE;
 import static com.dylibso.chicory.aot.AotMethodRefs.TABLE_INSTANCE;
@@ -387,7 +387,7 @@ public final class AotCompiler {
             asm.visitInsn(Opcodes.POP);
             asm.visitVarInsn(Opcodes.ILOAD, 1);
             asm.visitVarInsn(Opcodes.ALOAD, 2);
-            emitInvokeVirtual(asm, INSTANCE_CALL_HOST_FUNCTION);
+            emitInvokeStatic(asm, CALL_HOST_FUNCTION);
             asm.visitInsn(Opcodes.ARETURN);
         }
 
@@ -533,7 +533,7 @@ public final class AotCompiler {
         asm.visitLdcInsn(funcId);
         emitBoxArguments(asm, type.params());
 
-        emitInvokeVirtual(asm, INSTANCE_CALL_HOST_FUNCTION);
+        emitInvokeStatic(asm, CALL_HOST_FUNCTION);
 
         emitUnboxResult(type, asm);
     }

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethodRefs.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethodRefs.java
@@ -11,7 +11,7 @@ public final class AotMethodRefs {
     static final Method CHECK_INTERRUPTION;
     static final Method CALL_INDIRECT;
     static final Method INSTANCE_MEMORY;
-    static final Method INSTANCE_CALL_HOST_FUNCTION;
+    static final Method CALL_HOST_FUNCTION;
     static final Method READ_GLOBAL;
     static final Method WRITE_GLOBAL;
     static final Method INSTANCE_SET_ELEMENT;
@@ -58,8 +58,9 @@ public final class AotMethodRefs {
                     AotMethods.class.getMethod(
                             "callIndirect", long[].class, int.class, int.class, Instance.class);
             INSTANCE_MEMORY = Instance.class.getMethod("memory");
-            INSTANCE_CALL_HOST_FUNCTION =
-                    Instance.class.getMethod("callHostFunction", int.class, long[].class);
+            CALL_HOST_FUNCTION =
+                    AotMethods.class.getMethod(
+                            "callHostFunction", Instance.class, int.class, long[].class);
             READ_GLOBAL = AotMethods.class.getMethod("readGlobal", int.class, Instance.class);
             WRITE_GLOBAL =
                     AotMethods.class.getMethod(

--- a/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/aot/AotMethods.java
@@ -26,6 +26,11 @@ public final class AotMethods {
         return instance.getMachine().call(funcId, args);
     }
 
+    public static long[] callHostFunction(Instance instance, int funcId, long[] args) {
+        var imprt = instance.imports().function(funcId);
+        return imprt.handle().apply(instance, args);
+    }
+
     public static boolean isRefNull(int ref) {
         return ref == REF_NULL_VALUE;
     }

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyHelloWasi.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyHelloWasi.approved.txt
@@ -33,7 +33,7 @@ public final class com/dylibso/chicory/$gen/CompiledMachine implements com/dylib
     POP
     ILOAD 1
     ALOAD 2
-    INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.callHostFunction (I[J)[J
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.callHostFunction (Lcom/dylibso/chicory/runtime/Instance;I[J)[J
     ARETURN
    L4
     ILOAD 1
@@ -76,7 +76,7 @@ public final class com/dylibso/chicory/$gen/CompiledMachine implements com/dylib
     ILOAD 3
     I2L
     LASTORE
-    INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.callHostFunction (I[J)[J
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.callHostFunction (Lcom/dylibso/chicory/runtime/Instance;I[J)[J
     ICONST_0
     LALOAD
     L2I

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
@@ -158,6 +158,22 @@ private final class FOO$AotMethods {
     ARETURN
    L5
 
+  public static callHostFunction(Lcom/dylibso/chicory/runtime/Instance;I[J)[J
+   L0
+    ALOAD 0
+    INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.imports ()Lcom/dylibso/chicory/runtime/ImportValues;
+    ILOAD 1
+    INVOKEVIRTUAL com/dylibso/chicory/runtime/ImportValues.function (I)Lcom/dylibso/chicory/runtime/ImportFunction;
+    ASTORE 3
+   L1
+    ALOAD 3
+    INVOKEVIRTUAL com/dylibso/chicory/runtime/ImportFunction.handle ()Lcom/dylibso/chicory/runtime/WasmFunctionHandle;
+    ALOAD 0
+    ALOAD 2
+    INVOKEINTERFACE com/dylibso/chicory/runtime/WasmFunctionHandle.apply (Lcom/dylibso/chicory/runtime/Instance;[J)[J (itf)
+    ARETURN
+   L2
+
   public static isRefNull(I)Z
    L0
     ILOAD 0

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyStart.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyStart.approved.txt
@@ -33,7 +33,7 @@ public final class com/dylibso/chicory/$gen/CompiledMachine implements com/dylib
     POP
     ILOAD 1
     ALOAD 2
-    INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.callHostFunction (I[J)[J
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.callHostFunction (Lcom/dylibso/chicory/runtime/Instance;I[J)[J
     ARETURN
    L4
     ILOAD 1
@@ -61,7 +61,7 @@ public final class com/dylibso/chicory/$gen/CompiledMachine implements com/dylib
     ILOAD 0
     I2L
     LASTORE
-    INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.callHostFunction (I[J)[J
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.callHostFunction (Lcom/dylibso/chicory/runtime/Instance;I[J)[J
     RETURN
 
   public static func_1(Lcom/dylibso/chicory/runtime/Memory;Lcom/dylibso/chicory/runtime/Instance;)V

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -320,14 +320,6 @@ public class Instance {
         return machine;
     }
 
-    public long[] callHostFunction(int funcId, long[] args) {
-        var imprt = imports.function(funcId);
-        if (imprt == null) {
-            throw new ChicoryException("Missing host import, number: " + funcId);
-        }
-        return imprt.handle().apply(this, args);
-    }
-
     void onExecution(Instruction instruction, MStack stack) {
         if (listener != null) {
             listener.onExecution(instruction, stack);

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -70,7 +70,8 @@ class InterpreterMachine implements Machine {
             stackFrame.pushCtrl(OpCode.CALL, 0, type.returns().size(), stack.size());
             callStack.push(stackFrame);
 
-            var results = instance.callHostFunction(funcId, args);
+            var imprt = instance.imports().function(funcId);
+            var results = imprt.handle().apply(instance, args);
             // a host function can return null or an array of ints
             // which we will push onto the stack
             if (results != null) {


### PR DESCRIPTION
Noticed reviewing the public API, `callHostFunction` is an internal implementation and we should not provide the user a helper method to user to invoke it.