### PR TITLE
Avoid MH in generated code

### DIFF
--- a/aot/src/main/java/com/dylibso/chicory/compiler/internal/Shaded.java
+++ b/aot/src/main/java/com/dylibso/chicory/compiler/internal/Shaded.java
@@ -188,7 +188,7 @@ public final class Shaded {
     }
 
     public static RuntimeException throwUnknownFunction(int index) {
-        throw new InvalidException("unknown function " + index);
+        throw new InvalidException(String.format("unknown function %d", index));
     }
 
     public static void checkInterruption() {

--- a/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
+++ b/aot/src/test/resources/com/dylibso/chicory/approvals/ApprovalTest.verifyI32Renamed.approved.txt
@@ -69,8 +69,6 @@ public final class FOO implements com/dylibso/chicory/runtime/Machine {
 
 final class FOOAotMethods {
 
-  public final static INNERCLASS java/lang/invoke/MethodHandles$Lookup java/lang/invoke/MethodHandles Lookup
-
   private final static Z memCopyWorkaround
 
   private <init>()V
@@ -487,11 +485,15 @@ final class FOOAotMethods {
    L0
     NEW com/dylibso/chicory/wasm/InvalidException
     DUP
+    LDC "unknown function %d"
+    ICONST_1
+    ANEWARRAY java/lang/Object
+    DUP
+    ICONST_0
     ILOAD 0
-    INVOKEDYNAMIC makeConcatWithConstants(I)Ljava/lang/String; [
-      java/lang/invoke/StringConcatFactory.makeConcatWithConstants(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;
-      "unknown function \u0001"
-    ]
+    INVOKESTATIC java/lang/Integer.valueOf (I)Ljava/lang/Integer;
+    AASTORE
+    INVOKESTATIC java/lang/String.format (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
     INVOKESPECIAL com/dylibso/chicory/wasm/InvalidException.<init> (Ljava/lang/String;)V
     ATHROW
    L1


### PR DESCRIPTION
I'm not sure it will cause and compatibility issue, since it is directly generated by the compiler,.

But with this change we remove the MH Lookup.

Noticed in #893 cc. @chirino 