### PR TITLE
feat(aot): tail call proposal

### DIFF
--- a/aot-tests/pom.xml
+++ b/aot-tests/pom.xml
@@ -152,7 +152,8 @@
             <wast>utf8-import-module.wast</wast>
             <wast>utf8-invalid-encoding.wast</wast>
           </includedWasts>
-          <excludedTests/>
+          <!-- Skip stack-overflows in tail calls -->
+          <excludedTests>SpecV1TcReturnCallTest.test19,SpecV1TcReturnCallTest.test24,SpecV1TcReturnCallTest.test25,SpecV1TcReturnCallTest.test30,SpecV1TcReturnCallTest.test31,SpecV1TcReturnCallIndirectTest.test40,SpecV1TcReturnCallIndirectTest.test41,SpecV1TcReturnCallIndirectTest.test46,SpecV1TcReturnCallIndirectTest.test47</excludedTests>
           <excludedMalformedWasts/>
           <excludedInvalidWasts/>
           <excludedUnlinkableWasts/>

--- a/aot-tests/pom.xml
+++ b/aot-tests/pom.xml
@@ -119,6 +119,8 @@
             <wast>memory_trap.wast</wast>
             <wast>names.wast</wast>
             <wast>nop.wast</wast>
+            <wast>proposals/tail-call/return_call.wast</wast>
+            <wast>proposals/tail-call/return_call_indirect.wast</wast>
             <wast>ref_func.wast</wast>
             <wast>ref_is_null.wast</wast>
             <wast>ref_null.wast</wast>


### PR DESCRIPTION
Because the JVM does not support tail calls natively, this only **desugars** RETURN_CALL into CALL+RETURN and RETURN_CALL_INDIRECT into CALL_INDIRECT+RETURN. 

However, there are indeed tests that exercise the stack; some of these _might_ be optimized (e.g. factorial of 1_000_000), but the others are mutually recursive functions that cannot be optimized in a general sense.  Notice that because of the massive size, even a custom stack size (in the `-Xss` sense) does not make much difference. 

Except for these cases (indeed those where proper tail calls would make sense 😅) the implementation passes all the other tests.

