### PR TITLE
Remove `ImportValues` public constructors, rely on the builder

### DIFF
--- a/aot-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
+++ b/aot-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
@@ -24,55 +24,70 @@ public final class Spectest {
     private Spectest() {}
 
     public static ImportValues toImportValues() {
-        return new ImportValues(
-                new HostFunction[] {
-                    new HostFunction("spectest", "print", List.of(), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_i32", List.of(ValueType.I32), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_i32_1", List.of(ValueType.I32), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_i32_2", List.of(ValueType.I32), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_f32", List.of(ValueType.F32), List.of(), noop),
-                    new HostFunction(
-                            "spectest",
-                            "print_i32_f32",
-                            List.of(ValueType.I32, ValueType.F32),
-                            List.of(),
-                            noop),
-                    new HostFunction(
-                            "spectest", "print_i64", List.of(ValueType.I64), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_i64_1", List.of(ValueType.I64), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_i64_2", List.of(ValueType.I64), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_f64", List.of(ValueType.F64), List.of(), noop),
-                    new HostFunction(
-                            "spectest",
-                            "print_f64_f64",
-                            List.of(ValueType.F64, ValueType.F64),
-                            List.of(),
-                            noop)
-                },
-                new ImportGlobal[] {
-                    new ImportGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),
-                    new ImportGlobal("spectest", "global_i64", new GlobalInstance(Value.i64(666))),
-                    new ImportGlobal(
-                            "spectest", "global_f32", new GlobalInstance(Value.fromFloat(666.6f))),
-                    new ImportGlobal(
-                            "spectest", "global_f64", new GlobalInstance(Value.fromDouble(666.6))),
-                },
-                new ImportMemory[] {
-                    new ImportMemory("spectest", "memory", new Memory(new MemoryLimits(1, 2)))
-                },
-                new ImportTable[] {
-                    new ImportTable(
-                            "spectest",
-                            "table",
-                            new TableInstance(
-                                    new Table(ValueType.FuncRef, new TableLimits(10, 20))))
-                });
+        return ImportValues.builder()
+                .addFunction(new HostFunction("spectest", "print", List.of(), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_i32", List.of(ValueType.I32), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_i32_1", List.of(ValueType.I32), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_i32_2", List.of(ValueType.I32), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_f32", List.of(ValueType.F32), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest",
+                                "print_i32_f32",
+                                List.of(ValueType.I32, ValueType.F32),
+                                List.of(),
+                                noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_i64", List.of(ValueType.I64), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_i64_1", List.of(ValueType.I64), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_i64_2", List.of(ValueType.I64), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_f64", List.of(ValueType.F64), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest",
+                                "print_f64_f64",
+                                List.of(ValueType.F64, ValueType.F64),
+                                List.of(),
+                                noop))
+                .addGlobal(
+                        new ImportGlobal(
+                                "spectest", "global_i32", new GlobalInstance(Value.i32(666))))
+                .addGlobal(
+                        new ImportGlobal(
+                                "spectest", "global_i64", new GlobalInstance(Value.i64(666))))
+                .addGlobal(
+                        new ImportGlobal(
+                                "spectest",
+                                "global_f32",
+                                new GlobalInstance(Value.fromFloat(666.6f))))
+                .addGlobal(
+                        new ImportGlobal(
+                                "spectest",
+                                "global_f64",
+                                new GlobalInstance(Value.fromDouble(666.6))))
+                .addMemory(
+                        new ImportMemory("spectest", "memory", new Memory(new MemoryLimits(1, 2))))
+                .addTable(
+                        new ImportTable(
+                                "spectest",
+                                "table",
+                                new TableInstance(
+                                        new Table(ValueType.FuncRef, new TableLimits(10, 20)))))
+                .build();
     }
 }

