### PR TITLE
(WIP) Refactors concrete ValueTypes to implement an interface

### DIFF
--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotUtil.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotUtil.java
@@ -1,6 +1,12 @@
 package com.dylibso.chicory.experimental.aot;
 
 import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.ExternRef;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.F32;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.F64;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.FuncRef;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.I32;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.I64;
 import static java.lang.invoke.MethodType.methodType;
 import static java.util.stream.Collectors.joining;
 import static org.objectweb.asm.Type.DOUBLE_TYPE;
@@ -46,7 +52,7 @@ final class AotUtil {
     }
 
     public static Class<?> jvmType(ValueType type) {
-        switch (type) {
+        switch (type.id()) {
             case I32:
             case ExternRef:
             case FuncRef:
@@ -58,12 +64,12 @@ final class AotUtil {
             case F64:
                 return double.class;
             default:
-                throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
+                throw new IllegalArgumentException("Unsupported ValueType: " + type);
         }
     }
 
     public static Type asmType(ValueType type) {
-        switch (type) {
+        switch (type.id()) {
             case I32:
             case ExternRef:
             case FuncRef:
@@ -88,7 +94,7 @@ final class AotUtil {
     }
 
     public static void emitLongToJvm(MethodVisitor asm, ValueType type) {
-        switch (type) {
+        switch (type.id()) {
             case I32:
             case ExternRef:
             case FuncRef:
@@ -103,12 +109,12 @@ final class AotUtil {
                 emitInvokeStatic(asm, LONG_TO_F64);
                 return;
             default:
-                throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
+                throw new IllegalArgumentException("Unsupported ValueType: " + type);
         }
     }
 
     public static void emitJvmToLong(MethodVisitor asm, ValueType type) {
-        switch (type) {
+        switch (type.id()) {
             case I32:
             case ExternRef:
             case FuncRef:
@@ -123,7 +129,7 @@ final class AotUtil {
                 emitInvokeStatic(asm, F64_TO_LONG);
                 return;
             default:
-                throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
+                throw new IllegalArgumentException("Unsupported ValueType: " + type);
         }
     }
 
@@ -164,7 +170,7 @@ final class AotUtil {
     }
 
     public static Object defaultValue(ValueType type) {
-        switch (type) {
+        switch (type.id()) {
             case I32:
                 return 0;
             case I64:
@@ -177,12 +183,12 @@ final class AotUtil {
             case FuncRef:
                 return REF_NULL_VALUE;
             default:
-                throw new IllegalArgumentException("Unsupported ValueType: " + type.name());
+                throw new IllegalArgumentException("Unsupported ValueType: " + type);
         }
     }
 
     public static int slotCount(ValueType type) {
-        switch (type) {
+        switch (type.id()) {
             case I32:
             case F32:
             case ExternRef:
@@ -234,7 +240,7 @@ final class AotUtil {
     public static String valueMethodName(List<ValueType> types) {
         return "value_"
                 + types.stream()
-                        .map(type -> type.name().toLowerCase(Locale.ROOT))
+                        .map(type -> type.shortName().toLowerCase(Locale.ROOT))
                         .collect(joining("_"));
     }
 

--- a/host-module/processor/src/main/java/com/dylibso/chicory/experimental/hostmodule/processor/WasmModuleProcessor.java
+++ b/host-module/processor/src/main/java/com/dylibso/chicory/experimental/hostmodule/processor/WasmModuleProcessor.java
@@ -1,5 +1,9 @@
 package com.dylibso.chicory.experimental.hostmodule.processor;
 
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.F32;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.F64;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.I32;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.I64;
 import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.StaticJavaParser.parseType;
 import static java.lang.String.format;
@@ -87,7 +91,7 @@ public final class WasmModuleProcessor extends AbstractModuleProcessor {
     }
 
     private Class javaClassFromValueType(ValueType type) {
-        switch (type) {
+        switch (type.id()) {
             case I32:
                 return int.class;
             case I64:
@@ -103,7 +107,7 @@ public final class WasmModuleProcessor extends AbstractModuleProcessor {
     }
 
     private Expression toLong(ValueType type, Expression nameExpr, CompilationUnit cu) {
-        switch (type) {
+        switch (type.id()) {
             case I32:
                 return new CastExpr(parseType("long"), nameExpr);
             case I64:
@@ -123,7 +127,7 @@ public final class WasmModuleProcessor extends AbstractModuleProcessor {
     }
 
     private Expression fromLong(ValueType type, Expression nameExpr, CompilationUnit cu) {
-        switch (type) {
+        switch (type.id()) {
             case I32:
                 return new CastExpr(parseType("int"), nameExpr);
             case I64:
@@ -156,7 +160,7 @@ public final class WasmModuleProcessor extends AbstractModuleProcessor {
                 valueTypes.stream()
                         .map(
                                 vt -> {
-                                    switch (vt) {
+                                    switch (vt.id()) {
                                         case I32:
                                             return new FieldAccessExpr(
                                                     new NameExpr("ValueType"), "I32");

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/ValueTypeTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/ValueTypeTest.java
@@ -1,0 +1,25 @@
+package com.dylibso.chicory.runtime;
+
+import com.dylibso.chicory.wasm.types.ValueType;
+import org.junit.jupiter.api.Test;
+
+public class ValueTypeTest {
+
+    @Test
+    public void roundtripTest() {
+        ValueType[] all =
+                new ValueType[] {
+                    ValueType.F64,
+                    ValueType.F32,
+                    ValueType.I64,
+                    ValueType.I32,
+                    ValueType.V128,
+                    ValueType.FuncRef,
+                    ValueType.ExternRef
+                };
+
+        for (ValueType v : all) {
+            assert ValueType.forId(v.id()).equals(v) : "cannot roundtrip: " + v;
+        }
+    }
+}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionType.java
@@ -1,7 +1,8 @@
 package com.dylibso.chicory.wasm.types;
 
-import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public final class FunctionType {
@@ -45,11 +46,11 @@ public final class FunctionType {
         return hashCode;
     }
 
-    private static final EnumMap<ValueType, FunctionType> returning;
-    private static final EnumMap<ValueType, FunctionType> accepting;
+    private static final Map<ValueType, FunctionType> returning;
+    private static final Map<ValueType, FunctionType> accepting;
 
     static {
-        EnumMap<ValueType, FunctionType> map = new EnumMap<>(ValueType.class);
+        Map<ValueType, FunctionType> map = new HashMap<>();
         map.put(ValueType.ExternRef, new FunctionType(List.of(), List.of(ValueType.ExternRef)));
         map.put(ValueType.FuncRef, new FunctionType(List.of(), List.of(ValueType.FuncRef)));
         map.put(ValueType.V128, new FunctionType(List.of(), List.of(ValueType.V128)));
@@ -58,7 +59,7 @@ public final class FunctionType {
         map.put(ValueType.I64, new FunctionType(List.of(), List.of(ValueType.I64)));
         map.put(ValueType.I32, new FunctionType(List.of(), List.of(ValueType.I32)));
         returning = map;
-        map = new EnumMap<>(ValueType.class);
+        map = new HashMap<>();
         map.put(ValueType.ExternRef, new FunctionType(List.of(ValueType.ExternRef), List.of()));
         map.put(ValueType.FuncRef, new FunctionType(List.of(ValueType.FuncRef), List.of()));
         map.put(ValueType.V128, new FunctionType(List.of(ValueType.V128), List.of()));

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -1,5 +1,12 @@
 package com.dylibso.chicory.wasm.types;
 
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.ExternRef;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.F32;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.F64;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.FuncRef;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.I32;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.I64;
+import static com.dylibso.chicory.wasm.types.valuetypes.ID.V128;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
@@ -268,7 +275,7 @@ public class Value {
      * @return a zero.
      */
     public static long zero(ValueType valueType) {
-        switch (valueType) {
+        switch (valueType.id()) {
             case I32:
             case F32:
             case I64:
@@ -285,7 +292,7 @@ public class Value {
 
     @Override
     public String toString() {
-        switch (type) {
+        switch (type.id()) {
             case I32:
                 return ((int) data) + "@i32";
             case I64:

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/valuetypes/ID.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/valuetypes/ID.java
@@ -1,0 +1,16 @@
+package com.dylibso.chicory.wasm.types.valuetypes;
+
+/**
+ * A separate holder class for constants.
+ */
+public final class ID {
+    private ID() {}
+
+    public static final int ExternRef = 0x6f;
+    public static final int FuncRef = 0x70;
+    public static final int V128 = 0x7b;
+    public static final int F64 = 0x7c;
+    public static final int F32 = 0x7d;
+    public static final int I64 = 0x7e;
+    public static final int I32 = 0x7f;
+}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/valuetypes/NumType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/valuetypes/NumType.java
@@ -1,0 +1,71 @@
+package com.dylibso.chicory.wasm.types.valuetypes;
+
+import com.dylibso.chicory.wasm.types.ValueType;
+
+public enum NumType implements ValueType {
+    I32,
+    I64,
+    F32,
+    F64;
+
+    @Override
+    public boolean isNumeric() {
+        return true;
+    }
+
+    @Override
+    public boolean isInteger() {
+        return this == I32 || this == I64;
+    }
+
+    @Override
+    public boolean isFloatingPoint() {
+        return this == F32 || this == F64;
+    }
+
+    @Override
+    public boolean isVec() {
+        return false;
+    }
+
+    @Override
+    public boolean isReference() {
+        return false;
+    }
+
+    @Override
+    public boolean equals(ValueType other) {
+        if (!(other instanceof NumType)) {
+            return false;
+        }
+
+        NumType that = (NumType) other;
+        return this == that;
+    }
+
+    @Override
+    public int id() {
+        switch (this) {
+            case I32:
+                return ID.I32;
+            case I64:
+                return ID.I64;
+            case F32:
+                return ID.F32;
+            case F64:
+                return ID.F64;
+            default:
+                throw new IllegalArgumentException("Invalid value type " + this);
+        }
+    }
+
+    @Override
+    public String shortName() {
+        return toString();
+    }
+
+    @Override
+    public int size() {
+        return 1;
+    }
+}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/valuetypes/RefType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/valuetypes/RefType.java
@@ -1,0 +1,115 @@
+package com.dylibso.chicory.wasm.types.valuetypes;
+
+import com.dylibso.chicory.wasm.types.ValueType;
+import java.util.Objects;
+
+public class RefType implements ValueType {
+    private final HeapType heapType;
+    private final boolean isNullable;
+
+    public RefType(HeapType heapType) {
+        this.heapType = heapType;
+        this.isNullable = true;
+    }
+
+    @Override
+    public boolean isNumeric() {
+        return false;
+    }
+
+    @Override
+    public boolean isInteger() {
+        return false;
+    }
+
+    @Override
+    public boolean isFloatingPoint() {
+        return false;
+    }
+
+    @Override
+    public boolean isVec() {
+        return false;
+    }
+
+    @Override
+    public boolean isReference() {
+        return true;
+    }
+
+    @Override
+    public boolean equals(ValueType other) {
+        if (!(other instanceof RefType)) {
+            return false;
+        }
+
+        RefType that = (RefType) other;
+        return this.isNullable == that.isNullable && this.heapType.equals(that.heapType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(heapType, isNullable);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("RefType[%b, %s]", isNullable, heapType.toString());
+    }
+
+    @Override
+    public int id() {
+        if (heapType instanceof HeapType.Union) {
+            HeapType.Union funcUnionType = (HeapType.Union) heapType;
+            switch (funcUnionType) {
+                case FUNC:
+                    return ID.FuncRef;
+                case EXTERN:
+                    return ID.ExternRef;
+                default:
+                    throw new IllegalArgumentException("Invalid union type: " + funcUnionType);
+            }
+        }
+
+        throw new IllegalArgumentException("Invalid heap type: " + heapType);
+    }
+
+    @Override
+    public String shortName() {
+        return heapType.toString();
+    }
+
+    @Override
+    public int size() {
+        return 1;
+    }
+
+    public interface HeapType {
+        boolean equals(HeapType other);
+
+        // in the future, there will be a Def implementation
+        // see https://webassembly.github.io/function-references/core/appendix/algorithm.html
+
+        int hashCode();
+
+        String toString();
+
+        /**
+         * Heap types that represent a union of all types of functions.
+         */
+        enum Union implements HeapType {
+            FUNC,
+            EXTERN;
+
+            @Override
+            public boolean equals(HeapType other) {
+                if (!(other instanceof Union)) {
+                    return false;
+                }
+
+                Union that = (Union) other;
+                return this == that;
+            }
+        }
+    }
+}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/valuetypes/UnknownType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/valuetypes/UnknownType.java
@@ -1,0 +1,53 @@
+package com.dylibso.chicory.wasm.types.valuetypes;
+
+import com.dylibso.chicory.wasm.ChicoryException;
+import com.dylibso.chicory.wasm.types.ValueType;
+
+public enum UnknownType implements ValueType {
+    UNKNOWN;
+
+    @Override
+    public boolean isNumeric() {
+        return false;
+    }
+
+    @Override
+    public boolean isInteger() {
+        return false;
+    }
+
+    @Override
+    public boolean isFloatingPoint() {
+        return false;
+    }
+
+    @Override
+    public boolean isVec() {
+        return false;
+    }
+
+    @Override
+    public boolean isReference() {
+        return false;
+    }
+
+    @Override
+    public boolean equals(ValueType other) {
+        return other instanceof UnknownType;
+    }
+
+    @Override
+    public int id() {
+        throw new IllegalArgumentException("cannot get id() of UnknownType");
+    }
+
+    @Override
+    public String shortName() {
+        return toString();
+    }
+
+    @Override
+    public int size() {
+        throw new ChicoryException("size on Unknown type");
+    }
+}

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/valuetypes/VecType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/valuetypes/VecType.java
@@ -1,0 +1,52 @@
+package com.dylibso.chicory.wasm.types.valuetypes;
+
+import com.dylibso.chicory.wasm.types.ValueType;
+
+public enum VecType implements ValueType {
+    V128;
+
+    @Override
+    public boolean isNumeric() {
+        return false;
+    }
+
+    @Override
+    public boolean isInteger() {
+        return false;
+    }
+
+    @Override
+    public boolean isFloatingPoint() {
+        return false;
+    }
+
+    @Override
+    public boolean isVec() {
+        return true;
+    }
+
+    @Override
+    public boolean isReference() {
+        return false;
+    }
+
+    @Override
+    public boolean equals(ValueType other) {
+        return other instanceof VecType;
+    }
+
+    @Override
+    public int id() {
+        return ID.V128;
+    }
+
+    @Override
+    public String shortName() {
+        return toString();
+    }
+
+    @Override
+    public int size() {
+        return 2;
+    }
+}


### PR DESCRIPTION
For typed references proposal, we need to introduce a new Heap Type that takes a typeidx: int as an argument. See [spec](https://webassembly.github.io/function-references/core/binary/types.html#heap-types).

This can't be represented right now in its enum implementation. Thus, this PR changes ValueType into an interface, and concrete ValueTypes implement that interface.

Open to any feedback!