### PR TITLE
Fix nigthly Zig build failures

### DIFF
--- a/scripts/build-zig-testsuite.sh
+++ b/scripts/build-zig-testsuite.sh
@@ -13,16 +13,18 @@ BINARYEN_INSTALL="binaryen-install"
 
 ZIG_TESTSUITE="zig-testsuite"
 
+ZIG_MIRROR=$(${SCRIPT_DIR}/pick-zig-mirror.sh)
+
 # Install Zig 
 if [ ! -d "$ZIG_INSTALL" ]; then
     mkdir -p ${ZIG_INSTALL}
-    curl -sSL https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz | tar -xJ --strip-components=1 -C ${ZIG_INSTALL}
+    curl -sSL ${ZIG_MIRROR}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz | tar -xJ --strip-components=1 -C ${ZIG_INSTALL}
 fi
 
 # Install Zig source
 if [ ! -d "$ZIG_SOURCE" ]; then
     mkdir -p ${ZIG_SOURCE}
-    curl -sSL https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_VERSION}.tar.xz | tar -xJ --strip-components=1 -C ${ZIG_SOURCE}
+    curl -sSL ${ZIG_MIRROR}/zig-${ZIG_VERSION}.tar.xz | tar -xJ --strip-components=1 -C ${ZIG_SOURCE}
 fi
 
 #Install Binaryen

--- a/scripts/pick-zig-mirror.sh
+++ b/scripts/pick-zig-mirror.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mirrors=$(curl -s https://ziglang.org/download/community-mirrors.txt)
+
+for url in $(echo "$mirrors" | shuf); do
+  curl_opts=(--head --fail --silent --show-error)
+  if curl "${curl_opts[@]}" "$url/" > /dev/null 2>&1; then
+    echo "$url"
+    exit 0
+  fi
+done
+
+echo "https://ziglang.org/download"


### PR DESCRIPTION
To download Zig we need to go through a community mirror now (the original server is too slow and incosistent).

Following the note here: https://ziglang.org/download/community-mirrors/
