### PR TITLE
Clear the call stack when performing a return

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/InterpreterMachine.java
@@ -194,6 +194,7 @@ public class InterpreterMachine implements Machine {
                         // RETURN doesn't pass through the END
                         var ctrlFrame = frame.popCtrlTillCall();
                         StackFrame.doControlTransfer(ctrlFrame, stack);
+                        callStack.clear();
 
                         shouldReturn = true;
                         break;


### PR DESCRIPTION
I found this when working on #794 , and it's extremely confusing, so separating the fix to get it merged early.