### PR TITLE
disable filesystem rights in wasi tests

### DIFF
--- a/wasi-tests/src/test/java/com/dylibso/chicory/wasi/WasiTestRunner.java
+++ b/wasi-tests/src/test/java/com/dylibso/chicory/wasi/WasiTestRunner.java
@@ -53,6 +53,7 @@ public final class WasiTestRunner {
             // TODO: dangling filesystem is not supported
             if (!test.getName().contains("environ")) {
                 options.withEnvironment("NO_DANGLING_FILESYSTEM", "true");
+                options.withEnvironment("NO_FILESYSTEM_RIGHTS", "false");
             }
 
             for (String dir : dirs) {


### PR DESCRIPTION
Fix #1042 

Counterpart of: https://github.com/WebAssembly/wasi-testsuite/pull/155