### PR TITLE
android: lower floor API version to 28

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [33, 35]
+        api-level: [28, 35]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4

--- a/android-tests/device-tests/build.gradle.kts
+++ b/android-tests/device-tests/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     compileSdk = 35
 
     defaultConfig {
-        minSdk = 33
+        minSdk = 28
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMethodInliner.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMethodInliner.java
@@ -4,6 +4,7 @@ import static com.dylibso.chicory.experimental.aot.AotUtil.internalClassName;
 import static org.objectweb.asm.Type.getInternalName;
 
 import com.dylibso.chicory.wasm.ChicoryException;
+import com.dylibso.chicory.wasm.io.InputStreams;
 import java.io.IOException;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -74,7 +75,7 @@ final class AotMethodInliner {
             if (in == null) {
                 throw new IOException("Resource not found: " + name);
             }
-            return in.readAllBytes();
+            return InputStreams.readAllBytes(in);
         } catch (IOException e) {
             throw new ChicoryException("Could not load bytecode for " + clazz, e);
         }

--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMethodInliner.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMethodInliner.java
@@ -4,7 +4,6 @@ import static com.dylibso.chicory.experimental.aot.AotUtil.internalClassName;
 import static org.objectweb.asm.Type.getInternalName;
 
 import com.dylibso.chicory.wasm.ChicoryException;
-import com.dylibso.chicory.wasm.io.InputStreams;
 import java.io.IOException;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -75,7 +74,7 @@ final class AotMethodInliner {
             if (in == null) {
                 throw new IOException("Resource not found: " + name);
             }
-            return InputStreams.readAllBytes(in);
+            return in.readAllBytes();
         } catch (IOException e) {
             throw new ChicoryException("Could not load bytecode for " + clazz, e);
         }

--- a/docs/docs/advanced/memory.md
+++ b/docs/docs/advanced/memory.md
@@ -50,3 +50,9 @@ var instance = Instance.builder(module).withMemoryFactory(limits -> {
 docs.FileOps.writeResult("docs/advanced", "memory.md.result", "empty");
 ```
 -->
+
+Since Chicory 1.1.0, an optimized memory implementation called
+`ByteArrayMemory` is also available. We recommend plugging this 
+implementation on all recent OpenJDK systems for enhanced performance. 
+On different Java runtimes (in particular, on Android VMs) 
+you should stick to `ByteBufferMemory`.

--- a/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
+++ b/runtime-tests/src/test/java/com/dylibso/chicory/testing/TestModule.java
@@ -1,5 +1,6 @@
 package com.dylibso.chicory.testing;
 
+import com.dylibso.chicory.runtime.ByteArrayMemory;
 import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Store;
@@ -70,10 +71,10 @@ public class TestModule {
 
     public Instance instantiate(Store s) {
         ImportValues importValues = s.toImportValues();
-
         return Instance.builder(module)
                 .withImportValues(importValues)
                 .withMachineFactory(InterpreterMachineFactory::create)
+                .withMemoryFactory(ByteArrayMemory::new)
                 .build();
     }
 }

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ByteBufferMemory.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ByteBufferMemory.java
@@ -21,6 +21,8 @@ import java.util.function.Function;
 /**
  * Represents the linear memory in the Wasm program. Can be shared
  * reference b/w the host and the guest.
+ *
+ * This is the preferred memory implementation on Android systems.
  */
 public final class ByteBufferMemory implements Memory {
 

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/Instance.java
@@ -735,7 +735,7 @@ public class Instance {
                 if (memories.memoryCount() > 0) {
                     var defaultLimits = memories.getMemory(0).limits();
                     memory =
-                            requireNonNullElse(memoryFactory, ByteArrayMemory::new)
+                            requireNonNullElse(memoryFactory, ByteBufferMemory::new)
                                     .apply(requireNonNullElse(memoryLimits, defaultLimits));
                 }
             } else {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -10,7 +10,6 @@ import static com.dylibso.chicory.wasm.Encoding.readVarSInt64;
 import static com.dylibso.chicory.wasm.Encoding.readVarUInt32;
 import static com.dylibso.chicory.wasm.WasmLimits.MAX_FUNCTION_LOCALS;
 import static com.dylibso.chicory.wasm.types.Instruction.EMPTY_OPERANDS;
-import static com.dylibso.chicory.wasm.types.WasmEncoding.VARUINT;
 import static java.util.Objects.requireNonNull;
 
 import com.dylibso.chicory.wasm.io.InputStreams;
@@ -72,6 +71,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -956,9 +956,10 @@ public final class Parser {
             var functionBody =
                     new FunctionBody(
                             locals,
-                            instructions.stream()
-                                    .map(ins -> ins.build())
-                                    .collect(Collectors.toUnmodifiableList()));
+                            Collections.unmodifiableList(
+                                    instructions.stream()
+                                            .map(ins -> ins.build())
+                                            .collect(Collectors.toList())));
             codeSection.addFunctionBody(functionBody);
         }
 

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Parser.java
@@ -13,6 +13,7 @@ import static com.dylibso.chicory.wasm.types.Instruction.EMPTY_OPERANDS;
 import static com.dylibso.chicory.wasm.types.WasmEncoding.VARUINT;
 import static java.util.Objects.requireNonNull;
 
+import com.dylibso.chicory.wasm.io.InputStreams;
 import com.dylibso.chicory.wasm.types.ActiveDataSegment;
 import com.dylibso.chicory.wasm.types.ActiveElement;
 import com.dylibso.chicory.wasm.types.AnnotatedInstruction;
@@ -104,7 +105,7 @@ public final class Parser {
 
     private static ByteBuffer readByteBuffer(InputStream is) {
         try {
-            var buffer = ByteBuffer.wrap(is.readAllBytes());
+            var buffer = ByteBuffer.wrap(InputStreams.readAllBytes(is));
             buffer.order(ByteOrder.LITTLE_ENDIAN);
             return buffer;
         } catch (IOException e) {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/io/InputStreams.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/io/InputStreams.java
@@ -1,0 +1,28 @@
+package com.dylibso.chicory.wasm.io;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class InputStreams {
+    private InputStreams() {}
+
+    public static byte[] readAllBytes(InputStream is) throws IOException {
+        if (is == null) {
+            throw new IllegalArgumentException("InputStream cannot be null");
+        }
+
+        int bufLen = 1024;
+        byte[] buf = new byte[bufLen];
+
+        // Create an output stream to store all bytes
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        int bytesRead;
+        while ((bytesRead = is.read(buf, 0, bufLen)) != -1) {
+            outputStream.write(buf, 0, bytesRead);
+        }
+
+        return outputStream.toByteArray();
+    }
+}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/CodeSection.java
@@ -15,7 +15,7 @@ public final class CodeSection extends Section {
     }
 
     public FunctionBody[] functionBodies() {
-        return functionBodies.toArray(FunctionBody[]::new);
+        return functionBodies.toArray(new FunctionBody[0]);
     }
 
     public int functionBodyCount() {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/DataSection.java
@@ -13,7 +13,7 @@ public final class DataSection extends Section {
     }
 
     public DataSegment[] dataSegments() {
-        return dataSegments.toArray(DataSegment[]::new);
+        return dataSegments.toArray(new DataSegment[0]);
     }
 
     public int dataSegmentCount() {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElementSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/ElementSection.java
@@ -14,7 +14,7 @@ public final class ElementSection extends Section {
     }
 
     public Element[] elements() {
-        return elements.toArray(Element[]::new);
+        return elements.toArray(new Element[0]);
     }
 
     public int elementCount() {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalSection.java
@@ -13,7 +13,7 @@ public final class GlobalSection extends Section {
     }
 
     public Global[] globals() {
-        return globals.toArray(Global[]::new);
+        return globals.toArray(new Global[0]);
     }
 
     public int globalCount() {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TagSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TagSection.java
@@ -13,7 +13,7 @@ public final class TagSection extends Section {
     }
 
     public TagType[] types() {
-        return tags.toArray(TagType[]::new);
+        return tags.toArray(new TagType[0]);
     }
 
     public int tagCount() {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TypeSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TypeSection.java
@@ -13,7 +13,7 @@ public final class TypeSection extends Section {
     }
 
     public FunctionType[] types() {
-        return types.toArray(FunctionType[]::new);
+        return types.toArray(new FunctionType[0]);
     }
 
     public int typeCount() {


### PR DESCRIPTION
Adjust all usages of unsupported APIs:

- `InputStream.readAllBytes()` -> `com.dylibso.chicory.wasm.io.InputStreams#readAllBytes(is)`
- `List.toArray(T[]::new)` -> `List.toArray(new T[0])`
- Stream `toArray(T[]::new)` -> `collect(toList()).toArray(new T[0]);
- Stream `collect(Collectors.toUnmodifiableList())` -> `Collections.toUnmodifiableList(...collect(toList()))`

Notably, the changes only affect `com.dylibso.chicory:wasm` because build-time codegen does not need to be affected.

closes #745