### PR TITLE
chore: remove proposals remapping from test gen

### DIFF
--- a/compiler-tests/pom.xml
+++ b/compiler-tests/pom.xml
@@ -188,18 +188,18 @@
           <!-- Skip stack-overflows in tail calls -->
           <excludedTests>
             SpecV1BinaryTest.test40,
-            SpecV1TcReturnCallTest.test19,
-            SpecV1TcReturnCallTest.test24,
-            SpecV1TcReturnCallTest.test25,
-            SpecV1TcReturnCallTest.test30,
-            SpecV1TcReturnCallTest.test31,
-            SpecV1TcReturnCallIndirectTest.test40,
-            SpecV1TcReturnCallIndirectTest.test41,
-            SpecV1TcReturnCallIndirectTest.test46,
-            SpecV1TcReturnCallIndirectTest.test47,
+            SpecV1TailCallReturnCallTest.test19,
+            SpecV1TailCallReturnCallTest.test24,
+            SpecV1TailCallReturnCallTest.test25,
+            SpecV1TailCallReturnCallTest.test30,
+            SpecV1TailCallReturnCallTest.test31,
+            SpecV1TailCallReturnCallIndirectTest.test40,
+            SpecV1TailCallReturnCallIndirectTest.test41,
+            SpecV1TailCallReturnCallIndirectTest.test46,
+            SpecV1TailCallReturnCallIndirectTest.test47,
             <!-- Skip exception tests with tail calls -->
-            SpecV1EhTryTableTest.test39,
-            SpecV1EhTryTableTest.test40,
+            SpecV1ExceptionHandlingTryTableTest.test39,
+            SpecV1ExceptionHandlingTryTableTest.test40,
             <!-- Investigate why this one fails -->
             SpecV1EhBinaryTest.test40,
             <!-- Testing an old behavior around multiple tables -->

--- a/test-gen-lib/src/main/java/com/dylibso/chicory/testgen/TestGen.java
+++ b/test-gen-lib/src/main/java/com/dylibso/chicory/testgen/TestGen.java
@@ -1,6 +1,7 @@
 package com.dylibso.chicory.testgen;
 
 import static com.dylibso.chicory.testgen.Constants.SPEC_JSON;
+import static com.dylibso.chicory.testgen.StringUtils.escapedCamelCase;
 
 import com.dylibso.chicory.testgen.wast.Wast;
 import com.dylibso.chicory.tools.wasm.Wast2Json;
@@ -15,7 +16,6 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -119,27 +119,6 @@ public final class TestGen {
         }
     }
 
-    private static final class Proposal {
-        final String remapping;
-
-        private Proposal(String remapping) {
-            this.remapping = remapping;
-        }
-    }
-
-    private static Map<String, Proposal> proposals =
-            Map.of(
-                    "gc",
-                    new Proposal("gc"),
-                    "tail-call",
-                    new Proposal("tc"),
-                    "exception-handling",
-                    new Proposal("eh"),
-                    "function-references",
-                    new Proposal("function-references"),
-                    "threads",
-                    new Proposal("threads"));
-
     private static final class TestGenerator {
 
         private final JavaTestGen testGen;
@@ -167,9 +146,9 @@ public final class TestGen {
 
             var plainName = wastFile.getName().replace(".wast", "");
             if (wastFile.getParentFile().getParentFile().getName().equalsIgnoreCase("proposals")) {
-                var proposal = proposals.get(wastFile.getParentFile().getName());
+                var proposal = escapedCamelCase(wastFile.getParentFile().getName());
                 plainName =
-                        proposal.remapping
+                        proposal
                                 + plainName.substring(0, 1).toUpperCase(Locale.ROOT)
                                 + plainName.substring(1);
             }


### PR DESCRIPTION
I'm starting working on a new proposal, this remapping mechanism was useful when using `wabt` but it's not anymore.
Extracted to reduce the diff of upcoming PRs.