### PR TITLE
Add an easily inspectable Version class for runtime

### DIFF
--- a/wasm/pom.xml
+++ b/wasm/pom.xml
@@ -30,4 +30,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>filtering-java-templates</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/wasm/src/main/java-templates/com/dylibso/chicory/wasm/Version.java
+++ b/wasm/src/main/java-templates/com/dylibso/chicory/wasm/Version.java
@@ -1,0 +1,9 @@
+package com.dylibso.chicory.wasm;
+
+public final class Version {
+
+    public static String version() {
+        return "${project.version}";
+    }
+
+}


### PR DESCRIPTION
This is almost a nitpick, I noticed that you are doing magic with version numbers in the Gradle plugin, and, I hope, this can improve the consistency.

cc. @illarionov 