### PR TITLE
fix: attach an empty javadoc for modules which are not intended to be consumed as libraries

### DIFF
--- a/build-time-compiler-cli/pom.xml
+++ b/build-time-compiler-cli/pom.xml
@@ -105,6 +105,7 @@
         <version>2.1.1</version>
         <configuration>
           <flags>-Xmx1G</flags>
+          <inputFile>${project.build.directory}/${project.build.finalName}.jar</inputFile>
           <programFile>chicory-compiler</programFile>
           <attachProgramFile>true</attachProgramFile>
         </configuration>

--- a/build-time-compiler-cli/src/main/javadoc/README.md
+++ b/build-time-compiler-cli/src/main/javadoc/README.md
@@ -1,0 +1,4 @@
+# Notice: Private API
+
+This module contains the private API.   It is not intended for public use and it's classes 
+are subject to change without notice.

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -90,6 +90,7 @@
         <version>2.1.1</version>
         <configuration>
           <flags>-Xmx1G</flags>
+          <inputFile>${project.build.directory}/${project.build.finalName}.jar</inputFile>
           <programFile>chicory</programFile>
           <attachProgramFile>true</attachProgramFile>
         </configuration>

--- a/cli/src/main/javadoc/README.md
+++ b/cli/src/main/javadoc/README.md
@@ -1,0 +1,4 @@
+# Notice: Private API
+
+This module contains the private API.   It is not intended for public use and it's classes 
+are subject to change without notice.

--- a/compiler-maven-plugin/src/main/javadoc/README.md
+++ b/compiler-maven-plugin/src/main/javadoc/README.md
@@ -1,0 +1,4 @@
+# Notice: Private API
+
+This module contains the private API.   It is not intended for public use and it's classes 
+are subject to change without notice.

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+    <maven-build-helper-maven-plugin>3.6.0</maven-build-helper-maven-plugin>
     <maven-plugin-plugin.version>3.15.1</maven-plugin-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
@@ -722,28 +723,6 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${maven-javadoc-plugin.version}</version>
-        <configuration>
-          <doclint>none</doclint>
-          <source>11</source>
-        </configuration>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <configuration>
-              <doclint>all,-missing</doclint>
-              <release>${maven.compiler.release}</release>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>${maven-source-plugin.version}</version>
         <executions>
@@ -770,6 +749,90 @@
   </build>
 
   <profiles>
+
+    <profile>
+      <id>package-javadoc-readme</id>
+      <activation>
+        <file>
+          <exists>${project.basedir}/src/main/javadoc/README.md</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>${maven-jar-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>package-javadoc-readme</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <classifier>javadoc</classifier>
+                  <classesDirectory>${project.basedir}/src/main/javadoc</classesDirectory>
+                  <includes>
+                    <include>**/*</include>
+                  </includes>
+                  <archive>
+                    <manifest>
+                      <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                    </manifest>
+                  </archive>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${maven-javadoc-plugin.version}</version>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>package-standard-javadocs</id>
+      <activation>
+        <file>
+          <missing>${project.basedir}/src/main/javadoc/README.md</missing>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${maven-javadoc-plugin.version}</version>
+            <configuration>
+              <!--<doclint>none</doclint>-->
+              <doclint>all,-missing</doclint>
+              <source>11</source>
+              <release>${maven.compiler.release}</release>
+              <sourceFileExcludes>
+                <sourceFileExclude>**/internal/**</sourceFileExclude>
+              </sourceFileExcludes>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <!-- Disable strict checks during development -->
       <id>dev</id>


### PR DESCRIPTION
The empty javadoc.jar contains a README.md stating why no javadoc was included.

Fixes #877