### PR TITLE
more robust MemCopyWorkaround java version parsing

### DIFF
--- a/runtime/src/main/java/com/dylibso/chicory/runtime/MemCopyWorkaround.java
+++ b/runtime/src/main/java/com/dylibso/chicory/runtime/MemCopyWorkaround.java
@@ -13,7 +13,10 @@ public final class MemCopyWorkaround {
     }
 
     public static boolean shouldUseMemWorkaround() {
-        String version = System.getProperty("java.version");
+        return shouldUseMemWorkaround(System.getProperty("java.version"));
+    }
+
+    public static boolean shouldUseMemWorkaround(String version) {
         if (version == null || version.equals("0")) {
             // Android https://developer.android.com/reference/java/lang/System#getProperties()
             return false;
@@ -24,7 +27,13 @@ public final class MemCopyWorkaround {
             // Java 9 or later: "11.0.9" or "17.0.1"
             int dotIndex = version.indexOf(".");
             String majorStr = (dotIndex != -1) ? version.substring(0, dotIndex) : version;
-            return Integer.parseInt(majorStr) <= 17;
+            int dashIndex = majorStr.indexOf("-");
+            majorStr = (dashIndex != -1) ? majorStr.substring(0, dashIndex) : majorStr;
+            try {
+                return Integer.parseInt(majorStr) <= 17;
+            } catch (NumberFormatException nfe) {
+                return false;
+            }
         }
     }
 

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/MemCopyWorkaroundTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/MemCopyWorkaroundTest.java
@@ -1,0 +1,45 @@
+package com.dylibso.chicory.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class MemCopyWorkaroundTest {
+
+    @Test
+    public void shouldReturnOnJavaVersion() {
+        var result = MemCopyWorkaround.shouldUseMemWorkaround("1.8");
+        assertTrue(result);
+        result = MemCopyWorkaround.shouldUseMemWorkaround("11");
+        assertTrue(result);
+        result = MemCopyWorkaround.shouldUseMemWorkaround("17");
+        assertTrue(result);
+        result = MemCopyWorkaround.shouldUseMemWorkaround("21");
+        assertFalse(result);
+        result = MemCopyWorkaround.shouldUseMemWorkaround("25");
+        assertFalse(result);
+    }
+
+    @Test
+    public void shouldReturnOnEdgeCases() {
+        var result = MemCopyWorkaround.shouldUseMemWorkaround(null);
+        assertFalse(result);
+        result = MemCopyWorkaround.shouldUseMemWorkaround("");
+        assertFalse(result);
+        result = MemCopyWorkaround.shouldUseMemWorkaround("0");
+        assertFalse(result);
+        result = MemCopyWorkaround.shouldUseMemWorkaround("000");
+        assertTrue(result);
+        result = MemCopyWorkaround.shouldUseMemWorkaround("00000");
+        assertTrue(result);
+        result = MemCopyWorkaround.shouldUseMemWorkaround("11-ea");
+        assertTrue(result);
+        result = MemCopyWorkaround.shouldUseMemWorkaround("25-ea");
+        assertFalse(result);
+        result = MemCopyWorkaround.shouldUseMemWorkaround("123-$%^&");
+        assertFalse(result);
+        result = MemCopyWorkaround.shouldUseMemWorkaround("$%^&-123");
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
Fix #969 