### PR TITLE
Easy HostModule rename mechanism

### DIFF
--- a/host-module/processor/src/test/resources/BasicMathGenerated.java
+++ b/host-module/processor/src/test/resources/BasicMathGenerated.java
@@ -14,8 +14,12 @@ public final class BasicMath_ModuleFactory {
     }
 
     public static HostFunction[] toHostFunctions(BasicMath functions) {
+        return toHostFunctions(functions, "math");
+    }
+
+    public static HostFunction[] toHostFunctions(BasicMath functions, String moduleName) {
         return new HostFunction[] { //
-        new HostFunction("math",
+        new HostFunction(moduleName,
                          "add",
                          List.of(ValueType.I32,
                                  ValueType.I32),
@@ -25,7 +29,7 @@ public final class BasicMath_ModuleFactory {
                                                          (int) args[1]);
                              return new long[] { result };
                          }), //
-        new HostFunction("math",
+        new HostFunction(moduleName,
                          "square",
                          List.of(ValueType.F32),
                          List.of(ValueType.F64),
@@ -33,7 +37,7 @@ public final class BasicMath_ModuleFactory {
                              double result = functions.pow2(Value.longToFloat(args[0]));
                              return new long[] { Value.doubleToLong(result) };
                          }), //
-        new HostFunction("math",
+        new HostFunction(moduleName,
                          "floor_div",
                          List.of(ValueType.I32,
                                  ValueType.I32),

--- a/host-module/processor/src/test/resources/NestedGenerated.java
+++ b/host-module/processor/src/test/resources/NestedGenerated.java
@@ -15,8 +15,12 @@ public final class Nested_ModuleFactory {
     }
 
     public static HostFunction[] toHostFunctions(Nested functions) {
+        return toHostFunctions(functions, "nested");
+    }
+
+    public static HostFunction[] toHostFunctions(Nested functions, String moduleName) {
         return new HostFunction[] { //
-        new HostFunction("nested",
+        new HostFunction(moduleName,
                          "print",
                          List.of(ValueType.I32,
                                  ValueType.I32),
@@ -27,7 +31,7 @@ public final class Nested_ModuleFactory {
                                              (int) args[1]);
                              return null;
                          }), //
-        new HostFunction("nested",
+        new HostFunction(moduleName,
                          "exit",
                          List.of(),
                          List.of(),

--- a/host-module/processor/src/test/resources/NoPackageGenerated.java
+++ b/host-module/processor/src/test/resources/NoPackageGenerated.java
@@ -12,8 +12,12 @@ public final class NoPackage_ModuleFactory {
     }
 
     public static HostFunction[] toHostFunctions(NoPackage functions) {
+        return toHostFunctions(functions, "nopackage");
+    }
+
+    public static HostFunction[] toHostFunctions(NoPackage functions, String moduleName) {
         return new HostFunction[] { //
-        new HostFunction("nopackage",
+        new HostFunction(moduleName,
                          "print",
                          List.of(ValueType.I32,
                                  ValueType.I32),
@@ -24,7 +28,7 @@ public final class NoPackage_ModuleFactory {
                                              (int) args[1]);
                              return null;
                          }), //
-        new HostFunction("nopackage",
+        new HostFunction(moduleName,
                          "exit",
                          List.of(),
                          List.of(),

--- a/host-module/processor/src/test/resources/SimpleGenerated.java
+++ b/host-module/processor/src/test/resources/SimpleGenerated.java
@@ -14,8 +14,12 @@ public final class Simple_ModuleFactory {
     }
 
     public static HostFunction[] toHostFunctions(Simple functions) {
+        return toHostFunctions(functions, "simple");
+    }
+
+    public static HostFunction[] toHostFunctions(Simple functions, String moduleName) {
         return new HostFunction[] { //
-        new HostFunction("simple",
+        new HostFunction(moduleName,
                          "print",
                          List.of(ValueType.I32,
                                  ValueType.I32),
@@ -25,7 +29,7 @@ public final class Simple_ModuleFactory {
                                                                           (int) args[1]));
                              return null;
                          }), //
-        new HostFunction("simple",
+        new HostFunction(moduleName,
                          "printx",
                          List.of(ValueType.I32),
                          List.of(),
@@ -33,7 +37,7 @@ public final class Simple_ModuleFactory {
                              functions.printx(instance.memory().readCString((int) args[0]));
                              return null;
                          }), //
-        new HostFunction("simple",
+        new HostFunction(moduleName,
                          "random_get",
                          List.of(ValueType.I32,
                                  ValueType.I32),
@@ -44,7 +48,7 @@ public final class Simple_ModuleFactory {
                                                  (int) args[1]);
                              return null;
                          }), //
-        new HostFunction("simple",
+        new HostFunction(moduleName,
                          "exit",
                          List.of(),
                          List.of(),


### PR DESCRIPTION
This adds a new generated overload where the module name can be supplied explicitly

```java
    public static HostFunction[] toHostFunctions(Simple functions, String moduleName) {
```

Looks like there are Wasm modules where the wasi function module is called `wasi_unstable`.

This change is backward-compatible and provides an easy mechanism for changing the module name to all the functions defined in a "HostModule".

cc. @chirino
