### PR TITLE
Remove public constructors for WasiPreview1

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -16,10 +16,6 @@
   <dependencies>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>
-      <artifactId>log</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.dylibso.chicory</groupId>
       <artifactId>runtime</artifactId>
     </dependency>
     <dependency>

--- a/cli/src/main/java/com/dylibso/chicory/experimental/cli/Cli.java
+++ b/cli/src/main/java/com/dylibso/chicory/experimental/cli/Cli.java
@@ -1,6 +1,5 @@
 package com.dylibso.chicory.experimental.cli;
 
-import com.dylibso.chicory.log.SystemLogger;
 import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasi.WasiOptions;
@@ -55,17 +54,17 @@ public class Cli implements Runnable {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        var logger = new SystemLogger();
         var module = Parser.parse(file);
         var imports =
                 wasi
                         ? ImportValues.builder()
                                 .addFunction(
-                                        new WasiPreview1(
-                                                        logger,
+                                        WasiPreview1.builder()
+                                                .withOptions(
                                                         WasiOptions.builder()
                                                                 .inheritSystem()
                                                                 .build())
+                                                .build()
                                                 .toHostFunctions())
                                 .build()
                         : ImportValues.empty();

--- a/docs/docs/usage/wasi.md
+++ b/docs/docs/usage/wasi.md
@@ -73,7 +73,7 @@ var logger = new SystemLogger();
 // let's just use the default options for now
 var options = WasiOptions.builder().build();
 // create our instance of wasip1
-var wasi = new WasiPreview1(logger, WasiOptions.builder().build());
+var wasi = WasiPreview1.builder().withOptions(WasiOptions.builder().build()).build();
 // create the module and connect the host functions
 var store = new Store().addFunction(wasi.toHostFunctions());
 // instantiate and execute the main entry point
@@ -111,7 +111,7 @@ var fakeStderr = new ByteArrayOutputStream();
 // now pass those to our wasi options builder
 var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).withStderr(fakeStderr).withStdin(fakeStdin).build();
 
-var wasi = new WasiPreview1(logger, wasiOpts);
+var wasi = WasiPreview1.builder().withOptions(wasiOpts).build();
 
 // greet-wasi is a rust program that greets the string passed in stdin
 var store = new Store().addFunction(wasi.toHostFunctions());

--- a/machine-tests/pom.xml
+++ b/machine-tests/pom.xml
@@ -28,11 +28,6 @@
     </dependency>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>
-      <artifactId>log</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.dylibso.chicory</groupId>
       <artifactId>wasi</artifactId>
       <scope>test</scope>
     </dependency>

--- a/machine-tests/src/test/java/com/dylibso/chicory/testing/MachinesTest.java
+++ b/machine-tests/src/test/java/com/dylibso/chicory/testing/MachinesTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.dylibso.chicory.experimental.aot.AotMachine;
-import com.dylibso.chicory.log.SystemLogger;
 import com.dylibso.chicory.runtime.ImportTable;
 import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
@@ -63,9 +62,8 @@ public final class MachinesTest {
                         .withStderr(stderr)
                         .withStdin(stdin)
                         .build();
-        var logger = new SystemLogger();
 
-        return new WasiPreview1(logger, wasiOpts);
+        return WasiPreview1.builder().withOptions(wasiOpts).build();
     }
 
     private static final String expectedOutput = "Hello world dynamic Javy!\n";

--- a/wasi-tests/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
+++ b/wasi-tests/src/test/java/com/dylibso/chicory/wasi/WasiPreview1Test.java
@@ -41,7 +41,10 @@ public class WasiPreview1Test {
         // check with: wasmtime src/test/resources/compiled/hello-wasi.wat.wasm
         var fakeStdout = new MockPrintStream();
         var wasi =
-                new WasiPreview1(this.logger, WasiOptions.builder().withStdout(fakeStdout).build());
+                WasiPreview1.builder()
+                        .withLogger(this.logger)
+                        .withOptions(WasiOptions.builder().withStdout(fakeStdout).build())
+                        .build();
         var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
         Instance.builder(loadModule("compiled/hello-wasi.wat.wasm"))
                 .withImportValues(imports)
@@ -54,7 +57,11 @@ public class WasiPreview1Test {
         // check with: wasmtime src/test/resources/compiled/hello-wasi.rs.wasm
         var expected = "Hello, World!";
         var stdout = new MockPrintStream();
-        var wasi = new WasiPreview1(this.logger, WasiOptions.builder().withStdout(stdout).build());
+        var wasi =
+                WasiPreview1.builder()
+                        .withLogger(this.logger)
+                        .withOptions(WasiOptions.builder().withStdout(stdout).build())
+                        .build();
         var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
         Instance.builder(loadModule("compiled/hello-wasi.rs.wasm"))
                 .withImportValues(imports)
@@ -68,7 +75,7 @@ public class WasiPreview1Test {
         var fakeStdin = new ByteArrayInputStream("Benjamin".getBytes(UTF_8));
         var fakeStdout = new MockPrintStream();
         var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).withStdin(fakeStdin).build();
-        var wasi = new WasiPreview1(this.logger, wasiOpts);
+        var wasi = WasiPreview1.builder().withLogger(this.logger).withOptions(wasiOpts).build();
         var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
         Instance.builder(loadModule("compiled/greet-wasi.rs.wasm"))
                 .withImportValues(imports)
@@ -83,7 +90,7 @@ public class WasiPreview1Test {
         var fakeStdin = new ByteArrayInputStream("{ \"n\": 2, \"bar\": \"baz\" }".getBytes(UTF_8));
         var fakeStdout = new MockPrintStream();
         var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).withStdin(fakeStdin).build();
-        var wasi = new WasiPreview1(this.logger, wasiOpts);
+        var wasi = WasiPreview1.builder().withLogger(this.logger).withOptions(wasiOpts).build();
         var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
         Instance.builder(loadModule("compiled/javy-demo.js.javy.wasm"))
                 .withImportValues(imports)
@@ -104,9 +111,8 @@ public class WasiPreview1Test {
                         .withStderr(stderr)
                         .withStdin(stdin)
                         .build();
-        var logger = new SystemLogger();
 
-        var wasi = new WasiPreview1(logger, wasiOpts);
+        var wasi = WasiPreview1.builder().withOptions(wasiOpts).build();
         var quickjs =
                 Instance.builder(loadModule("compiled/quickjs-provider.javy-dynamic.wasm"))
                         .withImportValues(
@@ -149,9 +155,8 @@ public class WasiPreview1Test {
                         .withStderr(stderr)
                         .withStdin(stdin)
                         .build();
-        var logger = new SystemLogger();
 
-        var wasi = new WasiPreview1(logger, wasiOpts);
+        var wasi = WasiPreview1.builder().withOptions(wasiOpts).build();
         var quickjs =
                 Instance.builder(loadModule("compiled/quickjs-provider.javy-dynamic.wasm"))
                         .withImportValues(
@@ -172,7 +177,7 @@ public class WasiPreview1Test {
     @Test
     public void shouldRunTinyGoModule() {
         var wasiOpts = WasiOptions.builder().build();
-        var wasi = new WasiPreview1(this.logger, wasiOpts);
+        var wasi = WasiPreview1.builder().withLogger(this.logger).withOptions(wasiOpts).build();
         var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
         var module = loadModule("compiled/sum.go.tiny.wasm");
         var instance = Instance.builder(module).withImportValues(imports).build();
@@ -186,7 +191,7 @@ public class WasiPreview1Test {
     public void shouldRunWasiGoModule() {
         var fakeStdout = new MockPrintStream();
         var wasiOpts = WasiOptions.builder().withStdout(fakeStdout).build();
-        var wasi = new WasiPreview1(this.logger, wasiOpts);
+        var wasi = WasiPreview1.builder().withLogger(this.logger).withOptions(wasiOpts).build();
         var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
         var module = loadModule("compiled/main.go.wasm");
         var exit =
@@ -208,7 +213,7 @@ public class WasiPreview1Test {
                         // https://jflower.co.uk/running-net-8-on-cloudflare-workers/
                         .withArguments(List.of(""))
                         .build();
-        var wasi = new WasiPreview1(this.logger, wasiOpts);
+        var wasi = WasiPreview1.builder().withLogger(this.logger).withOptions(wasiOpts).build();
         var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
 
         var module = loadModule("compiled/basic.dotnet.wasm");
@@ -221,8 +226,10 @@ public class WasiPreview1Test {
     public void wasiRandom() {
         var seed = 0x12345678;
         var wasi =
-                new WasiPreview1(
-                        this.logger, WasiOptions.builder().withRandom(new Random(seed)).build());
+                WasiPreview1.builder()
+                        .withLogger(this.logger)
+                        .withOptions(WasiOptions.builder().withRandom(new Random(seed)).build())
+                        .build();
 
         var memory = new Memory(new MemoryLimits(8, 8));
         assertEquals(0, wasi.randomGet(memory, 0, 123_456));

--- a/wasi-tests/src/test/java/com/dylibso/chicory/wasi/WasiTestRunner.java
+++ b/wasi-tests/src/test/java/com/dylibso/chicory/wasi/WasiTestRunner.java
@@ -83,7 +83,8 @@ public final class WasiTestRunner {
     }
 
     private static int execute(File test, WasiOptions wasiOptions) {
-        try (var wasi = new WasiPreview1(LOGGER, wasiOptions)) {
+        try (var wasi =
+                WasiPreview1.builder().withLogger(LOGGER).withOptions(wasiOptions).build()) {
             Instance.builder(Parser.parse(test))
                     .withImportValues(
                             ImportValues.builder().addFunction(wasi.toHostFunctions()).build())

--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
@@ -70,14 +70,10 @@ public final class WasiPreview1 implements Closeable {
     private final List<Entry<byte[], byte[]>> environment;
     private final Descriptors descriptors = new Descriptors();
 
-    public WasiPreview1(Logger logger) {
+    private WasiPreview1(Logger logger, WasiOptions opts) {
         // TODO by default everything should by blocked
         // this works now because streams are null.
         // maybe we want a more explicit way of doing this though
-        this(logger, WasiOptions.builder().build());
-    }
-
-    public WasiPreview1(Logger logger, WasiOptions opts) {
         this.logger = requireNonNull(logger);
         this.random = opts.random();
         this.clock = opts.clock();


### PR DESCRIPTION
Remove public constructors from `WasiPreview1` to have a more "future proof" API forcing people to use the builder.

Fix #604 