### PR TITLE
fix: doc generation warnings, and redirect from old page locations to new ones.

### DIFF
--- a/docs/blog/2024-11-26-chicory-1.0.0-M2.md
+++ b/docs/blog/2024-11-26-chicory-1.0.0-M2.md
@@ -24,7 +24,7 @@ There is a lot of work that can be easily parallelized here, come and join the e
 
 ## AOT improvements
 
-We finished making modules compiled at build time with the `aot-maven-plugin-experimental` completely self-contained! You can now emit a binary that runs pure Java Bytecode and only depends on the Chicory runtime library: the original WASM file is not needed. The `WasmModule` is now provided by the compiled code. Additionally, we changed the Maven configuration so that you now specify the class name prefix rather than the `Machine` class name. See the documentation for [Build-time AOT](/docs/experimental/aot/#build-time-aot) for more details.
+We finished making modules compiled at build time with the `aot-maven-plugin-experimental` completely self-contained! You can now emit a binary that runs pure Java Bytecode and only depends on the Chicory runtime library: the original WASM file is not needed. The `WasmModule` is now provided by the compiled code. Additionally, we changed the Maven configuration so that you now specify the class name prefix rather than the `Machine` class name. See the documentation for [Build-time AOT](/docs/usage/build-time-compiler) for more details.
 
 ## Documentation
 

--- a/docs/blog/2024-12-25-chicory-1.0.0.md
+++ b/docs/blog/2024-12-25-chicory-1.0.0.md
@@ -34,7 +34,7 @@ Let’s start with the cover!
 
 Chicory now has a brand-new official website: [chicory.dev](https://chicory.dev).
 We’re continuously improving and updating it.
-A curious detail for the most attentive visitors: the documentation is tested continuously in CI using a clever combination of J[Jest](https://jestjs.io/) + [Approval Tests](https://approvaltests.com/) powered by [JBang](jbang.dev). This ensures that every code snippet displayed in the docs can be successfully compiled by users.
+A curious detail for the most attentive visitors: the documentation is tested continuously in CI using a clever combination of J[Jest](https://jestjs.io/) + [Approval Tests](https://approvaltests.com/) powered by [JBang](https://www.jbang.dev/). This ensures that every code snippet displayed in the docs can be successfully compiled by users.
 
 At the forefront of this release is the prominent **1.0.0**, marking Chicory’s first stable release.
 But what does that really mean? Over the past 12 months, we’ve been rapidly developing the engine, and early adopters likely noticed significant changes to the public API. There were several reasons for this:

--- a/docs/blog/tags.yml
+++ b/docs/blog/tags.yml
@@ -12,3 +12,8 @@ dylibso:
   label: Dylibso
   permalink: /dylibso
   description: Dylibso
+
+release:
+  label: Release
+  permalink: /release
+  description: Release tag description

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -29,6 +29,23 @@ const config: Config = {
     locales: ['en'],
   },
 
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          {
+            to: '/docs/usage/annotations',
+            from: ['/docs/experimental/host-modules'],
+          },
+          {
+            to: '/docs/usage/runtime-compiler',
+            from: ['/docs/experimental/aot'],
+          },
+        ],
+      },
+    ],
+  ],
   presets: [
     [
       'classic',

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.6.3",
+        "@docusaurus/plugin-client-redirects": "3.6.3",
         "@docusaurus/preset-classic": "3.6.3",
         "@mdx-js/react": "^3.1.0",
         "clsx": "^2.0.0",
@@ -3553,6 +3554,30 @@
         "react-dom": "*"
       }
     },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.6.3.tgz",
+      "integrity": "sha512-fQDCxoJCO1jXNQGQmhgYoX3Yx+Z2xSbrLf3PBET6pHnsRk6gGW/VuCHcfQuZlJzbTxN0giQ5u3XcQQ/LzXftJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@docusaurus/plugin-content-blog": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.6.3.tgz",
@@ -6719,7 +6744,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001664",
+      "version": "1.0.30001720",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
+      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
       "funding": [
         {
           "type": "opencollective",

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.6.3",
+    "@docusaurus/plugin-client-redirects": "3.6.3",
     "@docusaurus/preset-classic": "3.6.3",
     "@mdx-js/react": "^3.1.0",
     "clsx": "^2.0.0",


### PR DESCRIPTION

Was seeing these warnings:

```
[WARNING] Tags [release] used in 2024-11-26-chicory-1.0.0-M2.md are not defined in tags.yml
[WARNING] Tags [release] used in 2024-12-25-chicory-1.0.0.md are not defined in tags.yml
[WARNING] Tags [release] used in 2025-03-21-chicory-1.2.0.md are not defined in tags.yml
[WARNING] Tags [release] used in 2025-02-20-chicory-1.1.0.md are not defined in tags.yml
[WARNING] Tags [release] used in 2025-04-24-chicory-1.3.0.md are not defined in tags.yml
[WARNING] Tags [release] used in 2024-11-08-chicory-1.0.0-M1.md are not defined in tags.yml
```

And

```
Exhaustive list of all broken links found:
- Broken link on source page path = /blog/chicory-1.0.0:
   -> linking to jbang.dev (resolved as: /blog/jbang.dev)
- Broken link on source page path = /blog/chicory-1.0.0-M2:
   -> linking to /docs/experimental/aot/#build-time-aot
```