### PR TITLE
Fix tag name in release to GH

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,4 +83,5 @@ jobs:
       - name: Release to GH Action
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.inputs.release-version }}
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
It failed in the latest release, this should be the fix.