### PR TITLE
fix: prevent overflows in DefaultMemAllocStrategy

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/alloc/DefaultMemAllocStrategy.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/alloc/DefaultMemAllocStrategy.java
@@ -17,6 +17,9 @@ public final class DefaultMemAllocStrategy implements MemAllocStrategy {
         int next = (current <= 0) ? target : current;
         while (next < target && next < max) {
             next = next << 1;
+            if (next < 0) {
+                return max;
+            }
         }
         return Math.min(max, next);
     }

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/alloc/MemAllocStrategyTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/alloc/MemAllocStrategyTest.java
@@ -2,6 +2,7 @@ package com.dylibso.chicory.runtime.alloc;
 
 import static com.dylibso.chicory.runtime.Memory.PAGE_SIZE;
 import static com.dylibso.chicory.runtime.Memory.RUNTIME_MAX_PAGES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,18 @@ public class MemAllocStrategyTest {
 
         // Assert
         assertTrue(result >= 3);
+    }
+
+    @Test
+    public void avoidOverflows() {
+        // Arrange
+        var memAlloc = new DefaultMemAllocStrategy(2147418112);
+
+        // Act
+        var result = memAlloc.next(1610612736, 1610678272);
+
+        // Assert
+        assertEquals(2147418112, result);
     }
 
     @Test


### PR DESCRIPTION
As @electrum pointed out this was going to overflow, and I missed a guard over this condition :sweat: 
When the overflow happens the `while` goes into an infinite loop.