### PR TITLE
Fix title indentation

### DIFF
--- a/docs/docs/usage/build-time-compiler.md
+++ b/docs/docs/usage/build-time-compiler.md
@@ -176,7 +176,7 @@ To overcome this limitation you can use an additional Maven Plugin for a smoothe
 </plugin>
 ```
 
-### Using Gradle [community]
+## Using Gradle [community]
 
 Gradle users can leverage the [wasm2class-gradle-plugin](https://github.com/illarionov/wasm2class-gradle-plugin),
 a third-party plugin that serves as an alternative to the Maven plugin, running the AoT compiler at build time


### PR DESCRIPTION
The Maven and Gradle titles should be at the same level:

* `## Using Maven`
* `## Using Gradle`

Currently they are not:

<img width="987" alt="Screenshot 2025-07-09 at 09 04 25" src="https://github.com/user-attachments/assets/4720fc77-6b01-4334-9c2b-dcc7738501a1" />

