### PR TITLE
Skip simd_select.wast

### DIFF
--- a/aot-tests/pom.xml
+++ b/aot-tests/pom.xml
@@ -233,6 +233,7 @@
             <wast>simd_load_extend.wast</wast>
             <wast>simd_load_splat.wast</wast>
             <wast>simd_load_zero.wast</wast>
+            <wast>simd_select.wast</wast>
             <wast>simd_splat.wast</wast>
             <wast>simd_store.wast</wast>
             <wast>simd_store16_lane.wast</wast>

--- a/runtime-tests/pom.xml
+++ b/runtime-tests/pom.xml
@@ -214,6 +214,7 @@
             <wast>simd_load_extend.wast</wast>
             <wast>simd_load_splat.wast</wast>
             <wast>simd_load_zero.wast</wast>
+            <wast>simd_select.wast</wast>
             <wast>simd_splat.wast</wast>
             <wast>simd_store.wast</wast>
             <wast>simd_store16_lane.wast</wast>
@@ -439,6 +440,7 @@
               <excludedWasts>
                 <!-- obsolete-keywords is only stressing the wat parser -->
                 <wast>obsolete-keywords.wast</wast>
+                <wast>simd_select.wast</wast>
               </excludedWasts>
             </configuration>
             <executions>


### PR DESCRIPTION
Workaround to fix the CI currently failing on `main`.

Friendly reminder:
after this one gets merged you need to remove locally the `testsuite` folder at the root of your local Chicory repo (if present) cc. @chirino 