--- a/cli/src/main/java/com/dylibso/chicory/cli/Cli.java
+++ b/cli/src/main/java/com/dylibso/chicory/cli/Cli.java
@@ -59,12 +59,16 @@ public class Cli implements Runnable {
         var module = Parser.parse(file);
         var imports =
                 wasi
-                        ? new ImportValues(
-                                new WasiPreview1(
-                                                logger,
-                                                WasiOptions.builder().inheritSystem().build())
-                                        .toHostFunctions())
-                        : new ImportValues();
+                        ? ImportValues.builder()
+                                .addFunction(
+                                        new WasiPreview1(
+                                                        logger,
+                                                        WasiOptions.builder()
+                                                                .inheritSystem()
+                                                                .build())
+                                                .toHostFunctions())
+                                .build()
+                        : ImportValues.empty();
         var instance =
                 Instance.builder(module)
                         .withInitialize(true)

--- a/docs/docs/usage/host-functions.md
+++ b/docs/docs/usage/host-functions.md
@@ -44,6 +44,8 @@ curl https://raw.githubusercontent.com/dylibso/chicory/main/wasm-corpus/src/main
 ```java
 //DEPS com.dylibso.chicory:docs-lib:999-SNAPSHOT
 //DEPS com.dylibso.chicory:runtime:999-SNAPSHOT
+//DEPS com.dylibso.chicory:host-module-annotations:999-SNAPSHOT
+//DEPS com.dylibso.chicory:host-module-processor:999-SNAPSHOT
 ```
 -->
 <!--
@@ -123,6 +125,9 @@ useful when you have many host functions.
 ```java
 @HostModule("demo")
 public final class Demo {
+    
+    public Demo() {};
+    
     @WasmExport
     public long add(int a, int b) {
         return a + b;
@@ -153,9 +158,21 @@ This is because host functions will typically interact with instance state in th
 
 To use the host module, you need to instantiate the host module and fetch the host functions:
 
+<!--
+```java
+// bug in JShell: https://github.com/jbangdev/jbang/issues/1854
+public class Demo {
+    public Demo() {};
+
+    public HostFunction[] toHostFunctions() {
+        return new HostFunction[0];
+    }
+}
+```
+-->
 ```java
 var demo = new Demo();
-var imports = new ImportValues(demo.toHostFunctions());
+var imports = ImportValues.builder().addFunction(demo.toHostFunctions()).build();
 ```
 
 ### Type conversions

--- a/docs/tests/index.test.ts
+++ b/docs/tests/index.test.ts
@@ -28,6 +28,9 @@ describe("ApprovalTests", () => {
   it.each(markdownFiles)('test %s', (f) => {
     const jbangExec = jbang.exec(f);
     expect(jbangExec.code).toBe(0);
+    if (jbangExec.stderr.toLowerCase().includes("error")) {
+        throw jbangExec.stderr;
+    }
 
     if (!fs.existsSync(f + ".result")) {
       throw "Result file not found: " + f + ".result";

--- a/host-module/it/src/it/with-imports/src/test/java/chicory/test/WithImportsTest.java
+++ b/host-module/it/src/it/with-imports/src/test/java/chicory/test/WithImportsTest.java
@@ -25,8 +25,10 @@ class WithImportsTest {
                                             WithImportsTest.class.getResourceAsStream(
                                                     "/compiled/host-function.wat.wasm")))
                             .withImportValues(
-                                    new ImportValues(
-                                            TestModule_ModuleFactory.toHostFunctions(this)))
+                                    ImportValues.builder()
+                                            .addFunction(
+                                                    TestModule_ModuleFactory.toHostFunctions(this))
+                                            .build())
                             .build();
         }
 

--- a/machine-tests/src/test/java/com/dylibso/chicory/testing/MachinesTest.java
+++ b/machine-tests/src/test/java/com/dylibso/chicory/testing/MachinesTest.java
@@ -76,7 +76,8 @@ public final class MachinesTest {
         var quickjs =
                 quickJsInstanceBuilder()
                         .withMachineFactory(QuickJSMachineFactory::create)
-                        .withImportValues(new ImportValues(wasi.toHostFunctions()))
+                        .withImportValues(
+                                ImportValues.builder().addFunction(wasi.toHostFunctions()).build())
                         .build();
 
         var store = new Store().register("javy_quickjs_provider_v1", quickjs);
@@ -106,7 +107,8 @@ public final class MachinesTest {
         // using the pre-compiled version of QuickJS
         var quickjs =
                 quickJsInstanceBuilder()
-                        .withImportValues(new ImportValues(wasi.toHostFunctions()))
+                        .withImportValues(
+                                ImportValues.builder().addFunction(wasi.toHostFunctions()).build())
                         .build();
 
         var store = new Store().register("javy_quickjs_provider_v1", quickjs);
@@ -140,7 +142,8 @@ public final class MachinesTest {
         var quickjs =
                 quickJsInstanceBuilder()
                         .withMachineFactory(AotMachine::new)
-                        .withImportValues(new ImportValues(wasi.toHostFunctions()))
+                        .withImportValues(
+                                ImportValues.builder().addFunction(wasi.toHostFunctions()).build())
                         .build();
 
         var store = new Store().register("javy_quickjs_provider_v1", quickjs);
@@ -183,7 +186,8 @@ public final class MachinesTest {
                             .withArguments(List.of("wat2wasm", path.toString(), "--output=-"))
                             .build();
             try (var wasi = WasiPreview1.builder().withOptions(wasiOpts).build()) {
-                ImportValues imports = new ImportValues(wasi.toHostFunctions());
+                ImportValues imports =
+                        ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
                 var wat2WasmModule = Parser.parse(new File("../wabt/src/main/resources/wat2wasm"));
                 var startFunctionIndex = new AtomicInteger();
                 for (int i = 0; i < wat2WasmModule.exportSection().exportCount(); i++) {

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/Spectest.java
@@ -24,55 +24,70 @@ public final class Spectest {
     private Spectest() {}
 
     public static ImportValues toImportValues() {
-        return new ImportValues(
-                new HostFunction[] {
-                    new HostFunction("spectest", "print", List.of(), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_i32", List.of(ValueType.I32), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_i32_1", List.of(ValueType.I32), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_i32_2", List.of(ValueType.I32), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_f32", List.of(ValueType.F32), List.of(), noop),
-                    new HostFunction(
-                            "spectest",
-                            "print_i32_f32",
-                            List.of(ValueType.I32, ValueType.F32),
-                            List.of(),
-                            noop),
-                    new HostFunction(
-                            "spectest", "print_i64", List.of(ValueType.I64), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_i64_1", List.of(ValueType.I64), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_i64_2", List.of(ValueType.I64), List.of(), noop),
-                    new HostFunction(
-                            "spectest", "print_f64", List.of(ValueType.F64), List.of(), noop),
-                    new HostFunction(
-                            "spectest",
-                            "print_f64_f64",
-                            List.of(ValueType.F64, ValueType.F64),
-                            List.of(),
-                            noop)
-                },
-                new ImportGlobal[] {
-                    new ImportGlobal("spectest", "global_i32", new GlobalInstance(Value.i32(666))),
-                    new ImportGlobal("spectest", "global_i64", new GlobalInstance(Value.i64(666))),
-                    new ImportGlobal(
-                            "spectest", "global_f32", new GlobalInstance(Value.fromFloat(666.6f))),
-                    new ImportGlobal(
-                            "spectest", "global_f64", new GlobalInstance(Value.fromDouble(666.6))),
-                },
-                new ImportMemory[] {
-                    new ImportMemory("spectest", "memory", new Memory(new MemoryLimits(1, 2)))
-                },
-                new ImportTable[] {
-                    new ImportTable(
-                            "spectest",
-                            "table",
-                            new TableInstance(
-                                    new Table(ValueType.FuncRef, new TableLimits(10, 20))))
-                });
+        return ImportValues.builder()
+                .addFunction(new HostFunction("spectest", "print", List.of(), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_i32", List.of(ValueType.I32), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_i32_1", List.of(ValueType.I32), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_i32_2", List.of(ValueType.I32), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_f32", List.of(ValueType.F32), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest",
+                                "print_i32_f32",
+                                List.of(ValueType.I32, ValueType.F32),
+                                List.of(),
+                                noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_i64", List.of(ValueType.I64), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_i64_1", List.of(ValueType.I64), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_i64_2", List.of(ValueType.I64), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest", "print_f64", List.of(ValueType.F64), List.of(), noop))
+                .addFunction(
+                        new HostFunction(
+                                "spectest",
+                                "print_f64_f64",
+                                List.of(ValueType.F64, ValueType.F64),
+                                List.of(),
+                                noop))
+                .addGlobal(
+                        new ImportGlobal(
+                                "spectest", "global_i32", new GlobalInstance(Value.i32(666))))
+                .addGlobal(
+                        new ImportGlobal(
+                                "spectest", "global_i64", new GlobalInstance(Value.i64(666))))
+                .addGlobal(
+                        new ImportGlobal(
+                                "spectest",
+                                "global_f32",
+                                new GlobalInstance(Value.fromFloat(666.6f))))
+                .addGlobal(
+                        new ImportGlobal(
+                                "spectest",
+                                "global_f64",
+                                new GlobalInstance(Value.fromDouble(666.6))))
+                .addMemory(
+                        new ImportMemory("spectest", "memory", new Memory(new MemoryLimits(1, 2))))
+                .addTable(
+                        new ImportTable(
+                                "spectest",
+                                "table",
+                                new TableInstance(
+                                        new Table(ValueType.FuncRef, new TableLimits(10, 20)))))
+                .build();
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ImportValues.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ImportValues.java
@@ -1,10 +1,10 @@
 package com.dylibso.chicory.runtime;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
-public class ImportValues {
+public final class ImportValues {
     private static final ImportFunction[] NO_EXTERNAL_FUNCTIONS = new ImportFunction[0];
     private static final ImportGlobal[] NO_EXTERNAL_GLOBALS = new ImportGlobal[0];
     private static final ImportMemory[] NO_EXTERNAL_MEMORIES = new ImportMemory[0];
@@ -15,60 +15,7 @@ public class ImportValues {
     private final ImportMemory[] memories;
     private final ImportTable[] tables;
 
-    public ImportValues() {
-        this.functions = NO_EXTERNAL_FUNCTIONS;
-        this.globals = NO_EXTERNAL_GLOBALS;
-        this.memories = NO_EXTERNAL_MEMORIES;
-        this.tables = NO_EXTERNAL_TABLES;
-    }
-
-    public ImportValues(HostFunction[] functions) {
-        this.functions = functions.clone();
-        this.globals = NO_EXTERNAL_GLOBALS;
-        this.memories = NO_EXTERNAL_MEMORIES;
-        this.tables = NO_EXTERNAL_TABLES;
-    }
-
-    public ImportValues(ImportGlobal[] globals) {
-        this.functions = NO_EXTERNAL_FUNCTIONS;
-        this.globals = globals.clone();
-        this.memories = NO_EXTERNAL_MEMORIES;
-        this.tables = NO_EXTERNAL_TABLES;
-    }
-
-    public ImportValues(ImportMemory[] memories) {
-        this.functions = NO_EXTERNAL_FUNCTIONS;
-        this.globals = NO_EXTERNAL_GLOBALS;
-        this.memories = memories.clone();
-        this.tables = NO_EXTERNAL_TABLES;
-    }
-
-    public ImportValues(ImportMemory memory) {
-        this.functions = NO_EXTERNAL_FUNCTIONS;
-        this.globals = NO_EXTERNAL_GLOBALS;
-        this.memories = new ImportMemory[] {memory};
-        this.tables = NO_EXTERNAL_TABLES;
-    }
-
-    public ImportValues(ImportTable[] tables) {
-        this.functions = NO_EXTERNAL_FUNCTIONS;
-        this.globals = NO_EXTERNAL_GLOBALS;
-        this.memories = NO_EXTERNAL_MEMORIES;
-        this.tables = tables.clone();
-    }
-
-    public ImportValues(
-            ImportFunction[] functions,
-            ImportGlobal[] globals,
-            ImportMemory memory,
-            ImportTable[] tables) {
-        this.functions = functions.clone();
-        this.globals = globals.clone();
-        this.memories = new ImportMemory[] {memory};
-        this.tables = tables.clone();
-    }
-
-    public ImportValues(
+    private ImportValues(
             ImportFunction[] functions,
             ImportGlobal[] globals,
             ImportMemory[] memories,
@@ -136,14 +83,14 @@ public class ImportValues {
     }
 
     public static final class Builder {
-        private List<ImportFunction> functions;
-        private List<ImportGlobal> globals;
-        private List<ImportMemory> memories;
-        private List<ImportTable> tables;
+        private Collection<ImportFunction> functions;
+        private Collection<ImportGlobal> globals;
+        private Collection<ImportMemory> memories;
+        private Collection<ImportTable> tables;
 
         Builder() {}
 
-        public Builder withFunctions(List<ImportFunction> functions) {
+        public Builder withFunctions(Collection<ImportFunction> functions) {
             this.functions = functions;
             return this;
         }
@@ -156,7 +103,7 @@ public class ImportValues {
             return this;
         }
 
-        public Builder withGlobals(List<ImportGlobal> globals) {
+        public Builder withGlobals(Collection<ImportGlobal> globals) {
             this.globals = globals;
             return this;
         }
@@ -169,7 +116,7 @@ public class ImportValues {
             return this;
         }
 
-        public Builder withMemories(List<ImportMemory> memories) {
+        public Builder withMemories(Collection<ImportMemory> memories) {
             this.memories = memories;
             return this;
         }
@@ -182,7 +129,7 @@ public class ImportValues {
             return this;
         }
 
-        public Builder withTables(List<ImportTable> tables) {
+        public Builder withTables(Collection<ImportTable> tables) {
             this.tables = tables;
             return this;
         }
@@ -199,17 +146,17 @@ public class ImportValues {
             final ImportValues importValues =
                     new ImportValues(
                             functions == null
-                                    ? new HostFunction[0]
-                                    : functions.toArray(new HostFunction[0]),
+                                    ? NO_EXTERNAL_FUNCTIONS
+                                    : functions.toArray(NO_EXTERNAL_FUNCTIONS),
                             globals == null
-                                    ? new ImportGlobal[0]
-                                    : globals.toArray(new ImportGlobal[0]),
+                                    ? NO_EXTERNAL_GLOBALS
+                                    : globals.toArray(NO_EXTERNAL_GLOBALS),
                             memories == null
-                                    ? new ImportMemory[0]
-                                    : memories.toArray(new ImportMemory[0]),
+                                    ? NO_EXTERNAL_MEMORIES
+                                    : memories.toArray(NO_EXTERNAL_MEMORIES),
                             tables == null
-                                    ? new ImportTable[0]
-                                    : tables.toArray(new ImportTable[0]));
+                                    ? NO_EXTERNAL_TABLES
+                                    : tables.toArray(NO_EXTERNAL_TABLES));
             return importValues;
         }
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -542,7 +542,12 @@ public class Instance {
                 }
             }
 
-            return new ImportValues(hostFuncs, hostGlobals, hostMems, hostTables);
+            return ImportValues.builder()
+                    .addFunction(hostFuncs)
+                    .addGlobal(hostGlobals)
+                    .addMemory(hostMems)
+                    .addTable(hostTables)
+                    .build();
         }
 
         private Map<String, Export> genExports(ExportSection export) {
@@ -592,7 +597,7 @@ public class Instance {
             var mappedHostImports =
                     mapHostImports(
                             imports,
-                            requireNonNullElseGet(importValues, ImportValues::new),
+                            requireNonNullElseGet(importValues, ImportValues::empty),
                             module.memorySection().map(MemorySection::memoryCount).orElse(0));
 
             if (module.startSection().isPresent()) {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
@@ -72,11 +72,12 @@ public class Store {
      * Convert the contents of a store to a {@link ImportValues} instance.
      */
     public ImportValues toImportValues() {
-        return new ImportValues(
-                functions.values().toArray(new ImportFunction[0]),
-                globals.values().toArray(new ImportGlobal[0]),
-                memories.values().toArray(new ImportMemory[0]),
-                tables.values().toArray(new ImportTable[0]));
+        return ImportValues.builder()
+                .withFunctions(functions.values())
+                .withGlobals(globals.values())
+                .withMemories(memories.values())
+                .withTables(tables.values())
+                .build();
     }
 
     /**

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/ModuleTest.java
@@ -101,7 +101,7 @@ public class ModuleTest {
         var funcs = new HostFunction[] {func};
         var instance =
                 Instance.builder(loadModule("compiled/host-function.wat.wasm"))
-                        .withImportValues(new ImportValues(funcs))
+                        .withImportValues(ImportValues.builder().addFunction(funcs).build())
                         .build();
         var logIt = instance.export("logIt");
         logIt.apply();
@@ -151,7 +151,7 @@ public class ModuleTest {
                         });
         var funcs = new HostFunction[] {func};
         Instance.builder(loadModule("compiled/start.wat.wasm"))
-                .withImportValues(new ImportValues(funcs))
+                .withImportValues(ImportValues.builder().addFunction(funcs).build())
                 .build();
 
         assertTrue(count.get() > 0);
@@ -288,11 +288,7 @@ public class ModuleTest {
         var memory = new ImportMemory("env", "memory", new Memory(new MemoryLimits(1)));
 
         var hostImports =
-                new ImportValues(
-                        new HostFunction[] {cbrtFunc, logFunc},
-                        new ImportGlobal[0],
-                        memory,
-                        new ImportTable[0]);
+                ImportValues.builder().addFunction(cbrtFunc, logFunc).addMemory(memory).build();
         var instance =
                 Instance.builder(loadModule("compiled/mixed-imports.wat.wasm"))
                         .withImportValues(hostImports)

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
@@ -86,7 +86,8 @@ public final class Wast2Json {
                                 .withLogger(logger)
                                 .withOptions(wasiOpts.build())
                                 .build()) {
-                    ImportValues imports = new ImportValues(wasi.toHostFunctions());
+                    ImportValues imports =
+                            ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
 
                     Instance.builder(MODULE)
                             .withImportValues(imports)

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
@@ -71,7 +71,8 @@ public final class Wat2Wasm {
 
                 try (var wasi =
                         WasiPreview1.builder().withLogger(logger).withOptions(wasiOpts).build()) {
-                    ImportValues imports = new ImportValues(wasi.toHostFunctions());
+                    ImportValues imports =
+                            ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
                     Instance.builder(MODULE)
                             .withMachineFactory(Wat2WasmModuleMachineFactory::create)
                             .withImportValues(imports)

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
@@ -40,7 +40,7 @@ public class WasiPreview1Test {
         var fakeStdout = new MockPrintStream();
         var wasi =
                 new WasiPreview1(this.logger, WasiOptions.builder().withStdout(fakeStdout).build());
-        var imports = new ImportValues(wasi.toHostFunctions());
+        var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
         Instance.builder(loadModule("compiled/hello-wasi.wat.wasm"))
                 .withImportValues(imports)
                 .build();
@@ -53,7 +53,7 @@ public class WasiPreview1Test {
         var expected = "Hello, World!";
         var stdout = new MockPrintStream();
         var wasi = new WasiPreview1(this.logger, WasiOptions.builder().withStdout(stdout).build());
-        var imports = new ImportValues(wasi.toHostFunctions());
+        var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
         Instance.builder(loadModule("compiled/hello-wasi.rs.wasm"))
                 .withImportValues(imports)
                 .build(); // run _start and prints Hello, World!
@@ -67,7 +67,7 @@ public class WasiPreview1Test {
         var fakeStdout = new MockPrintStream();
         var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).withStdin(fakeStdin).build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
-        var imports = new ImportValues(wasi.toHostFunctions());
+        var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
         Instance.builder(loadModule("compiled/greet-wasi.rs.wasm"))
                 .withImportValues(imports)
                 .build();
@@ -82,7 +82,7 @@ public class WasiPreview1Test {
         var fakeStdout = new MockPrintStream();
         var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).withStdin(fakeStdin).build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
-        var imports = new ImportValues(wasi.toHostFunctions());
+        var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
         Instance.builder(loadModule("compiled/javy-demo.js.javy.wasm"))
                 .withImportValues(imports)
                 .build();
@@ -107,7 +107,8 @@ public class WasiPreview1Test {
         var wasi = new WasiPreview1(logger, wasiOpts);
         var quickjs =
                 Instance.builder(loadModule("compiled/quickjs-provider.javy-dynamic.wasm"))
-                        .withImportValues(new ImportValues(wasi.toHostFunctions()))
+                        .withImportValues(
+                                ImportValues.builder().addFunction(wasi.toHostFunctions()).build())
                         .build();
 
         var greetingMsg = "Hello QuickJS!";
@@ -151,7 +152,8 @@ public class WasiPreview1Test {
         var wasi = new WasiPreview1(logger, wasiOpts);
         var quickjs =
                 Instance.builder(loadModule("compiled/quickjs-provider.javy-dynamic.wasm"))
-                        .withImportValues(new ImportValues(wasi.toHostFunctions()))
+                        .withImportValues(
+                                ImportValues.builder().addFunction(wasi.toHostFunctions()).build())
                         .build();
 
         var store = new Store();
@@ -169,7 +171,7 @@ public class WasiPreview1Test {
     public void shouldRunTinyGoModule() {
         var wasiOpts = WasiOptions.builder().build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
-        var imports = new ImportValues(wasi.toHostFunctions());
+        var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
         var module = loadModule("compiled/sum.go.tiny.wasm");
         var instance = Instance.builder(module).withImportValues(imports).build();
         var sum = instance.export("add");
@@ -183,7 +185,7 @@ public class WasiPreview1Test {
         var fakeStdout = new MockPrintStream();
         var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
-        var imports = new ImportValues(wasi.toHostFunctions());
+        var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
         var module = loadModule("compiled/main.go.wasm");
         var exit =
                 assertThrows(
@@ -205,7 +207,7 @@ public class WasiPreview1Test {
                         .withArguments(List.of(""))
                         .build();
         var wasi = new WasiPreview1(this.logger, wasiOpts);
-        var imports = new ImportValues(wasi.toHostFunctions());
+        var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
 
         var module = loadModule("compiled/basic.dotnet.wasm");
         Instance.builder(module).withImportValues(imports).build();

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiTestRunner.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiTestRunner.java
@@ -85,7 +85,8 @@ public final class WasiTestRunner {
     private static int execute(File test, WasiOptions wasiOptions) {
         try (var wasi = new WasiPreview1(LOGGER, wasiOptions)) {
             Instance.builder(Parser.parse(test))
-                    .withImportValues(new ImportValues(wasi.toHostFunctions()))
+                    .withImportValues(
+                            ImportValues.builder().addFunction(wasi.toHostFunctions()).build())
                     .build();
         } catch (WasiExitException e) {
             return e.exitCode();


### PR DESCRIPTION
Working on something else I found out that the overloaded constructors of `ImportValues` are not going to age well.
This PR removes them from the public API forcing to go through the builder interface that's much more "future-proof".