### PR TITLE
Rename Module to WasmModule

### DIFF
--- a/aot-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/aot-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -6,13 +6,13 @@ import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Store;
 import com.dylibso.chicory.wabt.Wat2Wasm;
 import com.dylibso.chicory.wasm.MalformedException;
-import com.dylibso.chicory.wasm.Module;
 import com.dylibso.chicory.wasm.Parser;
+import com.dylibso.chicory.wasm.WasmModule;
 import java.io.File;
 
 public class TestModule {
 
-    private final Module module;
+    private final WasmModule module;
 
     private static final String HACK_MATCH_ALL_MALFORMED_EXCEPTION_TEXT =
             "Matching keywords to get the WebAssembly testsuite to pass: "
@@ -53,11 +53,11 @@ public class TestModule {
         return of(Parser.parse(file));
     }
 
-    public static TestModule of(Module module) {
+    public static TestModule of(WasmModule module) {
         return new TestModule(module);
     }
 
-    public TestModule(Module module) {
+    public TestModule(WasmModule module) {
         this.module = module;
     }
 

--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotAnalyzer.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotAnalyzer.java
@@ -6,7 +6,7 @@ import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toUnmodifiableList;
 
 import com.dylibso.chicory.wasm.ChicoryException;
-import com.dylibso.chicory.wasm.Module;
+import com.dylibso.chicory.wasm.WasmModule;
 import com.dylibso.chicory.wasm.types.AnnotatedInstruction;
 import com.dylibso.chicory.wasm.types.ExternalType;
 import com.dylibso.chicory.wasm.types.FunctionBody;
@@ -32,13 +32,13 @@ import java.util.stream.Stream;
 
 final class AotAnalyzer {
 
-    private final Module module;
+    private final WasmModule module;
     private final List<ValueType> globalTypes;
     private final List<FunctionType> functionTypes;
     private final List<ValueType> tableTypes;
     private final int functionImports;
 
-    public AotAnalyzer(Module module) {
+    public AotAnalyzer(WasmModule module) {
         this.module = module;
         this.globalTypes = getGlobalTypes(module);
         this.functionTypes = getFunctionTypes(module);
@@ -668,7 +668,7 @@ final class AotAnalyzer {
         return module.typeSection().getType(typeId);
     }
 
-    private static List<ValueType> getGlobalTypes(Module module) {
+    private static List<ValueType> getGlobalTypes(WasmModule module) {
         var importedGlobals =
                 module.importSection().stream()
                         .filter(GlobalImport.class::isInstance)
@@ -684,7 +684,7 @@ final class AotAnalyzer {
         return Stream.concat(importedGlobals, moduleGlobals).collect(toUnmodifiableList());
     }
 
-    private static List<FunctionType> getFunctionTypes(Module module) {
+    private static List<FunctionType> getFunctionTypes(WasmModule module) {
         var importedFunctions =
                 module.importSection().stream()
                         .filter(FunctionImport.class::isInstance)
@@ -699,7 +699,7 @@ final class AotAnalyzer {
         return Stream.concat(importedFunctions, moduleFunctions).collect(toUnmodifiableList());
     }
 
-    private static List<ValueType> getTableTypes(Module module) {
+    private static List<ValueType> getTableTypes(WasmModule module) {
         var importedTables =
                 module.importSection().stream()
                         .filter(TableImport.class::isInstance)

--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotCompiler.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotCompiler.java
@@ -46,7 +46,7 @@ import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Machine;
 import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.wasm.ChicoryException;
-import com.dylibso.chicory.wasm.Module;
+import com.dylibso.chicory.wasm.WasmModule;
 import com.dylibso.chicory.wasm.types.ExternalType;
 import com.dylibso.chicory.wasm.types.FunctionBody;
 import com.dylibso.chicory.wasm.types.FunctionSection;
@@ -83,13 +83,13 @@ public final class AotCompiler {
 
     private final AotClassLoader classLoader = new AotClassLoader();
     private final String className;
-    private final Module module;
+    private final WasmModule module;
     private final AotAnalyzer analyzer;
     private final int functionImports;
     private final List<FunctionType> functionTypes;
     private final Map<String, byte[]> extraClasses;
 
-    private AotCompiler(Module module, String className) {
+    private AotCompiler(WasmModule module, String className) {
         this.className = requireNonNull(className, "className");
         this.module = requireNonNull(module, "module");
         this.analyzer = new AotAnalyzer(module);
@@ -98,11 +98,11 @@ public final class AotCompiler {
         this.extraClasses = compileExtraClasses();
     }
 
-    public static CompilerResult compileModule(Module module) {
+    public static CompilerResult compileModule(WasmModule module) {
         return compileModule(module, DEFAULT_CLASS_NAME);
     }
 
-    public static CompilerResult compileModule(Module module, String className) {
+    public static CompilerResult compileModule(WasmModule module, String className) {
         var compiler = new AotCompiler(module, className);
 
         var bytes = compiler.compileClass(module.functionSection());

--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMachineFactory.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMachineFactory.java
@@ -2,7 +2,7 @@ package com.dylibso.chicory.experimental.aot;
 
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Machine;
-import com.dylibso.chicory.wasm.Module;
+import com.dylibso.chicory.wasm.WasmModule;
 import java.util.function.Function;
 
 /**
@@ -12,10 +12,10 @@ import java.util.function.Function;
  */
 public final class AotMachineFactory implements Function<Instance, Machine> {
 
-    private final Module module;
+    private final WasmModule module;
     private final Function<Instance, Machine> factory;
 
-    public AotMachineFactory(Module module) {
+    public AotMachineFactory(WasmModule module) {
         this.module = module;
         this.factory = AotCompiler.compileModule(module).machineFactory();
     }

--- a/aot/src/test/java/com/dylibso/chicory/experimental/aot/InterruptionTest.java
+++ b/aot/src/test/java/com/dylibso/chicory/experimental/aot/InterruptionTest.java
@@ -8,8 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasm.ChicoryException;
-import com.dylibso.chicory.wasm.Module;
 import com.dylibso.chicory.wasm.Parser;
+import com.dylibso.chicory.wasm.WasmModule;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +35,7 @@ public class InterruptionTest {
         assertInterruption(() -> function.apply(100), functionIdx(module, "run"));
     }
 
-    private static int functionIdx(Module module, String name) {
+    private static int functionIdx(WasmModule module, String name) {
         for (int i = 0; i < module.exportSection().exportCount(); i++) {
             var export = module.exportSection().getExport(i);
             if (export.name().equals(name)) {

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -73,13 +73,13 @@ Now let's load this module and instantiate it:
 ```java
 import com.dylibso.chicory.runtime.ExportFunction;
 import com.dylibso.chicory.wasm.types.Value;
-import com.dylibso.chicory.wasm.Module;
+import com.dylibso.chicory.wasm.WasmModule;
 import com.dylibso.chicory.wasm.Parser;
 import com.dylibso.chicory.runtime.Instance;
 import java.io.File;
 
 // point this to your path on disk
-Module module = Parser.parse(new File("./factorial.wasm"));
+WasmModule module = Parser.parse(new File("./factorial.wasm"));
 Instance instance = Instance.builder(module).build();
 ```
 

--- a/fuzz/src/main/java/com/dylibso/chicory/fuzz/TestModule.java
+++ b/fuzz/src/main/java/com/dylibso/chicory/fuzz/TestModule.java
@@ -3,7 +3,7 @@ package com.dylibso.chicory.fuzz;
 import com.dylibso.chicory.log.Logger;
 import com.dylibso.chicory.log.SystemLogger;
 import com.dylibso.chicory.runtime.Instance;
-import com.dylibso.chicory.wasm.Module;
+import com.dylibso.chicory.wasm.WasmModule;
 import com.dylibso.chicory.wasm.types.FunctionType;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -30,13 +30,13 @@ public class TestModule {
         return RandomStringUtils.randomNumeric(2);
     }
 
-    public List<TestResult> testModule(File targetWasm, Module module, Instance instance)
+    public List<TestResult> testModule(File targetWasm, WasmModule module, Instance instance)
             throws Exception {
         return testModule(targetWasm, module, instance, true);
     }
 
     public List<TestResult> testModule(
-            File targetWasm, Module module, Instance instance, boolean commitOnFailure)
+            File targetWasm, WasmModule module, Instance instance, boolean commitOnFailure)
             throws Exception {
         var results = new ArrayList<TestResult>();
 

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -5,13 +5,13 @@ import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Store;
 import com.dylibso.chicory.wabt.Wat2Wasm;
 import com.dylibso.chicory.wasm.MalformedException;
-import com.dylibso.chicory.wasm.Module;
 import com.dylibso.chicory.wasm.Parser;
+import com.dylibso.chicory.wasm.WasmModule;
 import java.io.File;
 
 public class TestModule {
 
-    private Module module;
+    private WasmModule module;
 
     private static final String HACK_MATCH_ALL_MALFORMED_EXCEPTION_TEXT =
             "Matching keywords to get the WebAssembly testsuite to pass: "
@@ -52,11 +52,11 @@ public class TestModule {
         return of(Parser.parse(file));
     }
 
-    public static TestModule of(Module module) {
+    public static TestModule of(WasmModule module) {
         return new TestModule(module);
     }
 
-    public TestModule(Module module) {
+    public TestModule(WasmModule module) {
         this.module = module;
     }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -11,9 +11,9 @@ import static java.util.Objects.requireNonNullElseGet;
 
 import com.dylibso.chicory.wasm.ChicoryException;
 import com.dylibso.chicory.wasm.InvalidException;
-import com.dylibso.chicory.wasm.Module;
 import com.dylibso.chicory.wasm.UninstantiableException;
 import com.dylibso.chicory.wasm.UnlinkableException;
+import com.dylibso.chicory.wasm.WasmModule;
 import com.dylibso.chicory.wasm.types.ActiveDataSegment;
 import com.dylibso.chicory.wasm.types.ActiveElement;
 import com.dylibso.chicory.wasm.types.DataSegment;
@@ -45,7 +45,7 @@ import java.util.function.Function;
 public class Instance {
     public static final String START_FUNCTION_NAME = "_start";
 
-    private final Module module;
+    private final WasmModule module;
     private final Machine machine;
     private final FunctionBody[] functions;
     private final Memory memory;
@@ -61,7 +61,7 @@ public class Instance {
     private final ExecutionListener listener;
 
     Instance(
-            Module module,
+            WasmModule module,
             Global[] globalInitializers,
             Memory memory,
             DataSegment[] dataSegments,
@@ -242,7 +242,7 @@ public class Instance {
         return imports;
     }
 
-    public Module module() {
+    public WasmModule module() {
         return module;
     }
 
@@ -281,12 +281,12 @@ public class Instance {
         }
     }
 
-    public static Builder builder(Module module) {
+    public static Builder builder(WasmModule module) {
         return new Builder(module);
     }
 
     public static final class Builder {
-        private final Module module;
+        private final WasmModule module;
 
         private boolean initialize = true;
         private boolean start = true;
@@ -294,7 +294,7 @@ public class Instance {
         private ImportValues importValues;
         private Function<Instance, Machine> machineFactory;
 
-        private Builder(Module module) {
+        private Builder(WasmModule module) {
             this.module = Objects.requireNonNull(module);
         }
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
@@ -1,6 +1,6 @@
 package com.dylibso.chicory.runtime;
 
-import com.dylibso.chicory.wasm.Module;
+import com.dylibso.chicory.wasm.WasmModule;
 import com.dylibso.chicory.wasm.types.Export;
 import com.dylibso.chicory.wasm.types.ExportSection;
 import com.dylibso.chicory.wasm.types.FunctionType;
@@ -128,7 +128,7 @@ public class Store {
     /**
      * A shorthand for instantiating a module and registering it in the store.
      */
-    public Instance instantiate(String name, Module m) {
+    public Instance instantiate(String name, WasmModule m) {
         ImportValues importValues = this.toImportValues();
         Instance instance = Instance.builder(m).withImportValues(importValues).build();
         register(name, instance);

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/StoreTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/StoreTest.java
@@ -4,15 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.dylibso.chicory.wasm.Module;
 import com.dylibso.chicory.wasm.Parser;
+import com.dylibso.chicory.wasm.WasmModule;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class StoreTest {
 
-    private static Module loadModule(String fileName) {
-        return Parser.parse(ModuleTest.class.getResourceAsStream("/" + fileName));
+    private static WasmModule loadModule(String fileName) {
+        return Parser.parse(WasmModuleTest.class.getResourceAsStream("/" + fileName));
     }
 
     @Test

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/WasmModuleTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/WasmModuleTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.dylibso.chicory.wasm.Module;
 import com.dylibso.chicory.wasm.Parser;
 import com.dylibso.chicory.wasm.UninstantiableException;
+import com.dylibso.chicory.wasm.WasmModule;
 import com.dylibso.chicory.wasm.types.MemoryLimits;
 import com.dylibso.chicory.wasm.types.ValueType;
 import java.util.List;
@@ -16,10 +16,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
-public class ModuleTest {
+public class WasmModuleTest {
 
-    private static Module loadModule(String fileName) {
-        return Parser.parse(ModuleTest.class.getResourceAsStream("/" + fileName));
+    private static WasmModule loadModule(String fileName) {
+        return Parser.parse(WasmModuleTest.class.getResourceAsStream("/" + fileName));
     }
 
     @Test

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wast2Json.java
@@ -9,8 +9,8 @@ import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasi.WasiOptions;
 import com.dylibso.chicory.wasi.WasiPreview1;
-import com.dylibso.chicory.wasm.Module;
 import com.dylibso.chicory.wasm.Parser;
+import com.dylibso.chicory.wasm.WasmModule;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import java.io.ByteArrayOutputStream;
@@ -32,7 +32,7 @@ public final class Wast2Json {
                     return false;
                 }
             };
-    private static final Module MODULE =
+    private static final WasmModule MODULE =
             Parser.parse(Wast2Json.class.getResourceAsStream("/wast2json"));
 
     private final File input;

--- a/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
+++ b/wabt/src/main/java/com/dylibso/chicory/wabt/Wat2Wasm.java
@@ -8,8 +8,8 @@ import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasi.WasiOptions;
 import com.dylibso.chicory.wasi.WasiPreview1;
-import com.dylibso.chicory.wasm.Module;
 import com.dylibso.chicory.wasm.Parser;
+import com.dylibso.chicory.wasm.WasmModule;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import java.io.ByteArrayInputStream;
@@ -27,7 +27,7 @@ import java.util.List;
 
 public final class Wat2Wasm {
     private static final Logger logger = new SystemLogger();
-    private static final Module MODULE =
+    private static final WasmModule MODULE =
             Parser.parse(Wat2Wasm.class.getResourceAsStream("/wat2wasm"));
 
     private Wat2Wasm() {}

--- a/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
+++ b/wasi/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
@@ -12,8 +12,8 @@ import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.runtime.Store;
-import com.dylibso.chicory.wasm.Module;
 import com.dylibso.chicory.wasm.Parser;
+import com.dylibso.chicory.wasm.WasmModule;
 import com.dylibso.chicory.wasm.types.MemoryLimits;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 public class WasiPreview1Test {
     private final Logger logger = new SystemLogger();
 
-    private static Module loadModule(String fileName) {
+    private static WasmModule loadModule(String fileName) {
         return Parser.parse(WasiPreview1Test.class.getResourceAsStream("/" + fileName));
     }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -106,7 +106,7 @@ public final class Parser {
         }
     }
 
-    private static void onSection(Module.Builder module, Section s) {
+    private static void onSection(WasmModule.Builder module, Section s) {
         switch (s.sectionId()) {
             case SectionId.CUSTOM:
                 var customSection = (CustomSection) s;
@@ -154,19 +154,19 @@ public final class Parser {
         }
     }
 
-    public static Module parse(InputStream input) {
+    public static WasmModule parse(InputStream input) {
         return new Parser().parse(() -> input);
     }
 
-    public static Module parse(byte[] buffer) {
+    public static WasmModule parse(byte[] buffer) {
         return new Parser().parse(() -> new ByteArrayInputStream(buffer));
     }
 
-    public static Module parse(File file) {
+    public static WasmModule parse(File file) {
         return parse(file.toPath());
     }
 
-    public static Module parse(Path path) {
+    public static WasmModule parse(Path path) {
         return new Parser()
                 .parse(
                         () -> {
@@ -179,8 +179,8 @@ public final class Parser {
                         });
     }
 
-    public Module parse(Supplier<InputStream> inputStreamSupplier) {
-        Module.Builder moduleBuilder = Module.builder();
+    public WasmModule parse(Supplier<InputStream> inputStreamSupplier) {
+        WasmModule.Builder moduleBuilder = WasmModule.builder();
         try (InputStream is = inputStreamSupplier.get()) {
             parse(is, (s) -> onSection(moduleBuilder, s));
         } catch (IOException e) {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Validator.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Validator.java
@@ -78,14 +78,14 @@ final class Validator {
 
     private final List<InvalidException> errors = new ArrayList<>();
 
-    private final Module module;
+    private final WasmModule module;
     private final List<Global> globalImports;
     private final List<Integer> functionImports;
     private final List<ValueType> tableImports;
     private final int memoryImports;
     private final Set<Integer> declaredFunctions;
 
-    Validator(Module module) {
+    Validator(WasmModule module) {
         this.module = requireNonNull(module);
 
         this.globalImports =

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/WasmModule.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/WasmModule.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public final class Module {
+public final class WasmModule {
     private final Map<String, CustomSection> customSections;
 
     private final TypeSection typeSection;
@@ -39,7 +39,7 @@ public final class Module {
     private final Optional<DataCountSection> dataCountSection;
     private final List<Integer> ignoredSections;
 
-    private Module(
+    private WasmModule(
             TypeSection typeSection,
             ImportSection importSection,
             FunctionSection functionSection,
@@ -234,9 +234,9 @@ public final class Module {
             return this;
         }
 
-        public Module build() {
+        public WasmModule build() {
             var module =
-                    new Module(
+                    new WasmModule(
                             typeSection,
                             importSection,
                             functionSection,


### PR DESCRIPTION
As agreed, to avoid `java.lang.Module` to clash.