### PR TITLE
Fix wasi testsuite returning unsupported operation

### DIFF
--- a/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
+++ b/wasi/src/main/java/com/dylibso/chicory/wasi/WasiPreview1.java
@@ -416,8 +416,10 @@ public final class WasiPreview1 implements Closeable {
 
     @WasmExport
     public int fdFdstatSetRights(int fd, long rightsBase, long rightsInheriting) {
-        logger.tracef("fd_fdstat_set_rights: [%s, %s, %s]", fd, rightsBase, rightsInheriting);
-        throw new WasmRuntimeException("We don't yet support this WASI call: fd_fdstat_set_rights");
+        logger.errorf(
+                "fd_fdstat_set_rights operation not supported: [%s, %s, %s]",
+                fd, rightsBase, rightsInheriting);
+        return wasiResult(WasiErrno.ENOTSUP);
     }
 
     @WasmExport


### PR DESCRIPTION
This is following the path wasmtime is going down according to wasi-testsuite maintainers ... seems ok to me.