### PR TITLE
Remove usages of Runtime.version

### DIFF
--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMethods.java
@@ -73,7 +73,23 @@ public final class AotMethods {
         if (prop != null) {
             memCopyWorkaround = Boolean.valueOf(prop);
         } else {
-            memCopyWorkaround = Runtime.version().feature() <= 17;
+            memCopyWorkaround = shouldApplyMemWorkaround();
+        }
+    }
+
+    public static boolean shouldApplyMemWorkaround() {
+        String version = System.getProperty("java.version");
+        if (version.equals("0")) {
+            // Android https://developer.android.com/reference/java/lang/System#getProperties()
+            return false;
+        } else if (version.startsWith("1.")) {
+            // Java 8 or earlier: "1.8.0_231" → 8
+            return true;
+        } else {
+            // Java 9 or later: "11.0.9" or "17.0.1"
+            int dotIndex = version.indexOf(".");
+            String majorStr = (dotIndex != -1) ? version.substring(0, dotIndex) : version;
+            return Integer.parseInt(majorStr) <= 17;
         }
     }
 

--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMethods.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotMethods.java
@@ -1,5 +1,6 @@
 package com.dylibso.chicory.experimental.aot;
 
+import static com.dylibso.chicory.runtime.MemCopyWorkaround.shouldUseMemWorkaround;
 import static com.dylibso.chicory.wasm.types.Value.REF_NULL_VALUE;
 
 import com.dylibso.chicory.runtime.Instance;
