### PR TITLE
Allow overriding memory limits when constructing instance

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -6,6 +6,7 @@ import static com.dylibso.chicory.wasm.types.ExternalType.FUNCTION;
 import static com.dylibso.chicory.wasm.types.ExternalType.GLOBAL;
 import static com.dylibso.chicory.wasm.types.ExternalType.MEMORY;
 import static com.dylibso.chicory.wasm.types.ExternalType.TABLE;
+import static java.util.Objects.requireNonNullElse;
 import static java.util.Objects.requireNonNullElseGet;
 
 import com.dylibso.chicory.wasm.ChicoryException;
@@ -313,6 +314,7 @@ public class Instance {
 
         private boolean initialize = true;
         private boolean start = true;
+        private MemoryLimits memoryLimits;
         private ExecutionListener listener;
         private ImportValues importValues;
         private Function<Instance, Machine> machineFactory;
@@ -328,6 +330,11 @@ public class Instance {
 
         public Builder withStart(boolean s) {
             this.start = s;
+            return this;
+        }
+
+        public Builder withMemoryLimits(MemoryLimits limits) {
+            this.memoryLimits = limits;
             return this;
         }
 
@@ -648,7 +655,8 @@ public class Instance {
             if (module.memorySection().isPresent()) {
                 var memories = module.memorySection().get();
                 if (memories.memoryCount() > 0) {
-                    memory = new Memory(memories.getMemory(0).limits());
+                    var defaultLimits = memories.getMemory(0).limits();
+                    memory = new Memory(requireNonNullElse(memoryLimits, defaultLimits));
                 }
             } else {
                 if (mappedHostImports != null && mappedHostImports.memoryCount() > 0) {

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/WasmModuleTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/WasmModuleTest.java
@@ -189,6 +189,15 @@ public class WasmModuleTest {
     }
 
     @Test
+    public void shouldSupportMemoryLimitsOverride() {
+        var instance =
+                Instance.builder(loadModule("compiled/count_vowels.rs.wasm"))
+                        .withMemoryLimits(new MemoryLimits(17, 17))
+                        .build();
+        assertThrows(TrapException.class, () -> instance.export("alloc").apply(Memory.PAGE_SIZE));
+    }
+
+    @Test
     public void shouldRunBasicCProgram() {
         // check with: wasmtime basic.c.wasm --invoke run
         var instance = Instance.builder(loadModule("compiled/basic.c.wasm")).build();

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/MemoryLimits.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/MemoryLimits.java
@@ -4,13 +4,10 @@ import com.dylibso.chicory.wasm.InvalidException;
 
 /**
  * Limits for memory sizes, in pages.
- * Memory limits also define whether the corresponding memory is <em>shared</em>.
  * <p>
  * See <a href="https://webassembly.github.io/spec/core/syntax/types.html#syntax-limits">Limits</a>
  * and <a href="https://webassembly.github.io/spec/core/syntax/modules.html#syntax-mem">Memories</a>
  * for reference.
- * See also <a href="https://github.com/WebAssembly/threads/blob/main/proposals/threads/Overview.md#spec-changes">Overview</a>
- * for the history of shared memory.
  */
 public final class MemoryLimits {
 
@@ -32,29 +29,13 @@ public final class MemoryLimits {
     private final int maximum;
 
     /**
-     * Whether the memory limits apply to a shared memory segment.
-     */
-    private final boolean shared;
-
-    /**
      * Construct a new instance.
-     * The maximum size will be {@link #MAX_PAGES} and {@code shared} will be {@code false}.
+     * The maximum size will be {@link #MAX_PAGES}.
      *
-     * @param initial the initial size
+     * @param initial the initial size, in pages
      */
     public MemoryLimits(int initial) {
-        this(initial, MAX_PAGES, false);
-    }
-
-    /**
-     * Construct a new instance.
-     * {@code shared} will be {@code false}.
-     *
-     * @param initial the initial size
-     * @param maximum the maximum size, in pages
-     */
-    public MemoryLimits(int initial, int maximum) {
-        this(initial, maximum, false);
+        this(initial, MAX_PAGES);
     }
 
     /**
@@ -62,9 +43,8 @@ public final class MemoryLimits {
      *
      * @param initial the initial size, in pages
      * @param maximum the maximum size, in pages
-     * @param shared {@code true} if the limits apply to a shared memory segment, or {@code false} otherwise
      */
-    public MemoryLimits(int initial, int maximum, boolean shared) {
+    public MemoryLimits(int initial, int maximum) {
         if (initial > MAX_PAGES || maximum > MAX_PAGES || initial < 0 || maximum < 0) {
             throw new InvalidException("memory size must be at most 65536 pages (4GiB)");
         }
@@ -74,7 +54,6 @@ public final class MemoryLimits {
 
         this.initial = initial;
         this.maximum = maximum;
-        this.shared = shared;
     }
 
     /**
@@ -96,13 +75,6 @@ public final class MemoryLimits {
      */
     public int maximumPages() {
         return maximum;
-    }
-
-    /**
-     * @return {@code true} if the limits apply to a shared memory segment, or {@code false} otherwise
-     */
-    public boolean shared() {
-        return shared;
     }
 
     @Override
@@ -133,9 +105,6 @@ public final class MemoryLimits {
             b.append(maximum);
         }
         b.append(']');
-        if (shared) {
-            b.append(":shared");
-        }
         return b;
     }
 }


### PR DESCRIPTION
This removes the unused `shared` flag from `MemoryLimits` as that is part of the threads proposal which is not yet standardized. That flag is for validating memory imports, so it's not clear if `MemoryLimits` is the correct place for it. We can revisit that if we implement threads.

Fixes #606