### PR TITLE
Clean the Android cache in CI

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -46,7 +46,7 @@ jobs:
           ~/.android/avd/*
           ~/.android/adb*
         # adding a unique identifier(today's date) to easily change it and effectively "clean the cache"
-        key: avd-25062025-${{ matrix.api-level }}
+        key: avd-07102025-${{ matrix.api-level }}
     # create AVD if cache failed.
     - name: create AVD and generate snapshot for caching
       if: steps.avd-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
The Android 28 CI jobs are hanging, let see if this makes it.