### PR TITLE
1.4.0 release blog post, with migration guide

### DIFF
--- a/docs/blog/2025-05-30-chicory-1.4.0.md
+++ b/docs/blog/2025-05-30-chicory-1.4.0.md
@@ -24,7 +24,7 @@ After extensive development and testing, the Compiler is now officially stable. 
 - **Integration**: Generates standard Java bytecode, facilitating integration with existing Java tools and libraries.
 - **Stability**: Extensively tested to ensure reliability across various use cases(with real-world modules like CPython, SQLite, etc.).
 
-## 🏷️ Annotations Now Stable
+## 🏷️ Annotations are Now Stable
 
 The annotation system has matured and is now considered stable too. It provides high level APIs to for exports and host function's declaration and usage, enhancing developer productivity and code clarity.
 
@@ -35,13 +35,7 @@ The annotation system has matured and is now considered stable too. It provides 
 
 ## 🧪 Progress Towards WasmGC with Reference Types
 
-Chicory 1.4.0 lays the groundwork for supporting WebAssembly's Garbage Collection(WasmGC) proposal, including reference types. This advancement moves us closer to full compliance with emerging WebAssembly standards, enabling more complex and efficient module interactions.
-
-**Current Status:**
-
-- **Reference Types**: Initial support implemented, allowing for more expressive module interfaces.
-- **Compatibility**: Ensures forward compatibility with upcoming WebAssembly features.
-- **Ongoing Development**: Continued efforts to fully support WasmGC in future releases.
+Chicory 1.4.0 lays the groundwork for supporting WebAssembly's Garbage Collection(WasmGC) proposal, including reference types. This advancement moves us closer to full compliance with emerging WebAssembly proposals, enabling more modules to run efficiently.
 
 ## 🙌 Acknowledgments
 
