### PR TITLE
Re-enable adv caching and bump version

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -38,18 +38,19 @@ jobs:
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
     # Reload AVD from the cache, if available.
-    # - name: AVD cache
-    #   uses: actions/cache@v4
-    #   id: avd-cache
-    #   with:
-    #     path: |
-    #       ~/.android/avd/*
-    #       ~/.android/adb*
-    #     key: avd-${{ matrix.api-level }}
+    - name: AVD cache
+      uses: actions/cache@v4
+      id: avd-cache
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        # adding a unique identifier(today's date) to easily change it and effectively "clean the cache"
+        key: avd-03062025-${{ matrix.api-level }}
     # create AVD if cache failed.
     - name: create AVD and generate snapshot for caching
       if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@v2.33.0
+      uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
       with:
         api-level: ${{ matrix.api-level }}
         target: google_apis
@@ -58,7 +59,7 @@ jobs:
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         script: echo "Generated AVD snapshot for caching."
     - name: Run tests
-      uses: reactivecircus/android-emulator-runner@v2.33.0
+      uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
       with:
         api-level: ${{ matrix.api-level }}
         target: google_apis


### PR DESCRIPTION
Re-enabling caching in Android CI, verified [here](https://github.com/andreaTP/chicory/actions/runs/15417035373/job/43382978811) without and with cache present (by re-running the successful job).

Supersede #925 
Fixes #923 