### PR TITLE
Pin the `reactivecircus/android-emulator-runner` version

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -49,7 +49,7 @@ jobs:
     # create AVD if cache failed.
     - name: create AVD and generate snapshot for caching
       if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@v2
+      uses: reactivecircus/android-emulator-runner@v2.33.0
       with:
         api-level: ${{ matrix.api-level }}
         target: google_apis
@@ -58,7 +58,7 @@ jobs:
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         script: echo "Generated AVD snapshot for caching."
     - name: Run tests
-      uses: reactivecircus/android-emulator-runner@v2
+      uses: reactivecircus/android-emulator-runner@v2.33.0
       with:
         api-level: ${{ matrix.api-level }}
         target: google_apis

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -38,14 +38,14 @@ jobs:
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
     # Reload AVD from the cache, if available.
-    - name: AVD cache
-      uses: actions/cache@v4
-      id: avd-cache
-      with:
-        path: |
-          ~/.android/avd/*
-          ~/.android/adb*
-        key: avd-${{ matrix.api-level }}
+    # - name: AVD cache
+    #   uses: actions/cache@v4
+    #   id: avd-cache
+    #   with:
+    #     path: |
+    #       ~/.android/avd/*
+    #       ~/.android/adb*
+    #     key: avd-${{ matrix.api-level }}
     # create AVD if cache failed.
     - name: create AVD and generate snapshot for caching
       if: steps.avd-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
I noticed on #920 that the Android CI is hanging and they released a new version yesterday.
As a temporary workaround I'm pinning the version to the latest working configuration we used so far.