### PR TITLE
Add `hashCode` and `equals` implementations to the data classes in the `wasm` module

### DIFF
--- a/wasm/src/main/java/com/dylibso/chicory/wasm/WasmModule.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/WasmModule.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 public final class WasmModule {
@@ -263,5 +264,47 @@ public final class WasmModule {
 
             return module;
         }
+    }
+
+    // Comparison uses everything but the custom section
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof WasmModule)) {
+            return false;
+        }
+        WasmModule that = (WasmModule) o;
+        return Objects.equals(typeSection, that.typeSection)
+                && Objects.equals(importSection, that.importSection)
+                && Objects.equals(functionSection, that.functionSection)
+                && Objects.equals(tableSection, that.tableSection)
+                && Objects.equals(memorySection, that.memorySection)
+                && Objects.equals(globalSection, that.globalSection)
+                && Objects.equals(exportSection, that.exportSection)
+                && Objects.equals(startSection, that.startSection)
+                && Objects.equals(elementSection, that.elementSection)
+                && Objects.equals(codeSection, that.codeSection)
+                && Objects.equals(dataSection, that.dataSection)
+                && Objects.equals(dataCountSection, that.dataCountSection)
+                && Objects.equals(ignoredSections, that.ignoredSections);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                typeSection,
+                importSection,
+                functionSection,
+                tableSection,
+                memorySection,
+                globalSection,
+                exportSection,
+                startSection,
+                elementSection,
+                codeSection,
+                dataSection,
+                dataCountSection);
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ActiveDataSegment.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ActiveDataSegment.java
@@ -1,6 +1,7 @@
 package com.dylibso.chicory.wasm.types;
 
 import java.util.List;
+import java.util.Objects;
 
 public final class ActiveDataSegment extends DataSegment {
     private final long idx;
@@ -18,5 +19,25 @@ public final class ActiveDataSegment extends DataSegment {
 
     public List<Instruction> offsetInstructions() {
         return offsetInstructions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof ActiveDataSegment)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        ActiveDataSegment that = (ActiveDataSegment) o;
+        return idx == that.idx && Objects.equals(offsetInstructions, that.offsetInstructions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), idx, offsetInstructions);
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/AnnotatedInstruction.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/AnnotatedInstruction.java
@@ -2,6 +2,7 @@ package com.dylibso.chicory.wasm.types;
 
 import com.dylibso.chicory.wasm.InvalidException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /*
@@ -182,5 +183,26 @@ public final class AnnotatedInstruction extends Instruction {
                     labelTable.orElse(List.of()),
                     scope.orElse(null));
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof AnnotatedInstruction)) {
+            return false;
+        }
+        AnnotatedInstruction that = (AnnotatedInstruction) o;
+        return depth == that.depth
+                && labelTrue == that.labelTrue
+                && labelFalse == that.labelFalse
+                && Objects.equals(labelTable, that.labelTable)
+                && Objects.equals(scope, that.scope);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(depth, labelTrue, labelFalse, labelTable, scope);
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeSection.java
@@ -61,4 +61,22 @@ public final class CodeSection extends Section {
             return new CodeSection(functionBodies, requiresDataCount);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof CodeSection)) {
+            return false;
+        }
+        CodeSection that = (CodeSection) o;
+        return requiresDataCount == that.requiresDataCount
+                && Objects.equals(functionBodies, that.functionBodies);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(functionBodies, requiresDataCount);
+    }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataCountSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataCountSection.java
@@ -28,4 +28,21 @@ public final class DataCountSection extends Section {
             return new DataCountSection(dataCount);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof DataCountSection)) {
+            return false;
+        }
+        DataCountSection that = (DataCountSection) o;
+        return dataCount == that.dataCount;
+    }
+
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(dataCount);
+    }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSection.java
@@ -49,4 +49,21 @@ public final class DataSection extends Section {
             return new DataSection(dataSegments);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof DataSection)) {
+            return false;
+        }
+        DataSection that = (DataSection) o;
+        return Objects.equals(dataSegments, that.dataSegments);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(dataSegments);
+    }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSegment.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSegment.java
@@ -1,5 +1,8 @@
 package com.dylibso.chicory.wasm.types;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 public abstract class DataSegment {
     private final byte[] data;
 
@@ -9,5 +12,22 @@ public abstract class DataSegment {
 
     public byte[] data() {
         return data.clone();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof DataSegment)) {
+            return false;
+        }
+        DataSegment that = (DataSegment) o;
+        return Objects.deepEquals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(data);
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Element.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Element.java
@@ -3,6 +3,7 @@ package com.dylibso.chicory.wasm.types;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An element, used to initialize table ranges.
@@ -43,5 +44,22 @@ public abstract class Element {
      */
     public int elementCount() {
         return initializers().size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof Element)) {
+            return false;
+        }
+        Element element = (Element) o;
+        return type == element.type && Objects.equals(initializers, element.initializers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, initializers);
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElementSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElementSection.java
@@ -52,4 +52,21 @@ public final class ElementSection extends Section {
             return new ElementSection(elements);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof ElementSection)) {
+            return false;
+        }
+        ElementSection that = (ElementSection) o;
+        return Objects.equals(elements, that.elements);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(elements);
+    }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ExportSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ExportSection.java
@@ -45,4 +45,21 @@ public final class ExportSection extends Section {
             return new ExportSection(exports);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof ExportSection)) {
+            return false;
+        }
+        ExportSection that = (ExportSection) o;
+        return Objects.equals(exports, that.exports);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(exports);
+    }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionBody.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionBody.java
@@ -1,6 +1,7 @@
 package com.dylibso.chicory.wasm.types;
 
 import java.util.List;
