### PR TITLE
fix: AOT Engine error: Method too large #405

### DIFF
--- a/aot-tests/pom.xml
+++ b/aot-tests/pom.xml
@@ -16,6 +16,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.approvaltests</groupId>
+      <artifactId>approvaltests</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.dylibso.chicory</groupId>
       <artifactId>aot-experimental</artifactId>
       <scope>test</scope>

--- a/aot-tests/src/test/java/com/dylibso/chicory/testing/MethodTooLargeTest.java
+++ b/aot-tests/src/test/java/com/dylibso/chicory/testing/MethodTooLargeTest.java
@@ -1,0 +1,27 @@
+package com.dylibso.chicory.testing;
+
+import static com.dylibso.chicory.corpus.WatGenerator.bigWat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.dylibso.chicory.experimental.aot.AotMachine;
+import com.dylibso.chicory.runtime.ExportFunction;
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wabt.Wat2Wasm;
+import com.dylibso.chicory.wasm.Parser;
+import org.junit.jupiter.api.Test;
+
+public class MethodTooLargeTest {
+
+    @Test
+    public void testBigFunc() {
+        byte[] wasm = Wat2Wasm.parse(bigWat(1, 20_000));
+        var instance =
+                Instance.builder(Parser.parse(wasm))
+                        .withMachineFactory(AotMachine::new)
+                        .withStart(false)
+                        .build();
+
+        ExportFunction func1 = instance.export("func_" + 1);
+        assertEquals(1, func1.apply(0)[0]);
+    }
+}

--- a/aot-tests/src/test/java/com/dylibso/chicory/testing/MethodTooLargeTest.java
+++ b/aot-tests/src/test/java/com/dylibso/chicory/testing/MethodTooLargeTest.java
@@ -2,26 +2,68 @@ package com.dylibso.chicory.testing;
 
 import static com.dylibso.chicory.corpus.WatGenerator.bigWat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.objectweb.asm.Type.getInternalName;
 
-import com.dylibso.chicory.experimental.aot.AotMachine;
+import com.dylibso.chicory.experimental.aot.AotCompiler;
+import com.dylibso.chicory.experimental.aot.AotMethods;
 import com.dylibso.chicory.runtime.ExportFunction;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wabt.Wat2Wasm;
 import com.dylibso.chicory.wasm.Parser;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
+import org.approvaltests.Approvals;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.util.TraceClassVisitor;
 
 public class MethodTooLargeTest {
 
     @Test
     public void testBigFunc() {
         byte[] wasm = Wat2Wasm.parse(bigWat(1, 20_000));
+
+        var module = Parser.parse(wasm);
+        var result = AotCompiler.builder(module).build().compile();
+
+        verifyClass(result.classBytes(), true);
+
         var instance =
-                Instance.builder(Parser.parse(wasm))
-                        .withMachineFactory(AotMachine::new)
+                Instance.builder(module)
+                        .withMachineFactory(result.machineFactory())
                         .withStart(false)
                         .build();
 
         ExportFunction func1 = instance.export("func_" + 1);
         assertEquals(1, func1.apply(0)[0]);
+    }
+
+    private static void verifyClass(Map<String, byte[]> classBytes, boolean skipAotMethods) {
+        var writer = new StringWriter();
+
+        for (byte[] bytes : classBytes.values()) {
+            ClassReader cr = new ClassReader(bytes);
+            if (skipAotMethods && cr.getClassName().endsWith("$AotMethods")) {
+                continue;
+            }
+            cr.accept(new TraceClassVisitor(new PrintWriter(writer)), 0);
+            writer.append("\n");
+        }
+
+        String output = writer.toString();
+        output = output.replaceAll("(?m)^ {3}FRAME.*\\n", "");
+        output = output.replaceAll("(?m)^ {4}MAX(STACK|LOCALS) = \\d+\\n", "");
+        output = output.replaceAll("(?m)^ {4}(LINENUMBER|LOCALVARIABLE) .*\\n", "");
+        output = output.replaceAll("(?m)^ *// .*\\n", "");
+        output = output.replaceAll("\\n{3,}", "\n\n");
+        output = output.strip() + "\n";
+
+        Approvals.verify(output);
+
+        assertFalse(
+                output.contains(getInternalName(AotMethods.class)),
+                "Class contains non-inlined reference to AotMethods");
     }
 }

