### PR TITLE
fix: flaky dircache test #1101

### DIFF
--- a/dircache/src/main/java/com/dylibso/chicory/experimental/dircache/DirectoryCache.java
+++ b/dircache/src/main/java/com/dylibso/chicory/experimental/dircache/DirectoryCache.java
@@ -40,8 +40,13 @@ public class DirectoryCache implements Cache {
      */
     @Override
     public byte[] get(String key) throws IOException {
-        Path target = toFilePath(key);
-        return Files.isRegularFile(target) ? Files.readAllBytes(target) : null;
+        try {
+            Path target = toFilePath(key);
+            return Files.isRegularFile(target) ? Files.readAllBytes(target) : null;
+        } catch (IOException e) {
+            // if we can't read it, then treat it like it not being in the cache.
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
If an io error occurs trying to read a cache entry, return null instead of failing.