+import java.util.Objects;
 
 public final class FunctionBody {
     private final List<ValueType> locals;
@@ -17,5 +18,23 @@ public final class FunctionBody {
 
     public List<AnnotatedInstruction> instructions() {
         return instructions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof FunctionBody)) {
+            return false;
+        }
+        FunctionBody that = (FunctionBody) o;
+        return Objects.equals(locals, that.locals)
+                && Objects.equals(instructions, that.instructions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(locals, instructions);
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionSection.java
@@ -2,6 +2,7 @@ package com.dylibso.chicory.wasm.types;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public final class FunctionSection extends Section {
     private final List<Integer> typeIndices;
@@ -46,5 +47,22 @@ public final class FunctionSection extends Section {
         public FunctionSection build() {
             return new FunctionSection(typeIndices);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof FunctionSection)) {
+            return false;
+        }
+        FunctionSection that = (FunctionSection) o;
+        return Objects.equals(typeIndices, that.typeIndices);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(typeIndices);
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Global.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Global.java
@@ -1,6 +1,7 @@
 package com.dylibso.chicory.wasm.types;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The definition of a global variable in the model of a module.
@@ -26,5 +27,24 @@ public final class Global {
 
     public List<Instruction> initInstructions() {
         return init;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof Global)) {
+            return false;
+        }
+        Global global = (Global) o;
+        return valueType == global.valueType
+                && mutabilityType == global.mutabilityType
+                && Objects.equals(init, global.init);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(valueType, mutabilityType, init);
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalSection.java
@@ -49,4 +49,21 @@ public final class GlobalSection extends Section {
             return new GlobalSection(globals);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof GlobalSection)) {
+            return false;
+        }
+        GlobalSection that = (GlobalSection) o;
+        return Objects.equals(globals, that.globals);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(globals);
+    }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ImportSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ImportSection.java
@@ -54,4 +54,21 @@ public final class ImportSection extends Section {
             return new ImportSection(imports);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof ImportSection)) {
+            return false;
+        }
+        ImportSection that = (ImportSection) o;
+        return Objects.equals(imports, that.imports);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(imports);
+    }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Instruction.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Instruction.java
@@ -1,6 +1,7 @@
 package com.dylibso.chicory.wasm.types;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public class Instruction {
     public static final long[] EMPTY_OPERANDS = new long[0];
@@ -42,5 +43,24 @@ public class Instruction {
             return result + opcode + " " + Arrays.toString(operands);
         }
         return result + opcode.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof Instruction)) {
+            return false;
+        }
+        Instruction that = (Instruction) o;
+        return address == that.address
+                && opcode == that.opcode
+                && Objects.deepEquals(operands, that.operands);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address, opcode, Arrays.hashCode(operands));
     }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Memory.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Memory.java
@@ -26,4 +26,21 @@ public final class Memory {
     public MemoryLimits limits() {
         return limits;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof Memory)) {
+            return false;
+        }
+        Memory memory = (Memory) o;
+        return Objects.equals(limits, memory.limits);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(limits);
+    }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/MemorySection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/MemorySection.java
@@ -45,4 +45,21 @@ public final class MemorySection extends Section {
             return new MemorySection(memories);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof MemorySection)) {
+            return false;
+        }
+        MemorySection that = (MemorySection) o;
+        return Objects.equals(memories, that.memories);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(memories);
+    }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/StartSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/StartSection.java
@@ -30,4 +30,21 @@ public final class StartSection extends Section {
             return new StartSection(startIndex);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof StartSection)) {
+            return false;
+        }
+        StartSection that = (StartSection) o;
+        return startIndex == that.startIndex;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(startIndex);
+    }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Table.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Table.java
@@ -21,4 +21,21 @@ public class Table {
     public TableLimits limits() {
         return limits;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof Table)) {
+            return false;
+        }
+        Table table = (Table) o;
+        return elementType == table.elementType && Objects.equals(limits, table.limits);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(elementType, limits);
+    }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableSection.java
@@ -45,4 +45,21 @@ public final class TableSection extends Section {
             return new TableSection(tables);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof TableSection)) {
+            return false;
+        }
+        TableSection that = (TableSection) o;
+        return Objects.equals(tables, that.tables);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(tables);
+    }
 }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TypeSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TypeSection.java
@@ -49,4 +49,21 @@ public final class TypeSection extends Section {
             return new TypeSection(types);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof TypeSection)) {
+            return false;
+        }
+        TypeSection that = (TypeSection) o;
+        return Objects.equals(types, that.types);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(types);
+    }
 }

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/WasmModuleTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/WasmModuleTest.java
@@ -1,0 +1,33 @@
+package com.dylibso.chicory.wasm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class WasmModuleTest {
+
+    @Test
+    public void shouldHaveTheSameHashCode() {
+        var mod1 =
+                Parser.parse(
+                        WasmModuleTest.class.getResourceAsStream("/compiled/count_vowels.rs.wasm"));
+        var mod2 =
+                Parser.parse(
+                        WasmModuleTest.class.getResourceAsStream("/compiled/count_vowels.rs.wasm"));
+
+        assertEquals(mod1.hashCode(), mod2.hashCode());
+    }
+
+    @Test
+    public void shouldBeEquals() {
+        var mod1 =
+                Parser.parse(
+                        WasmModuleTest.class.getResourceAsStream("/compiled/count_vowels.rs.wasm"));
+        var mod2 =
+                Parser.parse(
+                        WasmModuleTest.class.getResourceAsStream("/compiled/count_vowels.rs.wasm"));
+
+        assertTrue(mod1.equals(mod2));
+    }
+}


### PR DESCRIPTION
This allow the data class `WasmModule` to be safely stored in `HashMaps` and similar data structures.