@@ -51,9 +45,37 @@ For a detailed list of changes and contributions, please refer to the [commit hi
 
 ---
 
-## ⚠️ Migration Guide (Coming Soon)
+## ⚠️ Migration Guide
 
-As we transition out of the experimental phase, the old experimental modules are not going to be supported anymore.
-In this guide you can find the notes on how to move to the stable release of the functionalities.
+As we transition out of an experimental phase, the old experimental modules are not going to be supported anymore.
+In this guide you can find the notes on how to move to the stable release of the functionalities. If there is any missing detail, please, don't be afraid to [open an issue](https://github.com/dylibso/chicory/issues/new) asking for clarifications.
 
-TBD
+### ArtifactId renames
+
+The ArtifactId of the modules have changed in this way:
+
+| Old | New |
+|---|---|
+| `aot-experimental` | `compiler` |
+| `aot-maven-plugin-experimental` | `chicory-compiler-maven-plugin` |
+| `aot-build-time-experimental` | `build-time-compiler` |
+| `aot-build-time-cli-experimental` | `build-time-compiler-cli-experimental` |
+| `host-module-annotations-experimental` | `host-annotations` |
+| `host-module-processor-experimental` | `host-annotations-processor` |
+
+### Package names
+
+The name of the Java packages changed
+
+| Old | New |
+|---|---|
+| `com.dylibso.chicory.experimental.aot` | `com.dylibso.chicory.compiler` |
+| `com.dylibso.chicory.experimental.build.time.aot` | `com.dylibso.chicory.build.time.compiler` |
+| `com.dylibso.chicory.experimental.hostmodule.annotations` | `com.dylibso.chicory.host.annotations` |
+
+### Maven plugin
+
+Two main changes specific to the Maven plugin:
+
+- The name of the goal of the compiler changed from `wasm-aot-gen` to `chicory-compiler-gen`
+- The `name` configuration corresponds to the name of the generated class, i.e. the "Module" suffix is not added anymore automatically

--- a/docs/blog/2025-05-30-chicory-1.4.0.md
+++ b/docs/blog/2025-05-30-chicory-1.4.0.md
@@ -60,8 +60,8 @@ The ArtifactId of the modules have changed in this way:
 | `aot-maven-plugin-experimental` | `chicory-compiler-maven-plugin` |
 | `aot-build-time-experimental` | `build-time-compiler` |
 | `aot-build-time-cli-experimental` | `build-time-compiler-cli-experimental` |
-| `host-module-annotations-experimental` | `host-annotations` |
-| `host-module-processor-experimental` | `host-annotations-processor` |
+| `host-module-annotations-experimental` | `annotations` |
+| `host-module-processor-experimental` | `annotations-processor` |
 
 ### Package names
 
@@ -71,11 +71,11 @@ The name of the Java packages changed
 |---|---|
 | `com.dylibso.chicory.experimental.aot` | `com.dylibso.chicory.compiler` |
 | `com.dylibso.chicory.experimental.build.time.aot` | `com.dylibso.chicory.build.time.compiler` |
-| `com.dylibso.chicory.experimental.hostmodule.annotations` | `com.dylibso.chicory.host.annotations` |
+| `com.dylibso.chicory.experimental.hostmodule.annotations` | `com.dylibso.chicory.annotations` |
 
 ### Maven plugin
 
 Two main changes specific to the Maven plugin:
 
-- The name of the goal of the compiler changed from `wasm-aot-gen` to `chicory-compiler-gen`
+- The name of the goal of the compiler changed from `wasm-aot-gen` to `compile`
 - The `name` configuration corresponds to the name of the generated class, i.e. the "Module" suffix is not added anymore automatically

--- a/docs/blog/2025-05-30-chicory-1.4.0.md
+++ b/docs/blog/2025-05-30-chicory-1.4.0.md
@@ -1,0 +1,59 @@
+---
+slug: chicory-1.4.0
+title: 'Chicory 1.4.0 – Compiler Graduates, Annotations Stabilize, and WasmGC Advances'
+authors: [andreaTP]
+tags: [wasm, chicory, release]
+---
+
+<!-- truncate -->
+
+# Chicory **1.4.0** – Released May 30, 2025
+
+We’re excited to announce **Chicory 1.4.0**, a release that marks a significant milestone in our journey.
+This version brings the **Compiler**(Runtime and Build time) and **Annotations** out of the experimental phase, and introduces foundational support for **WebAssembly Garbage Collection (WasmGC)** with reference types.
+
+---
+
+## 🎓 Compiler Graduates from Experimental
+
+After extensive development and testing, the Compiler is now officially stable. It enables the compilation of WebAssembly modules into plain Java bytecode at build time or runtime, offering improved performance and seamless integration into Java applications.
+
+**Key Benefits:**
+
+- **Performance**: Faster execution by eliminating interpretation overhead.
+- **Integration**: Generates standard Java bytecode, facilitating integration with existing Java tools and libraries.
+- **Stability**: Extensively tested to ensure reliability across various use cases(with real-world modules like CPython, SQLite, etc.).
+
+## 🏷️ Annotations Now Stable
+
+The annotation system has matured and is now considered stable too. It provides high level APIs to for exports and host function's declaration and usage, enhancing developer productivity and code clarity.
+
+**Highlights:**
+
+- **Ease of Use**: Simplifies configuration through familiar Java annotations.
+- **Flexibility**: Allows fine-grained control over module behavior and integration.
+
+## 🧪 Progress Towards WasmGC with Reference Types
+
+Chicory 1.4.0 lays the groundwork for supporting WebAssembly's Garbage Collection(WasmGC) proposal, including reference types. This advancement moves us closer to full compliance with emerging WebAssembly standards, enabling more complex and efficient module interactions.
+
+**Current Status:**
+
+- **Reference Types**: Initial support implemented, allowing for more expressive module interfaces.
+- **Compatibility**: Ensures forward compatibility with upcoming WebAssembly features.
+- **Ongoing Development**: Continued efforts to fully support WasmGC in future releases.
+
+## 🙌 Acknowledgments
+
+We extend our heartfelt thanks to the community contributors whose efforts have been instrumental in this release. Your feedback, code contributions, and support continue to drive Chicory forward.
+
+For a detailed list of changes and contributions, please refer to the [commit history](https://github.com/dylibso/chicory/commits/main/).
+
+---
+
+## ⚠️ Migration Guide (Coming Soon)
+
+As we transition out of the experimental phase, the old experimental modules are not going to be supported anymore.
+In this guide you can find the notes on how to move to the stable release of the functionalities.
+
+TBD


### PR DESCRIPTION
Opening in draft for early comments.

Target release date is 30/05 (this Friday).