### PR TITLE
Implement WASI path_readlink

### DIFF
--- a/docs/docs/usage/wasi.md
+++ b/docs/docs/usage/wasi.md
@@ -163,7 +163,7 @@ For the most up-to-date info, and to see what specific functions we support, see
 | path_filestat_set_times | ✅         |                                                                           |
 | path_link               | ❌         |                                                                           |
 | path_open               | ✅         |                                                                           |
-| path_readlink           | ❌         |                                                                           |
+| path_readlink           | ✅         |                                                                           |
 | path_remove_directory   | ✅         |                                                                           |
 | path_rename             | ✅         |                                                                           |
 | path_symlink            | ❌         |                                                                           |

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
@@ -728,17 +728,14 @@ public final class WasiPreview1 implements Closeable {
             return wasiResult(WasiErrno.EBADF);
         }
 
-        Path directoryPath;
-        if (descriptor instanceof Directory) {
-            directoryPath = ((Directory) descriptor).path();
-        } else {
+        if (!(descriptor instanceof Directory)) {
             return wasiResult(WasiErrno.ENOTDIR);
         }
+        Path directory = ((Directory) descriptor).path();
 
         int used = 0;
-        try (Stream<Path> stream = Files.list(directoryPath)) {
-            Stream<Path> special =
-                    Stream.of(directoryPath.resolve("."), directoryPath.resolve(".."));
+        try (Stream<Path> stream = Files.list(directory)) {
+            Stream<Path> special = Stream.of(directory.resolve("."), directory.resolve(".."));
             Iterator<Path> iterator = Stream.concat(special, stream).skip(cookie).iterator();
             while (iterator.hasNext()) {
                 Path entryPath = iterator.next();


### PR DESCRIPTION
Python requires this when running `python foo.py`