### PR TITLE
Only implement AOT Machine call for exported functions

### DIFF
--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyBrTable.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyBrTable.approved.txt
@@ -115,7 +115,7 @@ final class com/dylibso/chicory/$gen/CompiledMachine$MachineCall {
     ALOAD 1
     ALOAD 3
     ILOAD 2
-    TABLESWITCH
+    LOOKUPSWITCH
       0: L0
       default: L1
    L0

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyBranching.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyBranching.approved.txt
@@ -117,7 +117,7 @@ final class com/dylibso/chicory/$gen/CompiledMachine$MachineCall {
     ALOAD 1
     ALOAD 3
     ILOAD 2
-    TABLESWITCH
+    LOOKUPSWITCH
       0: L0
       default: L1
    L0

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyFloat.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyFloat.approved.txt
@@ -91,7 +91,7 @@ final class com/dylibso/chicory/$gen/CompiledMachine$MachineCall {
     ALOAD 1
     ALOAD 3
     ILOAD 2
-    TABLESWITCH
+    LOOKUPSWITCH
       0: L0
       default: L1
    L0

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyHelloWasi.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyHelloWasi.approved.txt
@@ -205,21 +205,13 @@ final class com/dylibso/chicory/$gen/CompiledMachine$MachineCall {
     ALOAD 1
     ALOAD 3
     ILOAD 2
-    TABLESWITCH
-      0: L0
-      1: L1
-      default: L2
-   L1
+    LOOKUPSWITCH
+      1: L0
+      default: L1
+   L0
     INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$MachineCall.call_1 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
     ARETURN
-   L0
-    POP
-    POP
-    ILOAD 2
-    ALOAD 3
-    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.callHostFunction (Lcom/dylibso/chicory/runtime/Instance;I[J)[J
-    ARETURN
-   L2
+   L1
     ILOAD 2
     INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.throwUnknownFunction (I)Ljava/lang/RuntimeException;
     ATHROW

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32.approved.txt
@@ -115,7 +115,7 @@ final class com/dylibso/chicory/$gen/CompiledMachine$MachineCall {
     ALOAD 1
     ALOAD 3
     ILOAD 2
-    TABLESWITCH
+    LOOKUPSWITCH
       0: L0
       default: L1
    L0

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
@@ -592,7 +592,7 @@ final class FOO$MachineCall {
     ALOAD 1
     ALOAD 3
     ILOAD 2
-    TABLESWITCH
+    LOOKUPSWITCH
       0: L0
       default: L1
    L0

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyIterFact.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyIterFact.approved.txt
@@ -119,7 +119,7 @@ final class com/dylibso/chicory/$gen/CompiledMachine$MachineCall {
     ALOAD 1
     ALOAD 3
     ILOAD 2
-    TABLESWITCH
+    LOOKUPSWITCH
       0: L0
       default: L1
    L0

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyKitchenSink.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyKitchenSink.approved.txt
@@ -120,7 +120,7 @@ final class com/dylibso/chicory/$gen/CompiledMachine$MachineCall {
     ALOAD 1
     ALOAD 3
     ILOAD 2
-    TABLESWITCH
+    LOOKUPSWITCH
       0: L0
       default: L1
    L0

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyMemory.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyMemory.approved.txt
@@ -169,7 +169,7 @@ final class com/dylibso/chicory/$gen/CompiledMachine$MachineCall {
     ALOAD 1
     ALOAD 3
     ILOAD 2
-    TABLESWITCH
+    LOOKUPSWITCH
       0: L0
       1: L1
       default: L2

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyStart.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyStart.approved.txt
@@ -152,21 +152,13 @@ final class com/dylibso/chicory/$gen/CompiledMachine$MachineCall {
     ALOAD 1
     ALOAD 3
     ILOAD 2
-    TABLESWITCH
-      0: L0
-      1: L1
-      default: L2
-   L1
+    LOOKUPSWITCH
+      1: L0
+      default: L1
+   L0
     INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$MachineCall.call_1 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
     ARETURN
-   L0
-    POP
-    POP
-    ILOAD 2
-    ALOAD 3
-    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.callHostFunction (Lcom/dylibso/chicory/runtime/Instance;I[J)[J
-    ARETURN
-   L2
+   L1
     ILOAD 2
     INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.throwUnknownFunction (I)Ljava/lang/RuntimeException;
     ATHROW

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyTrap.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyTrap.approved.txt
@@ -112,40 +112,16 @@ final class com/dylibso/chicory/$gen/CompiledMachine$MachineCall {
     ALOAD 1
     ALOAD 3
     ILOAD 2
-    TABLESWITCH
-      0: L0
-      1: L1
-      2: L2
-      default: L3
+    LOOKUPSWITCH
+      2: L0
+      default: L1
    L0
-    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$MachineCall.call_0 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
-    ARETURN
-   L1
-    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$MachineCall.call_1 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
-    ARETURN
-   L2
     INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$MachineCall.call_2 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
     ARETURN
-   L3
+   L1
     ILOAD 2
     INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.throwUnknownFunction (I)Ljava/lang/RuntimeException;
     ATHROW
-
-  public static call_0(Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
-    ALOAD 1
-    ALOAD 0
-    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine.func_0 (Lcom/dylibso/chicory/runtime/Memory;Lcom/dylibso/chicory/runtime/Instance;)V
-    ICONST_0
-    NEWARRAY T_LONG
-    ARETURN
-
-  public static call_1(Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
-    ALOAD 1
-    ALOAD 0
-    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine.func_1 (Lcom/dylibso/chicory/runtime/Memory;Lcom/dylibso/chicory/runtime/Instance;)V
-    ICONST_0
-    NEWARRAY T_LONG
-    ARETURN
 
   public static call_2(Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
     ALOAD 1


### PR DESCRIPTION
The generated switch statement is too large for modules with thousands of functions. For example, Python has almost 10k functions, but we only need the few that are exported.