--- a/aot-tests/src/test/java/com/dylibso/chicory/testing/PackageSettings.java
+++ b/aot-tests/src/test/java/com/dylibso/chicory/testing/PackageSettings.java
@@ -1,0 +1,5 @@
+package com.dylibso.chicory.testing;
+
+public class PackageSettings {
+    public String ApprovalBaseDirectory = "../resources";
+}

--- a/aot-tests/src/test/resources/com/dylibso/chicory/testing/MethodTooLargeTest.testBigFunc.approved.txt
+++ b/aot-tests/src/test/resources/com/dylibso/chicory/testing/MethodTooLargeTest.testBigFunc.approved.txt
@@ -1,0 +1,163 @@
+public final class com/dylibso/chicory/$gen/CompiledMachine implements com/dylibso/chicory/runtime/Machine {
+
+  NESTMEMBER com/dylibso/chicory/$gen/CompiledMachine$AotMethods
+  NESTMEMBER com/dylibso/chicory/$gen/CompiledMachineFuncGroup_0
+  NESTMEMBER com/dylibso/chicory/$gen/CompiledMachine$MachineCall
+
+  private final Lcom/dylibso/chicory/runtime/Instance; instance
+
+  private final Lcom/dylibso/chicory/runtime/InterpreterMachine; interpreterMachine
+
+  public <init>(Lcom/dylibso/chicory/runtime/Instance;)V
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    ALOAD 0
+    ALOAD 1
+    PUTFIELD com/dylibso/chicory/$gen/CompiledMachine.instance : Lcom/dylibso/chicory/runtime/Instance;
+    ALOAD 0
+    NEW com/dylibso/chicory/runtime/InterpreterMachine
+    DUP
+    ALOAD 1
+    INVOKESPECIAL com/dylibso/chicory/runtime/InterpreterMachine.<init> (Lcom/dylibso/chicory/runtime/Instance;)V
+    PUTFIELD com/dylibso/chicory/$gen/CompiledMachine.interpreterMachine : Lcom/dylibso/chicory/runtime/InterpreterMachine;
+    RETURN
+
+  public call(I[J)[J
+    TRYCATCHBLOCK L0 L1 L1 java/lang/StackOverflowError
+    ILOAD 1
+    LOOKUPSWITCH
+      0: L2
+      default: L0
+   L2
+    ALOAD 0
+    GETFIELD com/dylibso/chicory/$gen/CompiledMachine.interpreterMachine : Lcom/dylibso/chicory/runtime/InterpreterMachine;
+    ILOAD 1
+    ALOAD 2
+    INVOKEVIRTUAL com/dylibso/chicory/runtime/InterpreterMachine.call (I[J)[J
+    ARETURN
+   L0
+    ALOAD 0
+    GETFIELD com/dylibso/chicory/$gen/CompiledMachine.instance : Lcom/dylibso/chicory/runtime/Instance;
+    DUP
+    INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.memory ()Lcom/dylibso/chicory/runtime/Memory;
+    ILOAD 1
+    ALOAD 2
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$MachineCall.call (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;I[J)[J
+    ARETURN
+   L1
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.throwCallStackExhausted (Ljava/lang/StackOverflowError;)Ljava/lang/RuntimeException;
+    ATHROW
+
+  public static call_indirect_0(IIILcom/dylibso/chicory/runtime/Memory;Lcom/dylibso/chicory/runtime/Instance;)I
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.checkInterruption ()V
+    ALOAD 4
+    ILOAD 2
+    INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.table (I)Lcom/dylibso/chicory/runtime/TableInstance;
+    ASTORE 5
+    ALOAD 5
+    ILOAD 1
+    INVOKEVIRTUAL com/dylibso/chicory/runtime/TableInstance.requiredRef (I)I
+    ISTORE 6
+    ALOAD 5
+    ILOAD 1
+    INVOKEVIRTUAL com/dylibso/chicory/runtime/TableInstance.instance (I)Lcom/dylibso/chicory/runtime/Instance;
+    ASTORE 7
+    ALOAD 7
+    IFNULL L0
+    ALOAD 7
+    ALOAD 4
+    IF_ACMPNE L1
+   L0
+    ILOAD 0
+    ALOAD 3
+    ALOAD 4
+    ILOAD 6
+    LOOKUPSWITCH
+      0: L2
+      default: L3
+   L2
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_0.func_0 (ILcom/dylibso/chicory/runtime/Memory;Lcom/dylibso/chicory/runtime/Instance;)I
+    IRETURN
+   L3
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.throwIndirectCallTypeMismatch ()Ljava/lang/RuntimeException;
+    ATHROW
+   L1
+    ICONST_1
+    NEWARRAY T_LONG
+    DUP
+    ICONST_0
+    ILOAD 0
+    I2L
+    LASTORE
+    ICONST_0
+    ILOAD 6
+    ALOAD 7
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.callIndirect ([JIILcom/dylibso/chicory/runtime/Instance;)[J
+    ICONST_0
+    LALOAD
+    L2I
+    IRETURN
+}
+
+final class com/dylibso/chicory/$gen/CompiledMachineFuncGroup_0 {
+
+  public static func_0(ILcom/dylibso/chicory/runtime/Memory;Lcom/dylibso/chicory/runtime/Instance;)I
+    ICONST_1
+    NEWARRAY T_LONG
+    DUP
+    ICONST_0
+    ILOAD 0
+    I2L
+    LASTORE
+    ICONST_0
+    ALOAD 2
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.callIndirect ([JILcom/dylibso/chicory/runtime/Instance;)[J
+    ICONST_0
+    LALOAD
+    L2I
+    IRETURN
+
+  public static call_0(Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
+    ALOAD 2
+    ICONST_0
+    LALOAD
+    L2I
+    ALOAD 1
+    ALOAD 0
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_0.func_0 (ILcom/dylibso/chicory/runtime/Memory;Lcom/dylibso/chicory/runtime/Instance;)I
+    I2L
+    LSTORE 3
+    ICONST_1
+    NEWARRAY T_LONG
+    DUP
+    ICONST_0
+    LLOAD 3
+    LASTORE
+    ARETURN
+}
+
+final class com/dylibso/chicory/$gen/CompiledMachine$MachineCall {
+
+  NESTHOST com/dylibso/chicory/$gen/CompiledMachine
+
+  public <init>()V
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+
+  public static call(Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;I[J)[J
+    ALOAD 0
+    ALOAD 1
+    ALOAD 3
+    ILOAD 2
+    TABLESWITCH
+      0: L0
+      default: L1
+   L0
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_0.call_0 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
+    ARETURN
+   L1
+    ILOAD 2
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachine$AotMethods.throwUnknownFunction (I)Ljava/lang/RuntimeException;
+    ATHROW
+}

--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotCompiler.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotCompiler.java
@@ -5,6 +5,7 @@ import static com.dylibso.chicory.experimental.aot.AotMethodInliner.aotMethodsRe
 import static com.dylibso.chicory.experimental.aot.AotMethodInliner.createAotMethodsClass;
 import static com.dylibso.chicory.experimental.aot.AotMethodRefs.CALL_HOST_FUNCTION;
 import static com.dylibso.chicory.experimental.aot.AotMethodRefs.CALL_INDIRECT;
+import static com.dylibso.chicory.experimental.aot.AotMethodRefs.CALL_INDIRECT_V2;
 import static com.dylibso.chicory.experimental.aot.AotMethodRefs.CHECK_INTERRUPTION;
 import static com.dylibso.chicory.experimental.aot.AotMethodRefs.INSTANCE_MEMORY;
 import static com.dylibso.chicory.experimental.aot.AotMethodRefs.INSTANCE_TABLE;
@@ -53,6 +54,7 @@ import static org.objectweb.asm.Type.getType;
 import static org.objectweb.asm.commons.InstructionAdapter.OBJECT_TYPE;
 
 import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.runtime.InterpreterMachine;
 import com.dylibso.chicory.runtime.Machine;
 import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.wasm.ChicoryException;
@@ -64,6 +66,7 @@ import com.dylibso.chicory.wasm.types.ValueType;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -88,12 +91,25 @@ public final class AotCompiler {
 
     public static final String DEFAULT_CLASS_NAME = "com.dylibso.chicory.$gen.CompiledMachine";
     private static final Type LONG_ARRAY_TYPE = Type.getType(long[].class);
+    private static final Type INTERPRETER_MACHINE_TYPE = Type.getType(InterpreterMachine.class);
+    private static final Type INSTANCE_TYPE = Type.getType(Instance.class);
 
     private static final MethodType CALL_METHOD_TYPE =
             methodType(long[].class, Instance.class, Memory.class, long[].class);
 
     private static final MethodType MACHINE_CALL_METHOD_TYPE =
             methodType(long[].class, Instance.class, Memory.class, int.class, long[].class);
+
+    static final Method INTERPRETER_MACHINE_CALL;
+
+    static {
+        try {
+            INTERPRETER_MACHINE_CALL =
+                    InterpreterMachine.class.getMethod("call", int.class, long[].class);
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
 
     private static final int MAX_MACHINE_CALL_METHODS = 1024; // must be power of two
     // 1024*12 was empirically determined to work for the 50K small wasm functions.
@@ -109,6 +125,7 @@ public final class AotCompiler {
     private final List<FunctionType> functionTypes;
     private final Map<String, byte[]> extraClasses = new LinkedHashMap<>();
     private int maxFunctionsPerClass;
+    private final HashSet<Integer> interpretedFunctions = new HashSet<>();
 
     private AotCompiler(WasmModule module, String className, int maxFunctionsPerClass) {
         this.className = requireNonNull(className, "className");
@@ -231,15 +248,30 @@ public final class AotCompiler {
         // "${className}FuncGroup_0", "${className}FuncGroup_1", and  "${className}FuncGroup_2" with
         // each class holding up to 6k of the functions.
         //
-        maxFunctionsPerClass =
-                loadChunkedClass(
-                        totalFunctions,
-                        maxFunctionsPerClass,
-                        (start, end) ->
-                                compileExtraClass(
-                                        classNameForFuncGroup(start),
-                                        emitFunctionGroup(
-                                                start, end, internalClassName(className))));
+
+        while (true) {
+            try {
+                maxFunctionsPerClass =
+                        loadChunkedClass(
+                                totalFunctions,
+                                maxFunctionsPerClass,
+                                (start, end) ->
+                                        compileExtraClass(
+                                                classNameForFuncGroup(start),
+                                                emitFunctionGroup(
+                                                        start, end, internalClassName(className))));
+                break;
+            } catch (MethodTooLargeException e) {
+                String methodName = e.getMethodName();
+                if (methodName.startsWith("func_")) {
+                    // Add the method to interpreted function list... and try again.
+                    var funcId = Integer.parseInt(methodName.substring("func_".length()));
+                    interpretedFunctions.add(funcId);
+                } else {
+                    throw e;
+                }
+            }
+        }
 
         if (!functionTypes.isEmpty()) {
             loadExtraClass(compileMachineCallClass());
@@ -310,6 +342,7 @@ public final class AotCompiler {
                     } else {
                         body = module.codeSection().getFunctionBody(i - functionImports);
                         var bodyCopy = body;
+
                         emitFunction(
                                 classWriter,
                                 methodNameForFunc(funcId),
@@ -374,6 +407,15 @@ public final class AotCompiler {
                 getDescriptor(Instance.class),
                 null,
                 null);
+
+        if (!interpretedFunctions.isEmpty()) {
+            classWriter.visitField(
+                    Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL,
+                    "interpreterMachine",
+                    getDescriptor(InterpreterMachine.class),
+                    null,
+                    null);
+        }
 
         // constructor
         emitFunction(
@@ -470,7 +512,7 @@ public final class AotCompiler {
                 OBJECT_TYPE.getInternalName(), "<init>", getMethodDescriptor(VOID_TYPE), false);
     }
 
-    private static void compileConstructor(InstructionAdapter asm, String internalClassName) {
+    private void compileConstructor(InstructionAdapter asm, String internalClassName) {
         emitCallSuper(asm);
 
         // this.instance = instance;
@@ -478,16 +520,67 @@ public final class AotCompiler {
         asm.load(1, OBJECT_TYPE);
         asm.putfield(internalClassName, "instance", getDescriptor(Instance.class));
 
+        if (!interpretedFunctions.isEmpty()) {
+
+            asm.load(0, OBJECT_TYPE);
+            asm.anew(INTERPRETER_MACHINE_TYPE);
+            asm.dup();
+            asm.load(1, OBJECT_TYPE);
+            asm.invokespecial(
+                    INTERPRETER_MACHINE_TYPE.getInternalName(),
+                    "<init>",
+                    getMethodDescriptor(VOID_TYPE, INSTANCE_TYPE),
+                    false);
+            asm.putfield(
+                    internalClassName,
+                    "interpreterMachine",
+                    getDescriptor(InterpreterMachine.class));
+        }
+
         asm.areturn(VOID_TYPE);
     }
 
+    // implements the body of:
+    // public long[] call(int var1, long[] var2)
     private void compileMachineCall(String internalClassName, InstructionAdapter asm) {
+
         // handle modules with no functions
         if (functionTypes.isEmpty()) {
             asm.load(1, INT_TYPE);
             emitInvokeStatic(asm, THROW_UNKNOWN_FUNCTION);
             asm.athrow();
             return;
+        }
+
+        if (!interpretedFunctions.isEmpty()) {
+            Label invalid = new Label();
+            int[] keys = interpretedFunctions.stream().mapToInt(x -> x).toArray();
+            Label[] labels =
+                    interpretedFunctions.stream().map(x -> new Label()).toArray(Label[]::new);
+            asm.load(1, INT_TYPE);
+            asm.lookupswitch(invalid, keys, labels);
+            for (int i = 0; i < interpretedFunctions.size(); i++) {
+                // case 0:
+                //    return this.interpreterMachine.call(var1, var2);
+                asm.mark(labels[i]);
+
+                asm.load(0, OBJECT_TYPE);
+                asm.getfield(
+                        internalClassName,
+                        "interpreterMachine",
+                        getDescriptor(InterpreterMachine.class));
+                asm.load(1, INT_TYPE);
+                asm.load(2, OBJECT_TYPE);
+
+                asm.visitMethodInsn(
+                        Opcodes.INVOKEVIRTUAL,
+                        INTERPRETER_MACHINE_TYPE.getInternalName(),
+                        "call",
+                        getMethodDescriptor(INTERPRETER_MACHINE_CALL),
+                        false);
+                asm.areturn(OBJECT_TYPE);
+            }
+            asm.mark(invalid);
         }
 
         // try block
@@ -671,7 +764,10 @@ public final class AotCompiler {
         asm.athrow();
     }
 
+    // implements the body of:
+    // public static long[] call_xxx(Memory memory, Instance instance, long[] args)
     private void compileCallFunction(int funcId, FunctionType type, InstructionAdapter asm) {
+
         if (hasTooManyParameters(type)) {
             asm.load(2, LONG_ARRAY_TYPE);
         } else {
@@ -708,8 +804,12 @@ public final class AotCompiler {
         asm.areturn(OBJECT_TYPE);
     }
 
+    // implements the body of:
+    // public static <TypeR> call_indirect_xxx(<TypeN> argN...,
+    //      int funcTableIdx, int tableIdx, Memory memory, Instance instance)
     private void compileCallIndirect(
             String internalClassName, int typeId, FunctionType type, InstructionAdapter asm) {
+
         int slots = type.params().stream().mapToInt(AotUtil::slotCount).sum();
         if (hasTooManyParameters(type)) {
             slots = 1; // for long[]
@@ -929,6 +1029,8 @@ public final class AotCompiler {
         asm.athrow();
     }
 
+    // implements the body of:
+    // public static <TypeR> func_xx(<TypeN> argN..., Memory memory, Instance instance)
     private static void compileHostFunction(int funcId, FunctionType type, InstructionAdapter asm) {
 
         int slot = type.params().stream().mapToInt(AotUtil::slotCount).sum();
@@ -973,6 +1075,8 @@ public final class AotCompiler {
         }
     }
 
+    // implements the body of:
+    // public static <TypeR> func_xxx(<TypeN> ArgN..., Memory memory, Instance instance)
     private void compileFunction(
             String internalClassName,
             int funcId,
@@ -980,7 +1084,26 @@ public final class AotCompiler {
             FunctionBody body,
             InstructionAdapter asm) {
 
-        // func_xxx() body impl
+        if (interpretedFunctions.contains(funcId)) {
+
+            var slots = 0;
+            if (hasTooManyParameters(type)) {
+                asm.load(0, LONG_ARRAY_TYPE);
+                slots = 1;
+            } else {
+                emitBoxArguments(asm, type.params());
+                slots = type.params().stream().mapToInt(AotUtil::slotCount).sum();
+            }
+
+            var refInstance = slots + 1;
+
+            asm.iconst(funcId);
+            asm.load(refInstance, OBJECT_TYPE);
+            emitInvokeStatic(asm, CALL_INDIRECT_V2);
+            emitUnboxResult(type, asm);
+            return;
+        }
+
         var ctx =
                 new AotContext(
                         internalClassName,

--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMethodRefs.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMethodRefs.java
@@ -10,6 +10,7 @@ public final class AotMethodRefs {
 
     static final Method CHECK_INTERRUPTION;
     static final Method CALL_INDIRECT;
+    static final Method CALL_INDIRECT_V2;
     static final Method INSTANCE_MEMORY;
     static final Method CALL_HOST_FUNCTION;
     static final Method READ_GLOBAL;
@@ -56,6 +57,9 @@ public final class AotMethodRefs {
             CALL_INDIRECT =
                     AotMethods.class.getMethod(
                             "callIndirect", long[].class, int.class, int.class, Instance.class);
+            CALL_INDIRECT_V2 =
+                    AotMethods.class.getMethod(
+                            "callIndirect", long[].class, int.class, Instance.class);
             INSTANCE_MEMORY = Instance.class.getMethod("memory");
             CALL_HOST_FUNCTION =
                     AotMethods.class.getMethod(

--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMethods.java
@@ -25,6 +25,10 @@ public final class AotMethods {
         return instance.getMachine().call(funcId, args);
     }
 
+    public static long[] callIndirect(long[] args, int funcId, Instance instance) {
+        return instance.getMachine().call(funcId, args);
+    }
+
     public static long[] callHostFunction(Instance instance, int funcId, long[] args) {
         var imprt = instance.imports().function(funcId);
         return imprt.handle().apply(instance, args);

--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/Test.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/Test.java
@@ -1,0 +1,31 @@
+package com.dylibso.chicory.experimental.aot;
+
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.runtime.InterpreterMachine;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.util.TraceClassVisitor;
+
+public class Test {
+
+    InterpreterMachine interpreterMachine;
+
+    public Test(Instance foo) {
+        this.interpreterMachine = new InterpreterMachine(foo);
+    }
+
+    public long[] call(int var1, long[] var2) {
+        return this.interpreterMachine.call(var1, var2);
+    }
+
+    public static void main(String[] args) throws IOException {
+        var writer = new StringWriter();
+        var bytes = Test.class.getResourceAsStream("Test.class").readAllBytes();
+        ClassReader cr = new ClassReader(bytes);
+        cr.accept(new TraceClassVisitor(new PrintWriter(writer)), 0);
+        writer.append("\n");
+        System.out.println(writer);
+    }
+}

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
@@ -116,6 +116,16 @@ final class FOO$AotMethods {
     ARETURN
    L5
 
+  public static callIndirect([JILcom/dylibso/chicory/runtime/Instance;)[J
+   L0
+    ALOAD 2
+    INVOKEVIRTUAL com/dylibso/chicory/runtime/Instance.getMachine ()Lcom/dylibso/chicory/runtime/Machine;
+    ILOAD 1
+    ALOAD 0
+    INVOKEINTERFACE com/dylibso/chicory/runtime/Machine.call (I[J)[J (itf)
+    ARETURN
+   L1
+
   public static callHostFunction(Lcom/dylibso/chicory/runtime/Instance;I[J)[J
    L0
     ALOAD 0


### PR DESCRIPTION
If a function is too large to compile into a java method, fallback to using an interpreter to execute that function.