### PR TITLE
wasm-tools wat2wasm utility

### DIFF
--- a/wasm-tools/src/main/java/com/dylibso/chicory/tools/wasm/Wat2Wasm.java
+++ b/wasm-tools/src/main/java/com/dylibso/chicory/tools/wasm/Wat2Wasm.java
@@ -1,0 +1,104 @@
+package com.dylibso.chicory.tools.wasm;
+
+import static java.nio.file.Files.copy;
+
+import com.dylibso.chicory.log.Logger;
+import com.dylibso.chicory.log.SystemLogger;
+import com.dylibso.chicory.runtime.ByteArrayMemory;
+import com.dylibso.chicory.runtime.ImportValues;
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasi.WasiOptions;
+import com.dylibso.chicory.wasi.WasiPreview1;
+import com.dylibso.chicory.wasm.Parser;
+import com.dylibso.chicory.wasm.WasmModule;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class Wat2Wasm {
+    private Wat2Wasm() {}
+
+    private static final Logger logger =
+            new SystemLogger() {
+                @Override
+                public boolean isLoggable(Logger.Level level) {
+                    return false;
+                }
+            };
+    private static final WasmModule MODULE =
+            Parser.parse(Wat2Wasm.class.getResourceAsStream("/wasm-tools.wasm"));
+
+    public static byte[] parse(File file) {
+        try (InputStream is = new FileInputStream(file)) {
+            return parse(is, file.getName());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static byte[] parse(String wat) {
+        try (InputStream is = new ByteArrayInputStream(wat.getBytes(StandardCharsets.UTF_8))) {
+            return parse(is, "temp.wat");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static byte[] parse(InputStream is, String fileName) {
+        try (FileSystem fs =
+                Jimfs.newFileSystem(
+                        Configuration.unix().toBuilder().setAttributeViews("unix").build())) {
+
+            Path target = fs.getPath("tmp");
+            java.nio.file.Files.createDirectory(target);
+            Path path = target.resolve(fileName);
+            copy(is, path, StandardCopyOption.REPLACE_EXISTING);
+
+            String resultFileName = fileName + ".wasm";
+            Path result = target.resolve(resultFileName);
+
+            WasiOptions wasiOpts =
+                    WasiOptions.builder()
+                            .inheritSystem()
+                            .withDirectory(target.toString(), target)
+                            .withArguments(
+                                    List.of(
+                                            "wasm-tools",
+                                            "parse",
+                                            path.toString(),
+                                            "-o",
+                                            result.toString()))
+                            .build();
+
+            logger.info(
+                    "Running command: "
+                            + wasiOpts.arguments().stream().collect(Collectors.joining(" ")));
+
+            try (var wasi =
+                    WasiPreview1.builder().withLogger(logger).withOptions(wasiOpts).build()) {
+                ImportValues imports =
+                        ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
+
+                Instance.builder(MODULE)
+                        .withMemoryFactory(ByteArrayMemory::new)
+                        .withImportValues(imports)
+                        .build();
+            }
+
+            return java.nio.file.Files.readAllBytes(result);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/wasm-tools/src/test/java/com/dylibso/chicory/tools/wasm/WasmToolsTest.java
+++ b/wasm-tools/src/test/java/com/dylibso/chicory/tools/wasm/WasmToolsTest.java
@@ -1,7 +1,13 @@
 package com.dylibso.chicory.tools.wasm;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasi.WasiExitException;
+import com.dylibso.chicory.wasm.Parser;
 import java.io.File;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
@@ -25,5 +31,44 @@ public class WasmToolsTest {
         // Assert
         assertTrue(outputFile.exists());
         assertTrue(outputFile.toPath().resolve("spec.0.wasm").toFile().exists());
+    }
+
+    @Test
+    public void shouldRunWat2Wasm() throws Exception {
+        var result = Wat2Wasm.parse(new File("../wasm-corpus/src/main/resources/wat/iterfact.wat"));
+
+        assertTrue(result.length > 0);
+        assertTrue(new String(result, UTF_8).contains("iterFact"));
+    }
+
+    @Test
+    public void shouldRunWat2WasmOnString() {
+        var moduleInstance =
+                Instance.builder(
+                                Parser.parse(
+                                        Wat2Wasm.parse(
+                                                "(module (func (export \"add\") (param $x"
+                                                        + " i32) (param $y i32) (result i32)"
+                                                        + " (i32.add (local.get $x) (local.get"
+                                                        + " $y))))")))
+                        .withInitialize(true)
+                        .build();
+
+        var addFunction = moduleInstance.export("add");
+        var results = addFunction.apply(1, 41);
+        assertEquals(42L, results[0]);
+    }
+
+    @Test
+    public void shouldThrowMalformedException() throws Exception {
+        var exitException =
+                assertThrows(
+                        WasiExitException.class,
+                        () ->
+                                Wat2Wasm.parse(
+                                        new File(
+                                                "src/test/resources/utf8-invalid-encoding-spec.0.wat")));
+
+        assertEquals(1, exitException.exitCode());
     }
 }

--- a/wasm-tools/src/test/resources/utf8-invalid-encoding-spec.0.wat
+++ b/wasm-tools/src/test/resources/utf8-invalid-encoding-spec.0.wat
@@ -1,0 +1,1 @@
+(func (export "\00\00\fe\ff"))


### PR DESCRIPTION
There is a mysterious bug happening only in compiled mode when specific versions of Java are used, this PR adds another way to use `wat2wasm` with the interpreter mode.

To unblock #833 @chirino you can now use this one (please keep the numbers low as it's taking forever to finish ~2 minutes).