### PR TITLE
Fix nightly Zig testsuite execution

### DIFF
--- a/nightly-testsuite/pom.xml
+++ b/nightly-testsuite/pom.xml
@@ -60,7 +60,7 @@
               <goal>compile</goal>
             </goals>
             <configuration>
-              <name>com.dylibso.chicory.testing.Zig</name>
+              <name>com.dylibso.chicory.testing.ZigModule</name>
               <wasmFile>${project.basedir}/../zig-testsuite/test-opt.wasm</wasmFile>
               <!-- <interpreterFallback>WARN</interpreterFallback> -->
               <interpretedFunctions>


### PR DESCRIPTION
Add back the Module suffix to the Zig build time compiled module.
Leftover from the renamings.