### PR TITLE
[compiler] respect original build time configured class name

### DIFF
--- a/aot-build-time/src/main/java/com/dylibso/chicory/experimental/build/time/aot/Generator.java
+++ b/aot-build-time/src/main/java/com/dylibso/chicory/experimental/build/time/aot/Generator.java
@@ -86,7 +86,7 @@ public class Generator {
         SourceRoot dest = new SourceRoot(finalSourceFolder);
 
         var baseName = config.getBaseName();
-        var moduleName = baseName + "Module";
+        var moduleName = baseName;
         var wasmName = baseName + ".meta";
 
         var cu = new CompilationUnit(packageName);

--- a/machine-tests/src/test/java/com/dylibso/chicory/testing/MachinesTest.java
+++ b/machine-tests/src/test/java/com/dylibso/chicory/testing/MachinesTest.java
@@ -14,9 +14,9 @@ import com.dylibso.chicory.runtime.InterpreterMachine;
 import com.dylibso.chicory.runtime.Store;
 import com.dylibso.chicory.runtime.TableInstance;
 import com.dylibso.chicory.runtime.TrapException;
-import com.dylibso.chicory.testing.gen.DynamicHelloJSModule;
-import com.dylibso.chicory.testing.gen.QuickJSModule;
-import com.dylibso.chicory.wabt.Wat2WasmModule;
+import com.dylibso.chicory.testing.gen.DynamicHelloJS;
+import com.dylibso.chicory.testing.gen.QuickJS;
+import com.dylibso.chicory.wabt.Wat2Wasm;
 import com.dylibso.chicory.wasi.WasiOptions;
 import com.dylibso.chicory.wasi.WasiPreview1;
 import com.dylibso.chicory.wasm.Parser;
@@ -78,7 +78,7 @@ public final class MachinesTest {
         // using the pre-compiled version of QuickJS
         var quickjs =
                 quickJsInstanceBuilder()
-                        .withMachineFactory(QuickJSModule::create)
+                        .withMachineFactory(QuickJS::create)
                         .withImportValues(
                                 ImportValues.builder().addFunction(wasi.toHostFunctions()).build())
                         .build();
@@ -118,7 +118,7 @@ public final class MachinesTest {
 
         // the module is going to use the pre compiled aot
         moduleInstanceBuilder()
-                .withMachineFactory(DynamicHelloJSModule::create)
+                .withMachineFactory(DynamicHelloJS::create)
                 .withImportValues(store.toImportValues())
                 .build();
 
@@ -153,7 +153,7 @@ public final class MachinesTest {
 
         // the module is going to use the pre compiled aot
         moduleInstanceBuilder()
-                .withMachineFactory(DynamicHelloJSModule::create)
+                .withMachineFactory(DynamicHelloJS::create)
                 .withImportValues(store.toImportValues())
                 .build();
 
@@ -206,7 +206,7 @@ public final class MachinesTest {
                 Instance.builder(Parser.parse(new File("../wabt/src/main/resources/wat2wasm")))
                         .withMachineFactory(
                                 (inst) -> {
-                                    var machine = Wat2WasmModule.create(inst);
+                                    var machine = Wat2Wasm.create(inst);
                                     return (funcId, args) -> {
                                         assertEquals(startFunctionIndex.get(), funcId);
                                         return machine.call(funcId, args);

--- a/wabt/pom.xml
+++ b/wabt/pom.xml
@@ -59,7 +59,7 @@
               <goal>wasm-aot-gen</goal>
             </goals>
             <configuration>
-              <name>com.dylibso.chicory.wabt.Wast2Json</name>
+              <name>com.dylibso.chicory.wabt.Wast2JsonModule</name>
               <wasmFile>src/main/resources/wast2json</wasmFile>
             </configuration>
           </execution>
@@ -69,7 +69,7 @@
               <goal>wasm-aot-gen</goal>
             </goals>
             <configuration>
-              <name>com.dylibso.chicory.wabt.Wat2Wasm</name>
+              <name>com.dylibso.chicory.wabt.Wat2WasmModule</name>
               <wasmFile>src/main/resources/wat2wasm</wasmFile>
             </configuration>
           </execution>

--- a/wasm-tools/pom.xml
+++ b/wasm-tools/pom.xml
@@ -57,7 +57,7 @@
               <goal>wasm-aot-gen</goal>
             </goals>
             <configuration>
-              <name>com.dylibso.chicory.tools.wasm.WasmTools</name>
+              <name>com.dylibso.chicory.tools.wasm.WasmToolsModule</name>
               <wasmFile>${project.basedir}/target/wasm-tools.wasm</wasmFile>
               <interpretedFunctions>
                 <function>3938</function>


### PR DESCRIPTION
Fix #865 

Since we plan to release the compiler as stable we can do a breaking change here, it should be reflected in the release notes, something along those lines:

```
The build time compiler 'name' configuration doesn't append anymore the "Module" suffix to the generated class name.
```

cc. @chirino 