### PR TITLE
fix: NoSuchMethod 'long[] MachineFuncGroup_0.call_XXX ...) errors

### DIFF
--- a/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotCompiler.java
+++ b/aot/src/main/java/com/dylibso/chicory/experimental/aot/AotCompiler.java
@@ -810,7 +810,7 @@ public final class AotCompiler {
         for (int id = max(start, functionImports); id < end; id++) {
             asm.mark(labels[id - start]);
             asm.invokestatic(
-                    internalClassName(className + classNameForFuncGroup(start)),
+                    internalClassName(className + classNameForFuncGroup(id)),
                     callMethodName(id),
                     CALL_METHOD_TYPE.toMethodDescriptorString(),
                     false);

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.functions10.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.functions10.approved.txt
@@ -434,19 +434,19 @@ final class com/dylibso/chicory/$gen/CompiledMachineMachineCall {
     INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_0.call_4 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
     ARETURN
    L5
-    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_0.call_5 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_1.call_5 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
     ARETURN
    L6
-    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_0.call_6 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_1.call_6 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
     ARETURN
    L7
-    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_0.call_7 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_1.call_7 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
     ARETURN
    L8
-    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_0.call_8 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_1.call_8 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
     ARETURN
    L9
-    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_0.call_9 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
+    INVOKESTATIC com/dylibso/chicory/$gen/CompiledMachineFuncGroup_1.call_9 (Lcom/dylibso/chicory/runtime/Instance;Lcom/dylibso/chicory/runtime/Memory;[J)[J
     ARETURN
    L10
     ILOAD 2


### PR DESCRIPTION
fix: NoSuchMethod 'long[] MachineFuncGroup_0.call_XXX(com.dylibso.chicory.runtime.Instance, com.dylibso.chicory.runtime.Memory, long[])' errors