### PR TITLE
Extend the usage of the Jvm workaround to I32_GE_U

### DIFF
--- a/compiler/src/main/java/com/dylibso/chicory/compiler/internal/EmitterMap.java
+++ b/compiler/src/main/java/com/dylibso/chicory/compiler/internal/EmitterMap.java
@@ -229,7 +229,7 @@ final class EmitterMap {
                     .shared(CompilerOpCode.I32_EXTEND_8_S, OpcodeImpl.class)
                     .shared(CompilerOpCode.I32_EXTEND_16_S, OpcodeImpl.class)
                     .shared(CompilerOpCode.I32_GE_S, OpcodeImpl.class)
-                    .shared(CompilerOpCode.I32_GE_U, OpcodeImpl.class)
+                    .intrinsic(CompilerOpCode.I32_GE_U, Emitters::I32_GE_U)
                     .shared(CompilerOpCode.I32_GT_S, OpcodeImpl.class)
                     .shared(CompilerOpCode.I32_GT_U, OpcodeImpl.class)
                     .shared(CompilerOpCode.I32_LE_S, OpcodeImpl.class)

--- a/compiler/src/main/java/com/dylibso/chicory/compiler/internal/Emitters.java
+++ b/compiler/src/main/java/com/dylibso/chicory/compiler/internal/Emitters.java
@@ -349,6 +349,10 @@ final class Emitters {
         emitInvokeStatic(asm, ShadedRefs.MEMORY_DROP);
     }
 
+    public static void I32_GE_U(Context ctx, CompilerInstruction ins, InstructionAdapter asm) {
+        emitInvokeStatic(asm, ShadedRefs.I32_GE_U);
+    }
+
     public static void I32_ADD(Context ctx, CompilerInstruction ins, MethodVisitor asm) {
         asm.visitInsn(Opcodes.IADD);
     }

--- a/compiler/src/main/java/com/dylibso/chicory/compiler/internal/Shaded.java
+++ b/compiler/src/main/java/com/dylibso/chicory/compiler/internal/Shaded.java
@@ -75,6 +75,16 @@ public final class Shaded {
         OpcodeImpl.TABLE_INIT(instance, tableidx, elementidx, size, elemidx, offset);
     }
 
+    public static int i32_ge_u(int a, int b) {
+        if (memCopyWorkaround) {
+            // Use this workaround to avoid a bug in some JVMs (Temurin 17)
+            return MemCopyWorkaround.i32_ge_u(a, b);
+        } else {
+            // Go back to the original implementation, once that bug is no longer an issue:
+            return OpcodeImpl.I32_GE_U(a, b);
+        }
+    }
+
     private static final boolean memCopyWorkaround;
 
     static {

--- a/compiler/src/main/java/com/dylibso/chicory/compiler/internal/ShadedRefs.java
+++ b/compiler/src/main/java/com/dylibso/chicory/compiler/internal/ShadedRefs.java
@@ -44,6 +44,7 @@ public final class ShadedRefs {
     static final Method MEMORY_ATOMIC_LONG_SHORT_READ;
     static final Method MEMORY_ATOMIC_LONG_INT_READ;
     static final Method MEMORY_ATOMIC_LONG_READ;
+    static final Method I32_GE_U;
     static final Method REF_IS_NULL;
     static final Method TABLE_GET;
     static final Method TABLE_SET;
@@ -207,6 +208,7 @@ public final class ShadedRefs {
             MEMORY_ATOMIC_LONG_INT_READ =
                     Shaded.class.getMethod(
                             "memoryAtomicLongIntRead", int.class, int.class, Memory.class);
+            I32_GE_U = Shaded.class.getMethod("i32_ge_u", int.class, int.class);
             REF_IS_NULL = Shaded.class.getMethod("isRefNull", int.class);
             TABLE_GET = Shaded.class.getMethod("tableGet", int.class, int.class, Instance.class);
             TABLE_SET =


### PR DESCRIPTION
`I32_GE_U` is an opcode that frequently has been showing up during investigations.

Here we extend the memory workaround to create the megamorphic call on older Java versions.

I tested this patch on top of #1135 and it looks to be solving the issue.

As a follow up we should really report the bug upstream in OpenJDK, I'm afraid it might eventually sprawl if we don't do it.

cc. @andreas-karlsson 