@@ -73,23 +74,7 @@ public final class AotMethods {
         if (prop != null) {
             memCopyWorkaround = Boolean.valueOf(prop);
         } else {
-            memCopyWorkaround = shouldApplyMemWorkaround();
-        }
-    }
-
-    public static boolean shouldApplyMemWorkaround() {
-        String version = System.getProperty("java.version");
-        if (version.equals("0")) {
-            // Android https://developer.android.com/reference/java/lang/System#getProperties()
-            return false;
-        } else if (version.startsWith("1.")) {
-            // Java 8 or earlier: "1.8.0_231" → 8
-            return true;
-        } else {
-            // Java 9 or later: "11.0.9" or "17.0.1"
-            int dotIndex = version.indexOf(".");
-            String majorStr = (dotIndex != -1) ? version.substring(0, dotIndex) : version;
-            return Integer.parseInt(majorStr) <= 17;
+            memCopyWorkaround = shouldUseMemWorkaround();
         }
     }
 

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
@@ -225,58 +225,6 @@ final class FOO$AotMethods {
     RETURN
    L2
 
-  public static shouldApplyMemWorkaround()Z
-   L0
-    LDC "java.version"
-    INVOKESTATIC java/lang/System.getProperty (Ljava/lang/String;)Ljava/lang/String;
-    ASTORE 0
-   L1
-    ALOAD 0
-    LDC "0"
-    INVOKEVIRTUAL java/lang/String.equals (Ljava/lang/Object;)Z
-    IFEQ L2
-   L3
-    ICONST_0
-    IRETURN
-   L2
-    ALOAD 0
-    LDC "1."
-    INVOKEVIRTUAL java/lang/String.startsWith (Ljava/lang/String;)Z
-    IFEQ L4
-   L5
-    ICONST_1
-    IRETURN
-   L4
-    ALOAD 0
-    LDC "."
-    INVOKEVIRTUAL java/lang/String.indexOf (Ljava/lang/String;)I
-    ISTORE 1
-   L6
-    ILOAD 1
-    ICONST_M1
-    IF_ICMPEQ L7
-    ALOAD 0
-    ICONST_0
-    ILOAD 1
-    INVOKEVIRTUAL java/lang/String.substring (II)Ljava/lang/String;
-    GOTO L8
-   L7
-    ALOAD 0
-   L8
-    ASTORE 2
-   L9
-    ALOAD 2
-    INVOKESTATIC java/lang/Integer.parseInt (Ljava/lang/String;)I
-    BIPUSH 17
-    IF_ICMPGT L10
-    ICONST_1
-    GOTO L11
-   L10
-    ICONST_0
-   L11
-    IRETURN
-   L12
-
   public static memoryCopy(IIILcom/dylibso/chicory/runtime/Memory;)V
    L0
     GETSTATIC FOO$AotMethods.memCopyWorkaround : Z
@@ -592,7 +540,7 @@ final class FOO$AotMethods {
     PUTSTATIC FOO$AotMethods.memCopyWorkaround : Z
     GOTO L4
    L2
-    INVOKESTATIC FOO$AotMethods.shouldApplyMemWorkaround ()Z
+    INVOKESTATIC com/dylibso/chicory/runtime/MemCopyWorkaround.shouldUseMemWorkaround ()Z
     PUTSTATIC FOO$AotMethods.memCopyWorkaround : Z
    L4
     RETURN

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
@@ -74,7 +74,6 @@ public final class FOO implements com/dylibso/chicory/runtime/Machine {
 final class FOO$AotMethods {
 
   NESTHOST FOO
-  public final static INNERCLASS java/lang/Runtime$Version java/lang/Runtime Version
   public final static INNERCLASS java/lang/invoke/MethodHandles$Lookup java/lang/invoke/MethodHandles Lookup
 
   private final static Z memCopyWorkaround
@@ -225,6 +224,58 @@ final class FOO$AotMethods {
    L1
     RETURN
    L2
+
+  public static shouldApplyMemWorkaround()Z
+   L0
+    LDC "java.version"
+    INVOKESTATIC java/lang/System.getProperty (Ljava/lang/String;)Ljava/lang/String;
+    ASTORE 0
+   L1
+    ALOAD 0
+    LDC "0"
+    INVOKEVIRTUAL java/lang/String.equals (Ljava/lang/Object;)Z
+    IFEQ L2
+   L3
+    ICONST_0
+    IRETURN
+   L2
+    ALOAD 0
+    LDC "1."
+    INVOKEVIRTUAL java/lang/String.startsWith (Ljava/lang/String;)Z
+    IFEQ L4
+   L5
+    ICONST_1
+    IRETURN
+   L4
+    ALOAD 0
+    LDC "."
+    INVOKEVIRTUAL java/lang/String.indexOf (Ljava/lang/String;)I
+    ISTORE 1
+   L6
+    ILOAD 1
+    ICONST_M1
+    IF_ICMPEQ L7
+    ALOAD 0
+    ICONST_0
+    ILOAD 1
+    INVOKEVIRTUAL java/lang/String.substring (II)Ljava/lang/String;
+    GOTO L8
+   L7
+    ALOAD 0
+   L8
+    ASTORE 2
+   L9
+    ALOAD 2
+    INVOKESTATIC java/lang/Integer.parseInt (Ljava/lang/String;)I
+    BIPUSH 17
+    IF_ICMPGT L10
+    ICONST_1
+    GOTO L11
+   L10
+    ICONST_0
+   L11
+    IRETURN
+   L12
 
   public static memoryCopy(IIILcom/dylibso/chicory/runtime/Memory;)V
    L0
@@ -541,15 +592,7 @@ final class FOO$AotMethods {
     PUTSTATIC FOO$AotMethods.memCopyWorkaround : Z
     GOTO L4
    L2
-    INVOKESTATIC java/lang/Runtime.version ()Ljava/lang/Runtime$Version;
-    INVOKEVIRTUAL java/lang/Runtime$Version.feature ()I
-    BIPUSH 17
-    IF_ICMPGT L5
-    ICONST_1
-    GOTO L6
-   L5
-    ICONST_0
-   L6
+    INVOKESTATIC FOO$AotMethods.shouldApplyMemWorkaround ()Z
     PUTSTATIC FOO$AotMethods.memCopyWorkaround : Z
    L4
     RETURN

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MemCopyWorkaround.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MemCopyWorkaround.java
@@ -25,18 +25,22 @@ public final class MemCopyWorkaround {
     }
 
     static {
-        MemoryCopyFunc noop1 = (destination, offset, size, memory) -> {};
-        MemoryCopyFunc noop2 = (destination, offset, size, memory) -> {};
-        // Warm up the JIT... to make it see memoryCopyFunc.apply is megamorphic
-        for (int i = 0; i < 1000; i++) {
-            memoryCopyFunc = noop1;
-            MemCopyWorkaround.memoryCopy(0, 0, 0, null);
-            memoryCopyFunc = noop2;
-            MemCopyWorkaround.memoryCopy(0, 0, 0, null);
-        }
+        if (shouldUseMemWorkaround()) {
+            MemoryCopyFunc noop1 = (destination, offset, size, memory) -> {
+            };
+            MemoryCopyFunc noop2 = (destination, offset, size, memory) -> {
+            };
+            // Warm up the JIT... to make it see memoryCopyFunc.apply is megamorphic
+            for (int i = 0; i < 1000; i++) {
+                memoryCopyFunc = noop1;
+                MemCopyWorkaround.memoryCopy(0, 0, 0, null);
+                memoryCopyFunc = noop2;
+                MemCopyWorkaround.memoryCopy(0, 0, 0, null);
+            }
 
-        memoryCopyFunc =
-                (destination, offset, size, memory) -> memory.copy(destination, offset, size);
+            memoryCopyFunc =
+                    (destination, offset, size, memory) -> memory.copy(destination, offset, size);
+        }
     }
 
     static MemoryCopyFunc memoryCopyFunc;

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MemCopyWorkaround.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MemCopyWorkaround.java
@@ -8,6 +8,22 @@ public final class MemCopyWorkaround {
         void apply(int destination, int offset, int size, Memory memory);
     }
 
+    public static boolean shouldUseMemWorkaround() {
+        String version = System.getProperty("java.version");
+        if (version.equals("0")) {
+            // Android https://developer.android.com/reference/java/lang/System#getProperties()
+            return false;
+        } else if (version.startsWith("1.")) {
+            // Java 8 or earlier: "1.8.0_231" → 8
+            return true;
+        } else {
+            // Java 9 or later: "11.0.9" or "17.0.1"
+            int dotIndex = version.indexOf(".");
+            String majorStr = (dotIndex != -1) ? version.substring(0, dotIndex) : version;
+            return Integer.parseInt(majorStr) <= 17;
+        }
+    }
+
     static {
         MemoryCopyFunc noop1 = (destination, offset, size, memory) -> {};
         MemoryCopyFunc noop2 = (destination, offset, size, memory) -> {};

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MemCopyWorkaround.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MemCopyWorkaround.java
@@ -10,7 +10,7 @@ public final class MemCopyWorkaround {
 
     public static boolean shouldUseMemWorkaround() {
         String version = System.getProperty("java.version");
-        if (version.equals("0")) {
+        if (version == null || version.equals("0")) {
             // Android https://developer.android.com/reference/java/lang/System#getProperties()
             return false;
         } else if (version.startsWith("1.")) {

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MemCopyWorkaround.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MemCopyWorkaround.java
@@ -26,10 +26,8 @@ public final class MemCopyWorkaround {
 
     static {
         if (shouldUseMemWorkaround()) {
-            MemoryCopyFunc noop1 = (destination, offset, size, memory) -> {
-            };
-            MemoryCopyFunc noop2 = (destination, offset, size, memory) -> {
-            };
+            MemoryCopyFunc noop1 = (destination, offset, size, memory) -> {};
+            MemoryCopyFunc noop2 = (destination, offset, size, memory) -> {};
             // Warm up the JIT... to make it see memoryCopyFunc.apply is megamorphic
             for (int i = 0; i < 1000; i++) {
                 memoryCopyFunc = noop1;


### PR DESCRIPTION
Fix #870 

@illarionov the CI didn't reported this issue as we are only running tests on the interpreter, another task to be done before declaring the aot stable is to include a CI job for it on android.

(cc. @chirino )