### PR TITLE
resolve ValTypes after TypeSection is formed

### DIFF
--- a/compiler/src/main/java/com/dylibso/chicory/compiler/internal/Context.java
+++ b/compiler/src/main/java/com/dylibso/chicory/compiler/internal/Context.java
@@ -8,6 +8,7 @@ import com.dylibso.chicory.wasm.types.ExternalType;
 import com.dylibso.chicory.wasm.types.FunctionBody;
 import com.dylibso.chicory.wasm.types.FunctionType;
 import com.dylibso.chicory.wasm.types.TagImport;
+import com.dylibso.chicory.wasm.types.TypeSection;
 import com.dylibso.chicory.wasm.types.ValType;
 import java.util.ArrayList;
 import java.util.List;
@@ -112,6 +113,10 @@ final class Context {
 
     public FunctionType[] types() {
         return module.typeSection().types();
+    }
+
+    public TypeSection typeSection() {
+        return module.typeSection();
     }
 
     public int getId() {

--- a/compiler/src/main/java/com/dylibso/chicory/compiler/internal/Emitters.java
+++ b/compiler/src/main/java/com/dylibso/chicory/compiler/internal/Emitters.java
@@ -80,7 +80,7 @@ final class Emitters {
     }
 
     public static ValType valType(long id, Context ctx) {
-        return ValType.builder().fromId(id).build(ctx::type);
+        return ValType.builder().fromId(id).build().resolve(ctx.typeSection());
     }
 
     public static void DROP_KEEP(Context ctx, CompilerInstruction ins, InstructionAdapter asm) {

--- a/compiler/src/main/java/com/dylibso/chicory/compiler/internal/WasmAnalyzer.java
+++ b/compiler/src/main/java/com/dylibso/chicory/compiler/internal/WasmAnalyzer.java
@@ -785,7 +785,8 @@ final class WasmAnalyzer {
                         ValType.builder()
                                 .withOpcode(ValType.ID.RefNull)
                                 .withTypeIdx((int) ins.operand(0))
-                                .build(module.typeSection()::getType));
+                                .build()
+                                .resolve(module.typeSection()));
                 break;
             case REF_IS_NULL:
                 // [ref] -> [I32]
@@ -988,7 +989,7 @@ final class WasmAnalyzer {
         }
         if (ValType.isValid(typeId)) {
             return FunctionType.returning(
-                    ValType.builder().fromId(typeId).build(module.typeSection()::getType));
+                    ValType.builder().fromId(typeId).build().resolve(module.typeSection()));
         }
         return module.typeSection().getType((int) typeId);
     }

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/Validator.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/Validator.java
@@ -321,14 +321,15 @@ final class Validator {
     }
 
     private ValType valType(long id) {
-        return ValType.builder().fromId(id).build(module.typeSection()::getType);
+        return ValType.builder().fromId(id).build().resolve(module.typeSection());
     }
 
     private ValType valType(int opcode, int typeIdx) {
         return ValType.builder()
                 .withOpcode(opcode)
                 .withTypeIdx(typeIdx)
-                .build(module.typeSection()::getType);
+                .build()
+                .resolve(module.typeSection());
     }
 
     private List<ValType> getReturns(AnnotatedInstruction op) {

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionType.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/FunctionType.java
@@ -6,12 +6,10 @@ import java.util.Objects;
 public final class FunctionType {
     private final List<ValType> params;
     private final List<ValType> returns;
-    private final int hashCode;
 
     private FunctionType(List<ValType> params, List<ValType> returns) {
         this.params = params;
         this.returns = returns;
-        hashCode = Objects.hash(params, returns);
     }
 
     public List<ValType> params() {
@@ -36,12 +34,12 @@ public final class FunctionType {
     }
 
     public boolean equals(FunctionType other) {
-        return hashCode == other.hashCode && paramsMatch(other) && returnsMatch(other);
+        return hashCode() == other.hashCode() && paramsMatch(other) && returnsMatch(other);
     }
 
     @Override
     public int hashCode() {
-        return hashCode;
+        return Objects.hash(params, returns);
     }
 
     private static final FunctionType empty = new FunctionType(List.of(), List.of());

--- a/wasm/src/main/java/com/dylibso/chicory/wasm/types/TypeSection.java
+++ b/wasm/src/main/java/com/dylibso/chicory/wasm/types/TypeSection.java
@@ -33,6 +33,7 @@ public final class TypeSection extends Section {
 
         private Builder() {}
 
+        @Deprecated
         public List<FunctionType> getTypes() {
             return types;
         }

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/types/ValTypeTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/types/ValTypeTest.java
@@ -6,9 +6,6 @@ import com.dylibso.chicory.wasm.Parser;
 import org.junit.jupiter.api.Test;
 
 public class ValTypeTest {
-    private FunctionType context(int idx) {
-        return FunctionType.returning(ValType.FuncRef);
-    }
 
     @Test
     public void roundtrip() {
@@ -24,20 +21,17 @@ public class ValTypeTest {
                     ValType.builder()
                             .withOpcode(ValType.ID.RefNull)
                             .withTypeIdx(ValType.TypeIdxCode.FUNC.code())
-                            .build(this::context),
+                            .build(),
                     ValType.builder()
                             .withOpcode(ValType.ID.Ref)
                             .withTypeIdx(ValType.TypeIdxCode.EXTERN.code())
-                            .build(this::context),
-                    ValType.builder()
-                            .withOpcode(ValType.ID.Ref)
-                            .withTypeIdx(16)
-                            .build(this::context),
+                            .build(),
+                    ValType.builder().withOpcode(ValType.ID.Ref).withTypeIdx(16).build(),
                 };
 
         for (var vt : cases) {
             long id = vt.id();
-            ValType roundTrip = ValType.builder().fromId(id).build(this::context);
+            ValType roundTrip = ValType.builder().fromId(id).build();
             assert vt.equals(roundTrip) : "Failed to roundtrip: " + vt;
         }
     }


### PR DESCRIPTION
This is a "step 0" to enable the implementation of Wasm GC.
The plan is to try, as much as possible, to come up with small, self contained PRs implementing Wasm GC to guarantee the rest of the code base consistency and reduce the risk of accidentally breaking the stable API.

In Wasm GC the recursive types refer to themselves, so we need to split the `ValType` computation from the resolution.
In this PR, the resolution of `ValType` happens mutating the already instantiated `ValType` instead of doing it in the Builder.

Thanks to @evacchi for the help in getting this to the bottom of the last detail.
@hypercubestart if you wanna have a look :slightly_smiling_face: 
