### PR TITLE
Add an instance factory to let customize the instantiation on Store

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
@@ -6,6 +6,7 @@ import com.dylibso.chicory.wasm.types.ExportSection;
 import com.dylibso.chicory.wasm.types.FunctionType;
 import java.util.LinkedHashMap;
 import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * The runtime storage for all function, global, memory, table instances.
@@ -129,8 +130,16 @@ public class Store {
      * A shorthand for instantiating a module and registering it in the store.
      */
     public Instance instantiate(String name, WasmModule m) {
+        return this.instantiate(
+                name, imports -> Instance.builder(m).withImportValues(imports).build());
+    }
+
+    /**
+     * A shorthand for instantiating a module and registering it in the store.
+     */
+    public Instance instantiate(String name, Function<ImportValues, Instance> instanceBuilder) {
         ImportValues importValues = this.toImportValues();
-        Instance instance = Instance.builder(m).withImportValues(importValues).build();
+        Instance instance = instanceBuilder.apply(importValues);
         register(name, instance);
         return instance;
     }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Store.java
@@ -137,9 +137,9 @@ public class Store {
     /**
      * A shorthand for instantiating a module and registering it in the store.
      */
-    public Instance instantiate(String name, Function<ImportValues, Instance> instanceBuilder) {
+    public Instance instantiate(String name, Function<ImportValues, Instance> instanceFactory) {
         ImportValues importValues = this.toImportValues();
-        Instance instance = instanceBuilder.apply(importValues);
+        Instance instance = instanceFactory.apply(importValues);
         register(name, instance);
         return instance;
     }

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/StoreTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/StoreTest.java
@@ -130,4 +130,28 @@ public class StoreTest {
             assertTrue(store.functions.containsKey(new Store.QualifiedName(name, "get-4")));
         }
     }
+
+    @Test
+    public void moduleInstantiationShouldBeConfigurable() {
+        var store = new Store();
+
+        String name1 = "exports-module-1";
+        store.instantiate(
+                name1,
+                imports ->
+                        Instance.builder(loadModule("compiled/exports.wat.wasm"))
+                                .withImportValues(imports)
+                                .withStart(false)
+                                .build());
+
+        String name2 = "exports-module-2";
+        store.instantiate(
+                name2,
+                imports ->
+                        Instance.builder(loadModule("compiled/exports.wat.wasm"))
+                                .withImportValues(imports)
+                                .build());
+
+        assertEquals(2, store.memories.size());
+    }
 }


### PR DESCRIPTION
The current convenience helper method `instantiate` in `Store` doesn't leave room for customizations done with the `Instance.Builder`, such as `withStart` or `withMachineFactory`.

In this PR we add a more generic helper that let the user configure the `Instance` and we base the current helper on it.