### PR TITLE
Pin the testsuite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
           repository: WebAssembly/testsuite
           path: testsuite
           # The ref needs to stay in sync with the default value in test-gen-plugin
-          ref: main
+          ref: 88e97b0f742f4c3ee01fea683da130f344dd7b02
       - name: Checkout wasi-testsuite
         uses: actions/checkout@v4
         with:
@@ -92,7 +92,7 @@ jobs:
           repository: WebAssembly/testsuite
           path: testsuite
           # The ref needs to stay in sync with the default value in test-gen-plugin
-          ref: main
+          ref: 88e97b0f742f4c3ee01fea683da130f344dd7b02
       - name: Checkout wasi-testsuite
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,7 +22,7 @@ jobs:
           repository: WebAssembly/testsuite
           path: testsuite
           # The ref needs to stay in sync with the default value in test-gen-plugin
-          ref: main
+          ref: 88e97b0f742f4c3ee01fea683da130f344dd7b02
       - name: Checkout wasi-testsuite
         uses: actions/checkout@v4
         with:

--- a/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
+++ b/test-gen-plugin/src/main/java/com/dylibso/chicory/maven/TestGenMojo.java
@@ -28,7 +28,8 @@ public class TestGenMojo extends AbstractMojo {
     /**
      * Repository of the testsuite.
      */
-    @Parameter(required = true, defaultValue = "main")
+    // TODO: restore `main`
+    @Parameter(required = true, defaultValue = "88e97b0f742f4c3ee01fea683da130f344dd7b02")
     private String testSuiteRepoRef;
 
     /**


### PR DESCRIPTION
This PR caused the testsuite to fail: https://github.com/WebAssembly/testsuite/pull/129

Meanwhile we find a better solution we can keep working pinning the previous commit.