### PR TITLE
Remove forRemoval from fresh deprecations

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/GlobalInstance.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/GlobalInstance.java
@@ -26,7 +26,7 @@ public class GlobalInstance {
     /**
      * @deprecated use {@link #GlobalInstance(long, long, ValType, MutabilityType)}
      */
-    @Deprecated(since = "23/05/2025", forRemoval = true)
+    @Deprecated(since = "23/05/2025")
     public GlobalInstance(
             long valueLow, long valueHigh, ValueType valueType, MutabilityType mutabilityType) {
         this.valueLow = valueLow;

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/HostFunction.java
@@ -10,7 +10,7 @@ public class HostFunction extends ImportFunction {
     /**
      * @deprecated use {@link #HostFunction(String, String, FunctionType, WasmFunctionHandle)}
      */
-    @Deprecated(since = "23/05/2025", forRemoval = true)
+    @Deprecated(since = "23/05/2025")
     public HostFunction(
             String moduleName,
             String symbolName,

--- a/runtime/src/main/java/com/dylibso/chicory/runtime/ImportFunction.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/ImportFunction.java
@@ -39,7 +39,7 @@ public class ImportFunction implements ImportValue {
         this.handle = handle;
     }
 
-    @Deprecated(since = "23/05/2025", forRemoval = true)
+    @Deprecated(since = "23/05/2025")
     public ImportFunction(
             String module,
             String name,

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Global.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Global.java
@@ -20,7 +20,7 @@ public final class Global {
     /**
      * @deprecated use {@link #Global(ValType, MutabilityType, List)}
      */
-    @Deprecated(since = "23/05/2025", forRemoval = true)
+    @Deprecated(since = "23/05/2025")
     public Global(ValueType valueType, MutabilityType mutabilityType, List<Instruction> init) {
         this.valType = valueType.toValType();
         this.mutabilityType = mutabilityType;

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalImport.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/GlobalImport.java
@@ -27,7 +27,7 @@ public final class GlobalImport extends Import {
     /**
      * @deprecated use {@link #GlobalImport(String, String, MutabilityType, ValType)}
      */
-    @Deprecated(since = "23/05/2025", forRemoval = true)
+    @Deprecated(since = "23/05/2025")
     public GlobalImport(
             String moduleName, String name, MutabilityType mutabilityType, ValueType type) {
         super(moduleName, name);

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Table.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Table.java
@@ -17,7 +17,7 @@ public class Table {
     /**
      * @deprecated use {@link #Table(ValType, TableLimits)}
      */
-    @Deprecated(since = "23/05/2025", forRemoval = true)
+    @Deprecated(since = "23/05/2025")
     public Table(ValueType elementType, TableLimits limits) {
         this(
                 elementType.toValType(),

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableImport.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TableImport.java
@@ -26,7 +26,7 @@ public final class TableImport extends Import {
     /**
      * @deprecated use {@link #TableImport(String, String, ValType, TableLimits)}
      */
-    @Deprecated(since = "23/05/2025", forRemoval = true)
+    @Deprecated(since = "23/05/2025")
     public TableImport(String moduleName, String name, ValueType entryType, TableLimits limits) {
         super(moduleName, name);
         this.entryType = Objects.requireNonNull(entryType, "entryType").toValType();

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/Value.java
@@ -98,7 +98,7 @@ public class Value {
     /**
      * @deprecated use {@link #Value(ValType, long)}
      */
-    @Deprecated(since = "23/05/2025", forRemoval = true)
+    @Deprecated(since = "23/05/2025")
     public Value(ValueType type, long value) {
         this.type = requireNonNull(type, "type").toValType();
         data = value;


### PR DESCRIPTION
Both the IDE and the command line are extremely aggressive in notifying `Deprecation`s marked for removal, since we have not released yet those changes I take the chance to step back on this detail.