### PR TITLE
POC add an optional caching layer for runtime compilation

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -51,6 +51,19 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+      <version>3.11.1</version>
+      <classifier>jakarta</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/compiler/src/main/java/com/dylibso/chicory/compiler/Cache.java
+++ b/compiler/src/main/java/com/dylibso/chicory/compiler/Cache.java
@@ -1,0 +1,11 @@
+package com.dylibso.chicory.compiler;
+
+import com.dylibso.chicory.compiler.internal.CompilerResult;
+
+public interface Cache {
+
+    // TODO: this way CompilerResult becomes public API
+    void put(int key, CompilerResult content);
+
+    CompilerResult get(int key);
+}

--- a/compiler/src/main/java/com/dylibso/chicory/compiler/internal/CompilerResult.java
+++ b/compiler/src/main/java/com/dylibso/chicory/compiler/internal/CompilerResult.java
@@ -1,12 +1,16 @@
 package com.dylibso.chicory.compiler.internal;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
 
-public final class CompilerResult {
+public final class CompilerResult implements Serializable {
 
-    private final ClassCollector collector;
-    private final Set<Integer> interpretedFunctions;
+    private ClassCollector collector;
+    private Set<Integer> interpretedFunctions;
 
     public CompilerResult(ClassCollector collector, Set<Integer> interpretedFunctions) {
         this.collector = collector;
@@ -23,5 +27,68 @@ public final class CompilerResult {
 
     public Set<Integer> interpretedFunctions() {
         return interpretedFunctions;
+    }
+
+    private void writeObject(ObjectOutputStream oos) throws IOException {
+        // Write collector type and data
+        if (collector instanceof ClassLoadingCollector) {
+            oos.writeUTF("ClassLoadingCollector");
+            ClassLoadingCollector clc = (ClassLoadingCollector) collector;
+            oos.writeObject(clc.classBytes());
+            oos.writeObject(clc.mainClassName());
+        } else if (collector instanceof ByteClassCollector) {
+            oos.writeUTF("ByteClassCollector");
+            ByteClassCollector bcc = (ByteClassCollector) collector;
+            oos.writeObject(bcc.classBytes());
+            oos.writeObject(bcc.mainClassName());
+        } else {
+            oos.writeUTF("Unknown");
+            oos.writeObject(collector.classBytes());
+            oos.writeObject(collector.mainClassName());
+        }
+
+        // Write interpreted functions set
+        oos.writeObject(interpretedFunctions);
+    }
+
+    private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
+        // Read collector type and reconstruct collector
+        String collectorType = ois.readUTF();
+        @SuppressWarnings("unchecked")
+        Map<String, byte[]> classBytes = (Map<String, byte[]>) ois.readObject();
+        String mainClassName = (String) ois.readObject();
+
+        ClassCollector reconstructedCollector;
+        if ("ClassLoadingCollector".equals(collectorType)
+                || "ByteClassCollector".equals(collectorType)) {
+            reconstructedCollector = new ClassLoadingCollector();
+            if (mainClassName != null) {
+                reconstructedCollector.putMainClass(mainClassName, classBytes.get(mainClassName));
+            }
+            for (Map.Entry<String, byte[]> entry : classBytes.entrySet()) {
+                if (!entry.getKey().equals(mainClassName)) {
+                    reconstructedCollector.put(entry.getKey(), entry.getValue());
+                }
+            }
+        } else {
+            // Fallback to ByteClassCollector for unknown types
+            reconstructedCollector = new ByteClassCollector();
+            if (mainClassName != null) {
+                reconstructedCollector.putMainClass(mainClassName, classBytes.get(mainClassName));
+            }
+            for (Map.Entry<String, byte[]> entry : classBytes.entrySet()) {
+                if (!entry.getKey().equals(mainClassName)) {
+                    reconstructedCollector.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        // Read interpreted functions set
+        @SuppressWarnings("unchecked")
+        Set<Integer> reconstructedInterpretedFunctions = (Set<Integer>) ois.readObject();
+
+        // Assign reconstructed fields directly (no reflection)
+        this.collector = reconstructedCollector;
+        this.interpretedFunctions = reconstructedInterpretedFunctions;
     }
 }

--- a/compiler/src/test/java/com/dylibso/chicory/compiler/internal/CacheTest.java
+++ b/compiler/src/test/java/com/dylibso/chicory/compiler/internal/CacheTest.java
@@ -1,0 +1,216 @@
+package com.dylibso.chicory.compiler.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.dylibso.chicory.compiler.Cache;
+import com.dylibso.chicory.compiler.MachineFactoryCompiler;
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasm.Parser;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.ehcache.CacheManager;
+import org.ehcache.PersistentCacheManager;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.config.units.MemoryUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class CacheTest {
+
+    static class MockCacheImpl implements Cache {
+        private final Map<Integer, CompilerResult> cache = new HashMap<>();
+        public boolean cacheHit;
+
+        @Override
+        public void put(int key, CompilerResult content) {
+            cache.put(key, content);
+        }
+
+        @Override
+        public CompilerResult get(int key) {
+            var result = cache.get(key);
+            if (result != null) {
+                cacheHit = true;
+            }
+            return result;
+        }
+    }
+
+    private void exerciseCountVowels(Instance instance) {
+        var alloc = instance.export("alloc");
+        var dealloc = instance.export("dealloc");
+        var countVowels = instance.export("count_vowels");
+        var memory = instance.memory();
+        var message = "Hello, World!";
+        var len = message.getBytes(UTF_8).length;
+        int ptr = (int) alloc.apply(len)[0];
+        memory.writeString(ptr, message);
+        var result = countVowels.apply(ptr, len);
+        dealloc.apply(ptr, len);
+        assertEquals(3L, result[0]);
+    }
+
+    @Test
+    public void shouldCacheCompiledResult() {
+        var cache = new MockCacheImpl();
+        var module =
+                Parser.parse(CacheTest.class.getResourceAsStream("/compiled/count_vowels.rs.wasm"));
+
+        var instance1 =
+                Instance.builder(module)
+                        .withMachineFactory(
+                                MachineFactoryCompiler.builder(module).withCache(cache).compile())
+                        .build();
+
+        exerciseCountVowels(instance1);
+        assertFalse(cache.cacheHit);
+        var instance2 =
+                Instance.builder(module)
+                        .withMachineFactory(
+                                MachineFactoryCompiler.builder(module).withCache(cache).compile())
+                        .build();
+        exerciseCountVowels(instance2);
+        assertTrue(cache.cacheHit);
+    }
+
+    static class MockEhCacheImpl implements Cache, AutoCloseable {
+        private final CacheManager cacheManager;
+        private final org.ehcache.Cache<Integer, CompilerResult> cache;
+        public boolean cacheHit;
+
+        public MockEhCacheImpl() {
+            cacheManager =
+                    CacheManagerBuilder.newCacheManagerBuilder()
+                            .withCache(
+                                    "myCache",
+                                    CacheConfigurationBuilder.newCacheConfigurationBuilder(
+                                            Integer.class,
+                                            CompilerResult.class,
+                                            ResourcePoolsBuilder.heap(10)))
+                            .build(true);
+
+            cache = cacheManager.getCache("myCache", Integer.class, CompilerResult.class);
+        }
+
+        @Override
+        public void put(int key, CompilerResult content) {
+            cache.put(key, content);
+        }
+
+        @Override
+        public CompilerResult get(int key) {
+            var result = cache.get(key);
+            if (result != null) {
+                cacheHit = true;
+            }
+            return result;
+        }
+
+        @Override
+        public void close() {
+            cacheManager.removeCache("myCache");
+            cacheManager.close();
+        }
+    }
+
+    @Test
+    public void shouldUseEhCache() {
+        var cache = new MockEhCacheImpl();
+        var module =
+                Parser.parse(CacheTest.class.getResourceAsStream("/compiled/count_vowels.rs.wasm"));
+
+        var instance1 =
+                Instance.builder(module)
+                        .withMachineFactory(
+                                MachineFactoryCompiler.builder(module).withCache(cache).compile())
+                        .build();
+
+        exerciseCountVowels(instance1);
+        assertFalse(cache.cacheHit);
+
+        var instance2 =
+                Instance.builder(module)
+                        .withMachineFactory(
+                                MachineFactoryCompiler.builder(module).withCache(cache).compile())
+                        .build();
+        exerciseCountVowels(instance2);
+        assertTrue(cache.cacheHit);
+    }
+
+    static class MockPersistentEhCacheImpl implements Cache, AutoCloseable {
+        private final PersistentCacheManager cacheManager;
+        private final org.ehcache.Cache<Integer, CompilerResult> cache;
+        public boolean cacheHit;
+
+        public MockPersistentEhCacheImpl(Path tempDir) {
+            cacheManager =
+                    CacheManagerBuilder.newCacheManagerBuilder()
+                            .with(CacheManagerBuilder.persistence(tempDir.toFile()))
+                            .withCache(
+                                    "myCache",
+                                    CacheConfigurationBuilder.newCacheConfigurationBuilder(
+                                            Integer.class,
+                                            CompilerResult.class,
+                                            ResourcePoolsBuilder.newResourcePoolsBuilder()
+                                                    .heap(10, EntryUnit.ENTRIES)
+                                                    .disk(10, MemoryUnit.MB, true)))
+                            .build(true);
+
+            cache = cacheManager.getCache("myCache", Integer.class, CompilerResult.class);
+        }
+
+        @Override
+        public void put(int key, CompilerResult content) {
+            cache.put(key, content);
+        }
+
+        @Override
+        public CompilerResult get(int key) {
+            var result = cache.get(key);
+            if (result != null) {
+                cacheHit = true;
+            }
+            return result;
+        }
+
+        @Override
+        public void close() {
+            cacheManager.removeCache("myCache");
+            cacheManager.close();
+        }
+    }
+
+    @Test
+    public void shouldUsePeristentEhCache(@TempDir Path tempDir) {
+        var cache1 = new MockPersistentEhCacheImpl(tempDir);
+        var module =
+                Parser.parse(CacheTest.class.getResourceAsStream("/compiled/count_vowels.rs.wasm"));
+
+        var instance1 =
+                Instance.builder(module)
+                        .withMachineFactory(
+                                MachineFactoryCompiler.builder(module).withCache(cache1).compile())
+                        .build();
+
+        exerciseCountVowels(instance1);
+        assertFalse(cache1.cacheHit);
+
+        cache1.close();
+
+        var cache2 = new MockPersistentEhCacheImpl(tempDir);
+        var instance2 =
+                Instance.builder(module)
+                        .withMachineFactory(
+                                MachineFactoryCompiler.builder(module).withCache(cache2).compile())
+                        .build();
+        exerciseCountVowels(instance2);
+        assertTrue(cache2.cacheHit);
+    }
+}


### PR DESCRIPTION
This is a quick and dirty example of how a caching mechanism for the `runtime-compiler`.
There are a few questions I'd like to discuss before moving on:

- with this approach the `CompilerResult` becomes public API, I'm unsure this is desirable ...
- the build-time compiler is already serializing things to disk, would it make sense to re-use the same mechanism?

Happy to hear feedback!